### PR TITLE
PyPy3 test fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `test_syntax.py::test_from_path_lexer_override` test failure on PyPy3 https://github.com/Textualize/rich/pull/1904
+- Fixed test failures on PyPy3 https://github.com/Textualize/rich/pull/1904
 
 ## [11.1.0] - 2022-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for US spelling of "gray" in ANSI color names https://github.com/Textualize/rich/issues/1890
 
+### Fixed
+
+- Fixed `test_syntax.py::test_from_path_lexer_override` test failure on PyPy3 https://github.com/Textualize/rich/pull/1904
+
 ## [11.1.0] - 2022-01-28
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,3 +27,4 @@ The following people have contributed to the development of Rich:
 - [Nicolas Simonds](https://github.com/0xDEC0DE)
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)
 - [Patrick Arminio](https://github.com/patrick91)
+- [Michał Górny](https://github.com/mgorny)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -32,6 +32,11 @@ skip_py310 = pytest.mark.skipif(
     reason="rendered differently on py3.10",
 )
 
+skip_pypy3 = pytest.mark.skipif(
+    hasattr(sys, "pypy_version_info"),
+    reason="rendered differently on pypy3",
+)
+
 
 def render(obj, methods=False, value=False, width=50) -> str:
     console = Console(file=io.StringIO(), width=width, legacy_windows=False)
@@ -81,6 +86,7 @@ def test_render():
     assert expected == result
 
 
+@skip_pypy3
 def test_inspect_text():
     expected = (
         "╭──────────────── <class 'str'> ─────────────────╮\n"
@@ -98,6 +104,7 @@ def test_inspect_text():
 
 @skip_py36
 @skip_py37
+@skip_pypy3
 def test_inspect_empty_dict():
     expected = (
         "╭──────────────── <class 'dict'> ────────────────╮\n"
@@ -119,6 +126,7 @@ def test_inspect_empty_dict():
     assert render({}).startswith(expected)
 
 
+@skip_pypy3
 def test_inspect_builtin_function():
     expected = (
         "╭────────── <built-in function print> ───────────╮\n"
@@ -237,6 +245,7 @@ def test_inspect_integer_with_methods():
 
 @skip_py36
 @skip_py37
+@skip_pypy3
 def test_broken_call_attr():
     class NotCallable:
         __call__ = 5  # Passes callable() but isn't really callable

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -277,7 +277,7 @@ def test_from_path_lexer_override():
     try:
         os.write(fh, b"import this\n")
         syntax = Syntax.from_path(path, lexer="rust")
-        assert syntax.lexer.name is "Rust"
+        assert syntax.lexer.name == "Rust"
         assert syntax.code == "import this\n"
     finally:
         os.remove(path)


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

1. Fix test_syntax to compare strings via `==` rather than `is`, in order to fix test failure on PyPy3.
2. Skip a few test_inspect tests on PyPy3 that fail due to different output.