### PR TITLE
Minimally fix reportPrivateImportUsage in pyright for library users 

### DIFF
--- a/rich/box.py
+++ b/rich/box.py
@@ -435,7 +435,7 @@ if __name__ == "__main__":  # pragma: no cover
     from rich.columns import Columns
     from rich.panel import Panel
 
-    from . import box
+    from . import box as box
     from .console import Console
     from .table import Table
     from .text import Text

--- a/rich/live.py
+++ b/rich/live.py
@@ -276,7 +276,7 @@ if __name__ == "__main__":  # pragma: no cover
 
     from .align import Align
     from .console import Console
-    from .live import Live
+    from .live import Live as Live
     from .panel import Panel
     from .rule import Rule
     from .syntax import Syntax

--- a/rich/table.py
+++ b/rich/table.py
@@ -845,7 +845,7 @@ class Table(JupyterMixin):
 if __name__ == "__main__":  # pragma: no cover
     from rich.console import Console
     from rich.highlighter import ReprHighlighter
-    from rich.table import Table
+    from rich.table import Table as Table
 
     table = Table(
         title="Star Wars Movies",


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This PR resolves #1523 and is an alternative to #1551

This PR uses the standard (PEP 484) of redundant imports to avoid signalling the API as private to type checkers. Please see the commit message for additional details.
