### PR TITLE
Theme used for Traceback should not inherit defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added max_depth arg to pretty printing
+- Fix Traceback theme defaults override user supplied styles https://github.com/Textualize/rich/issues/1786
 
 ## [10.16.2] - 2021-01-02
 

--- a/rich/_windows.py
+++ b/rich/_windows.py
@@ -30,6 +30,7 @@ except (AttributeError, ImportError, ValueError):
         features = WindowsConsoleFeatures()
         return features
 
+
 else:
 
     STDOUT = -11

--- a/rich/_windows.py
+++ b/rich/_windows.py
@@ -1,5 +1,4 @@
 import sys
-
 from dataclasses import dataclass
 
 
@@ -15,8 +14,7 @@ class WindowsConsoleFeatures:
 
 try:
     import ctypes
-    from ctypes import wintypes
-    from ctypes import LibraryLoader
+    from ctypes import LibraryLoader, wintypes
 
     if sys.platform == "win32":
         windll = LibraryLoader(ctypes.WinDLL)
@@ -29,7 +27,6 @@ except (AttributeError, ImportError, ValueError):
     def get_windows_console_features() -> WindowsConsoleFeatures:
         features = WindowsConsoleFeatures()
         return features
-
 
 else:
 

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -6,7 +6,8 @@ import sys
 from dataclasses import dataclass, field
 from traceback import walk_tb
 from types import ModuleType, TracebackType
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Type, Union
+from typing import (Any, Callable, Dict, Iterable, List, Optional, Sequence,
+                    Type, Union)
 
 from pygments.lexers import guess_lexer_for_filename
 from pygments.token import Comment, Keyword, Name, Number, Operator, String
@@ -16,13 +17,8 @@ from pygments.token import Token
 from . import pretty
 from ._loop import loop_first, loop_last
 from .columns import Columns
-from .console import (
-    Console,
-    ConsoleOptions,
-    ConsoleRenderable,
-    RenderResult,
-    group,
-)
+from .console import (Console, ConsoleOptions, ConsoleRenderable, RenderResult,
+                      group)
 from .constrain import Constrain
 from .highlighter import RegexHighlighter, ReprHighlighter
 from .panel import Panel
@@ -443,7 +439,8 @@ class Traceback:
                 "scope.equals": token_style(Operator),
                 "scope.key": token_style(Name),
                 "scope.key.special": token_style(Name.Constant) + Style(dim=True),
-            }
+            },
+            inherit=False,
         )
 
         highlighter = ReprHighlighter()

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -6,8 +6,7 @@ import sys
 from dataclasses import dataclass, field
 from traceback import walk_tb
 from types import ModuleType, TracebackType
-from typing import (Any, Callable, Dict, Iterable, List, Optional, Sequence,
-                    Type, Union)
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Type, Union
 
 from pygments.lexers import guess_lexer_for_filename
 from pygments.token import Comment, Keyword, Name, Number, Operator, String
@@ -17,8 +16,7 @@ from pygments.token import Token
 from . import pretty
 from ._loop import loop_first, loop_last
 from .columns import Columns
-from .console import (Console, ConsoleOptions, ConsoleRenderable, RenderResult,
-                      group)
+from .console import Console, ConsoleOptions, ConsoleRenderable, RenderResult, group
 from .constrain import Constrain
 from .highlighter import RegexHighlighter, ReprHighlighter
 from .panel import Panel

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -4,7 +4,8 @@ import sys
 import pytest
 
 from rich.console import Console
-from rich.traceback import install, Traceback
+from rich.theme import Theme
+from rich.traceback import Traceback, install
 
 # from .render import render
 
@@ -109,7 +110,7 @@ def test_syntax_error():
     console = Console(width=100, file=io.StringIO())
     try:
         # raises SyntaxError: unexpected EOF while parsing
-        eval("(2 + 2")
+        compile("(2+2")
     except Exception:
         console.print_exception()
     exception_text = console.file.getvalue()
@@ -188,6 +189,29 @@ def test_filename_not_a_file():
         console.print_exception()
     exception_text = console.file.getvalue()
     assert "string" in exception_text
+
+
+def test_traceback_console_theme_applies():
+    """
+    Ensure that themes supplied via Console init work on Tracebacks.
+    Regression test for https://github.com/Textualize/rich/issues/1786
+    """
+    r, g, b = 123, 234, 123
+    console = Console(
+        force_terminal=True,
+        _environ={"COLORTERM": "truecolor"},
+        theme=Theme({"traceback.title": f"rgb({r},{g},{b})"}),
+    )
+
+    console.begin_capture()
+    try:
+        1 / 0
+    except Exception:
+        console.print_exception()
+
+    result = console.end_capture()
+
+    assert f"\\x1b[38;2;{r};{g};{b}mTraceback \\x1b[0m" in repr(result)
 
 
 def test_broken_str():

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -191,6 +191,7 @@ def test_filename_not_a_file():
     assert "string" in exception_text
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="renders different on windows")
 def test_traceback_console_theme_applies():
     """
     Ensure that themes supplied via Console init work on Tracebacks.


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

A `Theme` was instantiate to contain the styles used in the rendering of a traceback. This theme by default inherited the default styles, which in turn would override the user-supplied theme.
