### PR TITLE
Fix flipped traceback border styles

### DIFF
--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -450,7 +450,7 @@ class Traceback:
                     self._render_stack(stack),
                     title="[traceback.title]Traceback [dim](most recent call last)",
                     style=background_style,
-                    border_style="traceback.border.syntax_error",
+                    border_style="traceback.border",
                     expand=True,
                     padding=(0, 1),
                 )
@@ -463,7 +463,7 @@ class Traceback:
                         Panel(
                             self._render_syntax_error(stack.syntax_error),
                             style=background_style,
-                            border_style="traceback.border",
+                            border_style="traceback.border.syntax_error",
                             expand=True,
                             padding=(0, 1),
                             width=self.width,


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

The traceback border styles were backwards. I flipped them. That's it.
