### PR TITLE
Add default_columns classmethod to Progress class

### DIFF
--- a/rich/progress.py
+++ b/rich/progress.py
@@ -588,12 +588,7 @@ class Progress(JupyterMixin):
             refresh_per_second is None or refresh_per_second > 0
         ), "refresh_per_second must be > 0"
         self._lock = RLock()
-        self.columns = columns or (
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-            TimeRemainingColumn(),
-        )
+        self.columns = columns or self.default_columns()
         self.speed_estimate_period = speed_estimate_period
 
         self.disable = disable
@@ -612,6 +607,15 @@ class Progress(JupyterMixin):
         self.get_time = get_time or self.console.get_time
         self.print = self.console.print
         self.log = self.console.log
+
+    @classmethod
+    def default_columns(cls) -> Tuple[ProgressColumn, ...]:
+        return (
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            TimeRemainingColumn(),
+        )
 
     @property
     def console(self) -> Console:
@@ -1015,10 +1019,7 @@ if __name__ == "__main__":  # pragma: no coverage
 
     with Progress(
         SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(),
-        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-        TimeRemainingColumn(),
+        *Progress.default_columns(),
         TimeElapsedColumn(),
         console=console,
         transient=True,

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -588,7 +588,7 @@ class Progress(JupyterMixin):
             refresh_per_second is None or refresh_per_second > 0
         ), "refresh_per_second must be > 0"
         self._lock = RLock()
-        self.columns = columns or self.default_columns()
+        self.columns = columns or self.get_default_columns()
         self.speed_estimate_period = speed_estimate_period
 
         self.disable = disable
@@ -609,7 +609,29 @@ class Progress(JupyterMixin):
         self.log = self.console.log
 
     @classmethod
-    def default_columns(cls) -> Tuple[ProgressColumn, ...]:
+    def get_default_columns(cls) -> Tuple[ProgressColumn, ...]:
+        """Get the default columns used for a new Progress instance:
+           - a text column for the description (TextColumn)
+           - the bar itself (BarColumn)
+           - a text column showing completion percentage (TextColumn)
+           - an estimated-time-remaining column (TimeRemainingColumn)
+        If the Progress instance is created without passing a columns argument,
+        the default columns defined here will be used.
+
+        You can also create a Progress instance using custom columns before
+        and/or after the defaults, as in this example:
+
+            progress = Progress(
+                SpinnerColumn(),
+                *Progress.default_columns(),
+                "Elapsed:",
+                TimeElapsedColumn(),
+            )
+
+        This code shows the creation of a Progress display, containing
+        a spinner to the left, the default columns, and a labeled elapsed
+        time column.
+        """
         return (
             TextColumn("[progress.description]{task.description}"),
             BarColumn(),
@@ -1019,7 +1041,7 @@ if __name__ == "__main__":  # pragma: no coverage
 
     with Progress(
         SpinnerColumn(),
-        *Progress.default_columns(),
+        *Progress.get_default_columns(),
         TimeElapsedColumn(),
         console=console,
         transient=True,

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -334,6 +334,32 @@ def test_columns() -> None:
     assert result == expected
 
 
+def test_using_default_columns() -> None:
+    # can only check types, as the instances do not '==' each other
+    expected_default_types = [
+        TextColumn,
+        BarColumn,
+        TextColumn,
+        TimeRemainingColumn,
+    ]
+
+    progress = Progress()
+    assert [type(c) for c in progress.columns] == expected_default_types
+
+    progress = Progress(
+        SpinnerColumn(),
+        *Progress.default_columns(),
+        "Elapsed:",
+        TimeElapsedColumn(),
+    )
+    assert [type(c) for c in progress.columns] == [
+        SpinnerColumn,
+        *expected_default_types,
+        str,
+        TimeElapsedColumn,
+    ]
+
+
 def test_task_create() -> None:
     task = Task(TaskID(1), "foo", 100, 0, _get_time=lambda: 1)
     assert task.elapsed is None

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -348,7 +348,7 @@ def test_using_default_columns() -> None:
 
     progress = Progress(
         SpinnerColumn(),
-        *Progress.default_columns(),
+        *Progress.get_default_columns(),
         "Elapsed:",
         TimeElapsedColumn(),
     )


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Added new default_columns() classmethod to the Progress class, so that client code does not need to replicate the defaults literally, but can just add `*Progress.default_columns()`