### PR TITLE
Fix repr highlighter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for US spelling of "gray" in ANSI color names https://github.com/Textualize/rich/issues/1890
-
+- Add support for enum.Flag in ReprHighlighter
 ## [11.1.0] - 2022-01-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for US spelling of "gray" in ANSI color names https://github.com/Textualize/rich/issues/1890
-- Add support for enum.Flag in ReprHighlighter
+- Add support for enum.Flag in ReprHighlighter https://github.com/Textualize/rich/pull/1920
 ## [11.1.0] - 2022-01-28
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,3 +27,4 @@ The following people have contributed to the development of Rich:
 - [Nicolas Simonds](https://github.com/0xDEC0DE)
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)
 - [Patrick Arminio](https://github.com/patrick91)
+- [Dennis Brakhane](https://github.com/brakhane)

--- a/rich/highlighter.py
+++ b/rich/highlighter.py
@@ -81,7 +81,7 @@ class ReprHighlighter(RegexHighlighter):
 
     base_style = "repr."
     highlights = [
-        r"(?P<tag_start>\<)(?P<tag_name>[\w\-\.\:]*)(?P<tag_contents>[\w\W]*?)(?P<tag_end>\>)",
+        r"(?P<tag_start>\<)(?P<tag_name>[\w\-\.\:\|]*)(?P<tag_contents>[\w\W]*?)(?P<tag_end>\>)",
         r"(?P<attrib_name>[\w_]{1,50})=(?P<attrib_value>\"?[\w_]+\"?)?",
         r"(?P<brace>[\{\[\(\)\]\}])",
         _combine_regex(

--- a/rich/highlighter.py
+++ b/rich/highlighter.py
@@ -81,22 +81,22 @@ class ReprHighlighter(RegexHighlighter):
 
     base_style = "repr."
     highlights = [
-        r"(?P<tag_start>\<)(?P<tag_name>[\w\-\.\:\|]*)(?P<tag_contents>[\w\W]*?)(?P<tag_end>\>)",
-        r"(?P<attrib_name>[\w_]{1,50})=(?P<attrib_value>\"?[\w_]+\"?)?",
-        r"(?P<brace>[\{\[\(\)\]\}])",
+        r"(?P<tag_start><)(?P<tag_name>[-\w.:|]*)(?P<tag_contents>[\w\W]*?)(?P<tag_end>>)",
+        r'(?P<attrib_name>[\w_]{1,50})=(?P<attrib_value>"?[\w_]+"?)?',
+        r"(?P<brace>[][{}()])",
         _combine_regex(
             r"(?P<ipv4>[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})",
             r"(?P<ipv6>([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})",
             r"(?P<eui64>(?:[0-9A-Fa-f]{1,2}-){7}[0-9A-Fa-f]{1,2}|(?:[0-9A-Fa-f]{1,2}:){7}[0-9A-Fa-f]{1,2}|(?:[0-9A-Fa-f]{4}\.){3}[0-9A-Fa-f]{4})",
             r"(?P<eui48>(?:[0-9A-Fa-f]{1,2}-){5}[0-9A-Fa-f]{1,2}|(?:[0-9A-Fa-f]{1,2}:){5}[0-9A-Fa-f]{1,2}|(?:[0-9A-Fa-f]{4}\.){2}[0-9A-Fa-f]{4})",
-            r"(?P<call>[\w\.]*?)\(",
+            r"(?P<call>[\w.]*?)\(",
             r"\b(?P<bool_true>True)\b|\b(?P<bool_false>False)\b|\b(?P<none>None)\b",
             r"(?P<ellipsis>\.\.\.)",
-            r"(?P<number>(?<!\w)\-?[0-9]+\.?[0-9]*(e[\-\+]?\d+?)?\b|0x[0-9a-fA-F]*)",
-            r"(?P<path>\B(\/[\w\.\-\_\+]+)*\/)(?P<filename>[\w\.\-\_\+]*)?",
-            r"(?<![\\\w])(?P<str>b?\'\'\'.*?(?<!\\)\'\'\'|b?\'.*?(?<!\\)\'|b?\"\"\".*?(?<!\\)\"\"\"|b?\".*?(?<!\\)\")",
-            r"(?P<uuid>[a-fA-F0-9]{8}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{4}\-[a-fA-F0-9]{12})",
-            r"(?P<url>(file|https|http|ws|wss):\/\/[0-9a-zA-Z\$\-\_\+\!`\(\)\,\.\?\/\;\:\&\=\%\#]*)",
+            r"(?P<number>(?<!\w)\-?[0-9]+\.?[0-9]*(e[-+]?\d+?)?\b|0x[0-9a-fA-F]*)",
+            r"(?P<path>\B(/[-\w._+]+)*\/)(?P<filename>[-\w._+]*)?",
+            r"(?<![\\\w])(?P<str>b?'''.*?(?<!\\)'''|b?'.*?(?<!\\)'|b?\"\"\".*?(?<!\\)\"\"\"|b?\".*?(?<!\\)\")",
+            r"(?P<uuid>[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})",
+            r"(?P<url>(file|https|http|ws|wss)://[-0-9a-zA-Z$_+!`(),.?/;:&=%#]*)",
         ),
     ]
 

--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -40,6 +40,16 @@ highlight_tests = [
             Span(4, 9, "repr.str"),
         ],
     ),
+    (
+        "<Permission.WRITE|READ: 3>",
+        [
+            Span(0, 1, "repr.tag_start"),
+            Span(1, 23, "repr.tag_name"),
+            Span(23, 25, "repr.tag_contents"),
+            Span(25, 26, "repr.tag_end"),
+            Span(24, 25, "repr.number"),
+        ],
+    ),
     ("( )", [Span(0, 1, "repr.brace"), Span(2, 3, "repr.brace")]),
     ("[ ]", [Span(0, 1, "repr.brace"), Span(2, 3, "repr.brace")]),
     ("{ }", [Span(0, 1, "repr.brace"), Span(2, 3, "repr.brace")]),


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [X] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

This PR contains 2 changes:

1. enum.Flag supports more than one bit to be set, and it is displayed like `<Permission.READ|WRITE: 3>`. The `|` character was not recognised by ReprHighlighter as part of a tag_name, causing only the first part to be highlighted.

2. This is purely cosmetic, but I found the regexes to be really difficult to parse because of all the backslashes. Most of those actually weren't necessary, the commit explains the details further. However, this commit is completely optional.
