### PR TITLE
Tables - Column - Fix documentation of no_wrap option

### DIFF
--- a/docs/source/tables.rst
+++ b/docs/source/tables.rst
@@ -139,7 +139,7 @@ There are a number of options you can set on a column to modify how it will look
 - ``min_width`` When set to an integer will prevent the column from shrinking below this amount.
 - ``max_width`` When set to an integer will prevent the column from growing beyond this amount.
 - ``ratio`` Defines a ratio to set the column width. For instance, if there are 3 columns with a total of 6 ratio, and ``ratio=2`` then the column will be a third of the available size.
-- ``no_wrap`` Set to False to prevent this column from wrapping.
+- ``no_wrap`` Set to True to prevent this column from wrapping.
 
 Vertical Alignment
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code. (no new code)
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate. (too minor of a change)
- [ ] I've added tests for new code. (no new code)
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The ```Column``` option ```no_wrap``` was documented accidentally as if it is a ```wrap``` option.
Updated the documentation to match actual behavior and the ```add_column``` docstring.