### PR TITLE
Bump codecov-action (v1 is deprecated) and actions/checkout 

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -40,7 +40,7 @@ jobs:
           source $VENV
           pytest tests -v --cov=./rich --cov-report=xml:./coverage.xml --cov-report term-missing
       - name: Upload code coverage
-        uses: codecov/codecov-action@v1.0.10
+        uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
[codecov action v1](https://github.com/codecov/codecov-action#migration-from-v1-to-v2) has been deprecated and it don't seems like it would be breaking change for rich.
Also updates `checkout` [action to v2](https://github.com/actions/checkout#whats-new)
