### PR TITLE
Many Miscellaneous Typing Fixes

### DIFF
--- a/rich/_lru_cache.py
+++ b/rich/_lru_cache.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
-from typing import Dict, Generic, TypeVar
-
+from typing import Generic, TypeVar
 
 CacheKey = TypeVar("CacheKey")
 CacheValue = TypeVar("CacheValue")
@@ -17,18 +16,20 @@ class LRUCache(Generic[CacheKey, CacheValue], OrderedDict):  # type: ignore # ht
 
     def __init__(self, cache_size: int) -> None:
         self.cache_size = cache_size
-        super(LRUCache, self).__init__()
+        super().__init__()
 
     def __setitem__(self, key: CacheKey, value: CacheValue) -> None:
         """Store a new views, potentially discarding an old value."""
         if key not in self:
             if len(self) >= self.cache_size:
                 self.popitem(last=False)
-        OrderedDict.__setitem__(self, key, value)
+        super().__setitem__(key, value)
 
-    def __getitem__(self: Dict[CacheKey, CacheValue], key: CacheKey) -> CacheValue:
+    def __getitem__(
+        self: "LRUCache[CacheKey, CacheValue]", key: CacheKey
+    ) -> CacheValue:
         """Gets the item, but also makes it most recent."""
-        value: CacheValue = OrderedDict.__getitem__(self, key)
-        OrderedDict.__delitem__(self, key)
-        OrderedDict.__setitem__(self, key, value)
+        value: CacheValue = super().__getitem__(key)
+        super().__delitem__(key)
+        super().__setitem__(key, value)
         return value

--- a/rich/_pick.py
+++ b/rich/_pick.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 
 def pick_bool(*values: Optional[bool]) -> bool:
-    """Pick the first non-none bool or return the last value.
+    """Pick the first non-none bool or return False.
 
     Args:
         *values (bool): Any number of boolean or None values.
@@ -14,4 +14,4 @@ def pick_bool(*values: Optional[bool]) -> bool:
     for value in values:
         if value is not None:
             return value
-    return bool(value)
+    return False

--- a/rich/console.py
+++ b/rich/console.py
@@ -1805,7 +1805,7 @@ class Console:
             objects = (NewLine(),)
 
         with self:
-            renderables = self._collect_renderables(
+            renderables: List[ConsoleRenderable] = self._collect_renderables(
                 objects,
                 sep,
                 end,

--- a/rich/panel.py
+++ b/rich/panel.py
@@ -58,7 +58,7 @@ class Panel(JupyterMixin):
         self.title = title
         self.title_align: AlignMethod = title_align
         self.subtitle = subtitle
-        self.subtitle_align = subtitle_align
+        self.subtitle_align: AlignMethod = subtitle_align
         self.safe_box = safe_box
         self.expand = expand
         self.style = style

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -27,7 +27,8 @@ from types import MappingProxyType
 try:
     import attr as _attr_module
 except ImportError:  # pragma: no cover
-    _attr_module = None  # type: ignore
+    if not TYPE_CHECKING:
+        _attr_module = None
 
 
 from .highlighter import ReprHighlighter

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -657,6 +657,7 @@ def traverse(
             pop_visited(obj_id)
 
         elif isinstance(obj, _CONTAINERS):
+            assert not isinstance(obj, type)
             for container_type in _CONTAINERS:
                 if isinstance(obj, container_type):
                     obj_type = container_type


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This PR fixes almost the entirety of the remaining bugs that would prevent adding pyright to rich's CI if desired. All of these changes are genuine typing bugs that just aren't flagged by `mypy --strict` due to limitations in its design or particular quirks with how it works. Some of these changes are especially subtle, but I've included detailed explanations in the commit message for each change.

Are you interested in adding pyright to the CI? It's not necessary, but going through it has helped me find a number of genuinely incorrect things in the codebase.

The remaining 10 errors and 3 warnings thrown by pyright when run on the codebase (but not addressed by this PR and left for possible future work) fall into one of these categories:
- 4 errors: these are normal typing errors that are errors when using `mypy` too, but they're incidentally hidden due to the [project configuration](https://github.com/willmcgugan/rich/blob/eb673d1204340738d3084ebc2e4c789a35a4e49b/mypy.ini#L3) and CI not having the `types-pygments` package installed. If you install `types-pygments` locally and run `mypy --strict` on the codebase you will see the errors. At their surface they seem like they could be indicative of genuine bugs, but I haven't had a chance to look into them since validating the errors would require me learning some internals of the pygments package beyond the scope of this PR.
- 1 error: There is a `padding` property in `table.py` where the getter/setter don't have symmetric types; pyright is set to lint this asymmetry by default and throw an error. I've inspected the code in question and there is no bug or typing error; this is just a stylistic complaint from pyright. I see no way to change this without breaking rich's public API so an ignore for this error would need to be added to the file or project if pyright was added to CI.
- 5 errors: A variable is possibly unbound: these occur in cases where there is code that uses the iterating variable `x` after a `for x in y` has closed, but without setting a default value for `x`. I wasn't sure how you'd feel about merging code to work around this type of error. Leave it? Add code to init `x`? Look at it to see if it can be refactored?
- 3 warnings: `warning: TypeVar "DefaultType" appears only once in generic function signature`: These occur in the PromptBase class where the class is not a generic of `DefaultType`, but nonetheless uses these variables alone in class methods. I've inspected the methods in question and the `DefaultType` in these cases can safely be replaced with `object`; another possibility is to make the class a proper generic of `DefaultType` too. However, this latter option would be a bit awkward for usage. These warnings are addressed with #1607

I still intend to at some point make a pass on the codebase narrowing `Any` to `object` where possible, but I'd like to address the existing typing stuff first.
