### PR TITLE
Fix Justify default incorrectly set to DEFAULT_OVERFLOW

### DIFF
--- a/rich/text.py
+++ b/rich/text.py
@@ -14,7 +14,6 @@ from typing import (
     Optional,
     Tuple,
     Union,
-    cast,
 )
 
 from ._loop import loop_last
@@ -144,8 +143,8 @@ class Text(JupyterMixin):
     ) -> None:
         self._text = [strip_control_codes(text)]
         self.style = style
-        self.justify = justify
-        self.overflow = overflow
+        self.justify: Optional["JustifyMethod"] = justify
+        self.overflow: Optional["OverflowMethod"] = overflow
         self.no_wrap = no_wrap
         self.end = end
         self.tab_size = tab_size
@@ -557,11 +556,7 @@ class Text(JupyterMixin):
         tab_size: int = console.tab_size or self.tab_size or 8
         justify = self.justify or options.justify or DEFAULT_JUSTIFY
 
-        overflow = (
-            cast("OverflowMethod", self.overflow)
-            or options.overflow
-            or DEFAULT_OVERFLOW
-        )
+        overflow = self.overflow or options.overflow or DEFAULT_OVERFLOW
 
         lines = self.wrap(
             console,
@@ -1063,10 +1058,8 @@ class Text(JupyterMixin):
         Returns:
             Lines: Number of lines.
         """
-        wrap_justify = cast("JustifyMethod", justify or self.justify) or DEFAULT_JUSTIFY
-        wrap_overflow = (
-            cast("OverflowMethod", overflow or self.overflow) or DEFAULT_OVERFLOW
-        )
+        wrap_justify = justify or self.justify or DEFAULT_JUSTIFY
+        wrap_overflow = overflow or self.overflow or DEFAULT_OVERFLOW
 
         no_wrap = pick_bool(no_wrap, self.no_wrap, False) or overflow == "ignore"
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

In `text.py` the default for justify was incorrectly set to `OVERFLOW_DEFAULT` instead of `JUSTIFY_DEFAULT`. This wasn't caught by type checkers due to some errors in the typing. In addition to fixing the bug, I've fixed the errors that caused the bug to be missed by type checkers in the rest of the file. See commit messages for additional details.