### PR TITLE
Fixed force_terminal on Jupyter

### DIFF
--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -36,6 +36,7 @@ from ._loop import loop_last
 from ._pick import pick_bool
 from .abc import RichRenderable
 from .cells import cell_len
+from .console import Console
 from .highlighter import ReprHighlighter
 from .jupyter import JupyterMixin, JupyterRenderable
 from .measure import Measurement
@@ -119,12 +120,17 @@ def _ipy_display_hook(
                     repr_result = method()
                 except Exception:
                     continue  # If the method raises, treat it as if it doesn't exist, try any others
-                if repr_result is not None:
-                    return  # Delegate rendering to IPython
+                else:
+                    # Delegated rendering to IPython, so no further action needed.
+                    return
 
     # certain renderables should start on a new line
     if _safe_isinstance(value, ConsoleRenderable):
         console.line()
+
+    if console.is_terminal:
+        # Force render as colored text, rather than html.
+        console = Console(force_terminal=True, force_jupyter=False)
 
     console.print(
         value


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

Fixes behavior after running `rich.pretty.install()` Jupyter Lab:

- Do not show `<Figure size 432x288 with 1 Axes>` on Matplotlib figures
- With `force_terminal=True`. and `force_jupyter=None` (or `True`), pandas dataframe must still be rendered once (i.e., the html repr).
