### PR TITLE
fix environment to empty in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	pytest --cov-report term-missing --cov=rich tests/ -vv
+	TERM=unknown pytest --cov-report term-missing --cov=rich tests/ -vv
 format-check:
 	black --check .
 format:

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -686,7 +686,7 @@ def test_is_alt_screen():
 
 
 def test_update_screen():
-    console = Console(force_terminal=True, width=20, height=5)
+    console = Console(force_terminal=True, width=20, height=5, _environ={})
     if console.legacy_windows:
         return
     with pytest.raises(errors.NoAltScreen):

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -86,7 +86,7 @@ def test_tree():
 def test_refresh_screen():
     layout = Layout()
     layout.split_row(Layout(name="foo"), Layout(name="bar"))
-    console = Console(force_terminal=True, width=20, height=5)
+    console = Console(force_terminal=True, width=20, height=5, _environ={})
     with console.capture():
         console.print(layout)
     with console.screen():

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -41,7 +41,7 @@ def test_spinner_update():
         nonlocal time
         return time
 
-    console = Console(width=20, force_terminal=True, get_time=get_time)
+    console = Console(width=20, force_terminal=True, get_time=get_time, _environ={})
     console.begin_capture()
     spinner = Spinner("dots")
     console.print(spinner)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -67,7 +67,9 @@ def test_render_tree_non_win32():
     baz_tree.add("2")
     tree.add("egg")
 
-    console = Console(width=20, force_terminal=True, color_system="standard")
+    console = Console(
+        width=20, force_terminal=True, color_system="standard", _environ={}
+    )
     console.begin_capture()
     console.print(tree)
     result = console.end_capture()
@@ -103,7 +105,9 @@ def test_render_tree_hide_root_non_win32():
     baz_tree.add("2")
     tree.add("egg")
 
-    console = Console(width=20, force_terminal=True, color_system="standard")
+    console = Console(
+        width=20, force_terminal=True, color_system="standard", _environ={}
+    )
     console.begin_capture()
     console.print(tree)
     result = console.end_capture()


### PR DESCRIPTION
Sets _environ to empty dict so that CI environment doesn't change outcome of tests.

Fixes https://github.com/Textualize/rich/issues/1051

