### PR TITLE
Support pyright-style literal treatment

### DIFF
--- a/rich/columns.py
+++ b/rich/columns.py
@@ -48,7 +48,7 @@ class Columns(JupyterMixin):
         self.equal = equal
         self.column_first = column_first
         self.right_to_left = right_to_left
-        self.align = align
+        self.align: Optional[AlignMethod] = align
         self.title = title
 
     def add_renderable(self, renderable: RenderableType) -> None:

--- a/rich/console.py
+++ b/rich/console.py
@@ -666,7 +666,7 @@ class Console:
         self.record = record
         self._markup = markup
         self._emoji = emoji
-        self._emoji_variant = emoji_variant
+        self._emoji_variant: Optional[EmojiVariant] = emoji_variant
         self._highlight = highlight
         self.legacy_windows: bool = (
             (detect_legacy_windows() and not self.is_jupyter)

--- a/rich/panel.py
+++ b/rich/panel.py
@@ -56,7 +56,7 @@ class Panel(JupyterMixin):
         self.renderable = renderable
         self.box = box
         self.title = title
-        self.title_align = title_align
+        self.title_align: AlignMethod = title_align
         self.subtitle = subtitle
         self.subtitle_align = subtitle_align
         self.safe_box = safe_box

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -212,8 +212,8 @@ class Pretty(JupyterMixin):
         self._object = _object
         self.highlighter = highlighter or ReprHighlighter()
         self.indent_size = indent_size
-        self.justify = justify
-        self.overflow = overflow
+        self.justify: Optional["JustifyMethod"] = justify
+        self.overflow: Optional["OverflowMethod"] = overflow
         self.no_wrap = no_wrap
         self.indent_guides = indent_guides
         self.max_length = max_length

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -271,7 +271,7 @@ class TextColumn(ProgressColumn):
         table_column: Optional[Column] = None,
     ) -> None:
         self.text_format = text_format
-        self.justify = justify
+        self.justify: JustifyMethod = justify
         self.style = style
         self.markup = markup
         self.highlighter = highlighter

--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -330,11 +330,10 @@ class Confirm(PromptBase[bool]):
 
     response_type = bool
     validate_error_message = "[prompt.invalid]Please enter Y or N"
-    choices = ["y", "n"]
+    choices: List[str] = ["y", "n"]
 
     def render_default(self, default: DefaultType) -> Text:
         """Render the default as (y) or (n) rather than True/False."""
-        assert self.choices is not None
         yes, no = self.choices
         return Text(f"({yes})" if default else f"({no})", style="prompt.default")
 
@@ -343,7 +342,6 @@ class Confirm(PromptBase[bool]):
         value = value.strip().lower()
         if value not in self.choices:
             raise InvalidResponse(self.validate_error_message)
-        assert self.choices is not None
         return value == self.choices[0]
 
 

--- a/rich/table.py
+++ b/rich/table.py
@@ -6,6 +6,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Sequence,
     Tuple,
     Union,
 )
@@ -201,10 +202,10 @@ class Table(JupyterMixin):
         self.border_style = border_style
         self.title_style = title_style
         self.caption_style = caption_style
-        self.title_justify = title_justify
-        self.caption_justify = caption_justify
+        self.title_justify: "JustifyMethod" = title_justify
+        self.caption_justify: "JustifyMethod" = caption_justify
         self.highlight = highlight
-        self.row_styles = list(row_styles or [])
+        self.row_styles: Sequence[StyleType] = list(row_styles or [])
         append_column = self.columns.append
         for header in headers:
             if isinstance(header, str):


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description
Not all typecheckers will assume an instance variable assigned to a literal type is a literal. See discussion at https://github.com/microsoft/pyright/issues/2432 In order to maintain the literal type as the code assumes this needs to be signposted by setting variables as literals. This change was prompted by the discovery of the bug at https://github.com/willmcgugan/rich/pull/1583 but this patch only makes similar typing changes (no additional bugs were found).

I also made a change to prompt to avoid needing the assert and to better match how it's being used.
