### PR TITLE
Traceback coverage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,6 @@ repos:
     rev: v1.9.0
     hooks:
       - id: python-check-mock-methods
-      - id: python-no-eval
       - id: python-no-log-warn
       - id: python-use-type-annotations
       - id: rst-directive-colons

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -110,7 +110,7 @@ def test_syntax_error():
     console = Console(width=100, file=io.StringIO())
     try:
         # raises SyntaxError: unexpected EOF while parsing
-        compile("(2+2")
+        eval("(2+2")
     except Exception:
         console.print_exception()
     exception_text = console.file.getvalue()

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -111,7 +111,7 @@ def test_syntax_error():
     try:
         # raises SyntaxError: unexpected EOF while parsing
         eval("(2+2")
-    except Exception:
+    except SyntaxError:
         console.print_exception()
     exception_text = console.file.getvalue()
     assert "SyntaxError" in exception_text


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

A couple of weeks ago I changed this line of code because it was making the `no-eval` pre-commit hook fail. The test still passed because of the broad `except Exception` clause, but a SyntaxError was no longer being raised. This just reverts back and removes that pre-commit hook (I'm not aware of any means of having these hooks ignore a line).

```
rich/traceback.py          225      1    99%   386
```

Takes coverage of this file back from 93 to 99.

Fixes #1882 