### PR TITLE
allow for callable in rich.traceback.install(suppress=…)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 
 - Markdown codeblocks now word-wrap https://github.com/willmcgugan/rich/issues/1515
+- Tweak rich.traceback(suppress=[...]) to allow for callables (e.g.  lambda fname: '/mything/' not in fname)
 
 ## [10.12.0] - 2021-10-06
 

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -243,7 +243,7 @@ class Traceback:
         self.locals_max_length = locals_max_length
         self.locals_max_string = locals_max_string
 
-        self.suppress: Sequence[str, callable] = []
+        self.suppress: Sequence[str, Callable] = []
         for suppress_entity in suppress:
             if callable(suppress_entity):
                 self.suppress.append(suppress_entity)

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -65,6 +65,8 @@ def install(
         show_locals (bool, optional): Enable display of local variables. Defaults to False.
         indent_guides (bool, optional): Enable indent guides in code and locals. Defaults to True.
         suppress (Sequence[Union[str, ModuleType]]): Optional sequence of modules or paths to exclude from traceback.
+            Additionally, if any sequence item is callable and returns a a value that evaluates as True given the
+            module path as argument, the item will be suppressed.
 
     Returns:
         Callable: The previous exception handler that was replaced.
@@ -197,7 +199,7 @@ class Traceback:
         locals_max_length (int, optional): Maximum length of containers before abbreviating, or None for no abbreviation.
             Defaults to 10.
         locals_max_string (int, optional): Maximum length of string before truncating, or None to disable. Defaults to 80.
-        suppress (Sequence[Union[str, ModuleType]]): Optional sequence of modules or paths to exclude from traceback.
+        suppress (Sequence[Union[str, ModuleType, Callable]]): Optional sequence of modules or paths to exclude from traceback.
         max_frames (int): Maximum number of frames to show in a traceback, 0 for no maximum. Defaults to 100.
 
     """

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -239,6 +239,16 @@ def test_suppress():
         assert "pytest" in traceback.suppress[0]
         assert "foo" in traceback.suppress[1]
 
+def test_callable_suppress():
+    try:
+        1 / 0
+    except Exception:
+        sups = lambda x: 'test_traceback' not in x
+        traceback = Traceback(suppress=[sups])
+        assert len(traceback.suppress) == 1
+        for item in traceback.suppress:
+            traceback.suppress is sups
+
 
 if __name__ == "__main__":  # pragma: no cover
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I think this suite of readability improvements is just great. <3 ... but rich lacks the thing I was actually looking for when I found it. I was actually looking for a module that would limit the stack traces to code I actually wrote so I don't have to scroll back through 15 pages of stuff I didn't write to get to the actually relevant error on the lines I did write.

So, while `rich.traceback.install(suppress=[])` _almost_ does what I want, there was no way to actually achieve my goal without really annoying acrobatics; since, what I really want is `rich.traceback.install(suppress=[lambda fname: recognize_my_own_modules(fname)])`

This PR adds callable suppress_entity support. It's already doing what I want in my project by simply installing my modified version; but I doubt I'm the only person that would want this feature so I cleaned it up for sharing.