### PR TITLE
Revert "Stop using functools.lru_cache decorator on instance methods"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Stop using `functools.lru_cache` decorator on instance methods
+
 - Fix width measurement of 353 emoji variation sequences https://github.com/Textualize/rich/pull/1832
 
 ## [11.0.0] - 2022-01-09

--- a/rich/palette.py
+++ b/rich/palette.py
@@ -1,6 +1,6 @@
-from functools import lru_cache
 from math import sqrt
-from typing import TYPE_CHECKING, Sequence, Tuple
+from functools import lru_cache
+from typing import Sequence, Tuple, TYPE_CHECKING
 
 from .color_triplet import ColorTriplet
 
@@ -20,8 +20,8 @@ class Palette:
     def __rich__(self) -> "Table":
         from rich.color import Color
         from rich.style import Style
-        from rich.table import Table
         from rich.text import Text
+        from rich.table import Table
 
         table = Table(
             "index",
@@ -40,6 +40,8 @@ class Palette:
             )
         return table
 
+    # This is somewhat inefficient and needs caching
+    @lru_cache(maxsize=1024)
     def match(self, color: Tuple[int, int, int]) -> int:
         """Find a color from a palette that most closely matches a given color.
 
@@ -49,38 +51,30 @@ class Palette:
         Returns:
             int: Index of closes matching color.
         """
-        return _match_palette_cached(color=color, available_colors=tuple(self._colors))
+        red1, green1, blue1 = color
+        _sqrt = sqrt
+        get_color = self._colors.__getitem__
 
+        def get_color_distance(index: int) -> float:
+            """Get the distance to a color."""
+            red2, green2, blue2 = get_color(index)
+            red_mean = (red1 + red2) // 2
+            red = red1 - red2
+            green = green1 - green2
+            blue = blue1 - blue2
+            return _sqrt(
+                (((512 + red_mean) * red * red) >> 8)
+                + 4 * green * green
+                + (((767 - red_mean) * blue * blue) >> 8)
+            )
 
-@lru_cache(maxsize=1024)
-def _match_palette_cached(
-    color: Tuple[int, int, int], available_colors: Tuple[Tuple[int, int, int]]
-) -> int:
-    red1, green1, blue1 = color
-    _sqrt = sqrt
-    get_color = available_colors.__getitem__
-
-    def get_color_distance(index: int) -> float:
-        """Get the distance to a color."""
-        red2, green2, blue2 = get_color(index)
-        red_mean = (red1 + red2) // 2
-        red = red1 - red2
-        green = green1 - green2
-        blue = blue1 - blue2
-        return _sqrt(
-            (((512 + red_mean) * red * red) >> 8)
-            + 4 * green * green
-            + (((767 - red_mean) * blue * blue) >> 8)
-        )
-
-    min_index = min(range(len(available_colors)), key=get_color_distance)
-    return min_index
+        min_index = min(range(len(self._colors)), key=get_color_distance)
+        return min_index
 
 
 if __name__ == "__main__":  # pragma: no cover
     import colorsys
     from typing import Iterable
-
     from rich.color import Color
     from rich.console import Console, ConsoleOptions
     from rich.segment import Segment

--- a/rich/progress_bar.py
+++ b/rich/progress_bar.py
@@ -1,5 +1,5 @@
-import functools
 import math
+from functools import lru_cache
 from time import monotonic
 from typing import Iterable, List, Optional
 
@@ -13,51 +13,6 @@ from .style import Style, StyleType
 
 # Number of characters before 'pulse' animation repeats
 PULSE_SIZE = 20
-
-
-@functools.lru_cache(maxsize=16)
-def _get_pulse_segments(
-    fore_style: Style,
-    back_style: Style,
-    color_system: str,
-    no_color: bool,
-    ascii: bool = False,
-) -> List[Segment]:
-    """Get a list of segments to render a pulse animation.
-
-    Returns:
-        List[Segment]: A list of segments, one segment per character.
-    """
-    bar = "-" if ascii else "━"
-    segments: List[Segment] = []
-    if color_system not in ("standard", "eight_bit", "truecolor") or no_color:
-        segments += [Segment(bar, fore_style)] * (PULSE_SIZE // 2)
-        segments += [Segment(" " if no_color else bar, back_style)] * (
-            PULSE_SIZE - (PULSE_SIZE // 2)
-        )
-        return segments
-
-    append = segments.append
-    fore_color = (
-        fore_style.color.get_truecolor()
-        if fore_style.color
-        else ColorTriplet(255, 0, 255)
-    )
-    back_color = (
-        back_style.color.get_truecolor() if back_style.color else ColorTriplet(0, 0, 0)
-    )
-    cos = math.cos
-    pi = math.pi
-    _Segment = Segment
-    _Style = Style
-    from_triplet = Color.from_triplet
-
-    for index in range(PULSE_SIZE):
-        position = index / PULSE_SIZE
-        fade = 0.5 + cos((position * pi * 2)) / 2.0
-        color = blend_rgb(fore_color, back_color, cross_fade=fade)
-        append(_Segment(bar, _Style(color=from_triplet(color))))
-    return segments
 
 
 class ProgressBar(JupyterMixin):
@@ -109,6 +64,53 @@ class ProgressBar(JupyterMixin):
         completed = min(100, max(0.0, completed))
         return completed
 
+    @lru_cache(maxsize=16)
+    def _get_pulse_segments(
+        self,
+        fore_style: Style,
+        back_style: Style,
+        color_system: str,
+        no_color: bool,
+        ascii: bool = False,
+    ) -> List[Segment]:
+        """Get a list of segments to render a pulse animation.
+
+        Returns:
+            List[Segment]: A list of segments, one segment per character.
+        """
+        bar = "-" if ascii else "━"
+        segments: List[Segment] = []
+        if color_system not in ("standard", "eight_bit", "truecolor") or no_color:
+            segments += [Segment(bar, fore_style)] * (PULSE_SIZE // 2)
+            segments += [Segment(" " if no_color else bar, back_style)] * (
+                PULSE_SIZE - (PULSE_SIZE // 2)
+            )
+            return segments
+
+        append = segments.append
+        fore_color = (
+            fore_style.color.get_truecolor()
+            if fore_style.color
+            else ColorTriplet(255, 0, 255)
+        )
+        back_color = (
+            back_style.color.get_truecolor()
+            if back_style.color
+            else ColorTriplet(0, 0, 0)
+        )
+        cos = math.cos
+        pi = math.pi
+        _Segment = Segment
+        _Style = Style
+        from_triplet = Color.from_triplet
+
+        for index in range(PULSE_SIZE):
+            position = index / PULSE_SIZE
+            fade = 0.5 + cos((position * pi * 2)) / 2.0
+            color = blend_rgb(fore_color, back_color, cross_fade=fade)
+            append(_Segment(bar, _Style(color=from_triplet(color))))
+        return segments
+
     def update(self, completed: float, total: Optional[float] = None) -> None:
         """Update progress with new values.
 
@@ -137,7 +139,7 @@ class ProgressBar(JupyterMixin):
         fore_style = console.get_style(self.pulse_style, default="white")
         back_style = console.get_style(self.style, default="black")
 
-        pulse_segments = _get_pulse_segments(
+        pulse_segments = self._get_pulse_segments(
             fore_style, back_style, console.color_system, console.no_color, ascii=ascii
         )
         segment_count = len(pulse_segments)

--- a/tests/test_bar.py
+++ b/tests/test_bar.py
@@ -1,5 +1,5 @@
 from rich.console import Console
-from rich.progress_bar import ProgressBar, _get_pulse_segments
+from rich.progress_bar import ProgressBar
 from rich.segment import Segment
 from rich.style import Style
 
@@ -63,7 +63,7 @@ def test_pulse():
 
 def test_get_pulse_segments():
     bar = ProgressBar()
-    segments = _get_pulse_segments(
+    segments = bar._get_pulse_segments(
         Style.parse("red"), Style.parse("yellow"), None, False, False
     )
     print(repr(segments))


### PR DESCRIPTION
Reverts Textualize/rich#1834

In retrospect, this original behaviour was fine