### PR TITLE
fix a edge case bug when running under pytest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.12.1] - unreleased
+
+### Fixed
+
+- Fixed an edge case bug when console module try to detect if they are in a tty at the end of a pytest run
+
 ## [10.12.0] - 2021-10-06
 
 ### Updated

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@ The following people have contributed to the development of Rich:
 - [Will McGugan](https://github.com/willmcgugan)
 - [Nathan Page](https://github.com/nathanrpage97)
 - [Avi Perl](https://github.com/avi-perl)
+- [Laurent Peuch](https://github.com/psycojoker)
 - [Kylian Point](https://github.com/p0lux)
 - [Kyle Pollina](https://github.com/kylepollina)
 - [Clément Robert](https://github.com/neutrinoceros)

--- a/rich/console.py
+++ b/rich/console.py
@@ -899,7 +899,13 @@ class Console:
         if self._force_terminal is not None:
             return self._force_terminal
         isatty: Optional[Callable[[], bool]] = getattr(self.file, "isatty", None)
-        return False if isatty is None else isatty()
+        try:
+            return False if isatty is None else isatty()
+        except ValueError:
+            # in some situation (at the end of a pytest run for example) isatty() can raise
+            # ValueError: I/O operation on closed file
+            # return False because we aren't in a terminal anymore
+            return False
 
     @property
     def is_dumb_terminal(self) -> bool:

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -698,3 +698,14 @@ def test_print_newline_start():
     result = console.end_capture()
 
     assert result == "Foo\n\nFoo\nbar\n\n"
+
+
+def test_is_terminal_broken_file():
+    console = Console()
+
+    def _mock_isatty():
+        raise ValueError()
+
+    console.file.isatty = _mock_isatty
+
+    assert console.is_terminal == False


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X but] I've added tests for new code. -> but is_terminal wasn't test so I'm not sure we want to do that?
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Hello,

Here is an extract from a failing test run:

```
Traceback (most recent call last):
  File "/builds/cubicweb/cubicweb/.tox/py3-web/lib/python3.7/site-packages/rich/console.py", line 1579, in print
    render_options = self.options.update(
  File "/builds/cubicweb/cubicweb/.tox/py3-web/lib/python3.7/site-packages/rich/console.py", line 920, in options
    max_height=self.size.height,
  File "/builds/cubicweb/cubicweb/.tox/py3-web/lib/python3.7/site-packages/rich/console.py", line 940, in size
    if self.is_dumb_terminal:
  File "/builds/cubicweb/cubicweb/.tox/py3-web/lib/python3.7/site-packages/rich/console.py", line 914, in is_dumb_terminal
    return self.is_terminal and is_dumb
  File "/builds/cubicweb/cubicweb/.tox/py3-web/lib/python3.7/site-packages/rich/console.py", line 902, in is_terminal
    return False if isatty is None else isatty()
ValueError: I/O operation on closed file
```

From my understanding of the code this is just a very edge case that isn't taken into account and we never had this bug when we weren't using rich and the fix is pretty straightforward.

Anyway, thanks a lot for rich, this library is awesome :heart: 

Kind regards,