### PR TITLE
Fix all reportPrivateImportUsage in pyright for library users

### DIFF
--- a/rich/box.py
+++ b/rich/box.py
@@ -430,7 +430,7 @@ LEGACY_WINDOWS_SUBSTITUTIONS = {
 }
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__" and not TYPE_CHECKING:  # pragma: no cover
 
     from rich.columns import Columns
     from rich.panel import Panel

--- a/rich/live.py
+++ b/rich/live.py
@@ -1,7 +1,7 @@
 import sys
 from threading import Event, RLock, Thread
 from types import TracebackType
-from typing import IO, Any, Callable, List, Optional, TextIO, Type, cast
+from typing import IO, Any, Callable, List, Optional, TextIO, Type, cast, TYPE_CHECKING
 
 from . import get_console
 from .console import Console, ConsoleRenderable, RenderableType, RenderHook
@@ -268,7 +268,7 @@ class Live(JupyterMixin, RenderHook):
         return renderables
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__" and not TYPE_CHECKING:  # pragma: no cover
     import random
     import time
     from itertools import cycle

--- a/rich/table.py
+++ b/rich/table.py
@@ -842,7 +842,7 @@ class Table(JupyterMixin):
             yield new_line
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__" and not TYPE_CHECKING:  # pragma: no cover
     from rich.console import Console
     from rich.highlighter import ReprHighlighter
     from rich.table import Table


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This PR adds `TYPE_CHECKING` guards to the `__main__` sections of all files that imported/redefined part of their own API in this section. This hides the redefinition from type checkers as needed to avoid accidentally signalling the API as private and causing pyright errors for everyone using rich as a library.

Note there are many more `__main__` sections in the library; it was only necessary to add the guard to files importing their own API.

This PR resolves https://github.com/willmcgugan/rich/issues/1523

I didn't update CONTRIBUTORS since the change is minor, but if you have a policy of always updating it let me know and I'll add my name.