### PR TITLE
task._progress change default_factory to create deque(maxlen=1000), t…

### DIFF
--- a/rich/progress.py
+++ b/rich/progress.py
@@ -475,7 +475,7 @@ class Task:
     """Optional[float]: The last speed for a finished task."""
 
     _progress: Deque[ProgressSample] = field(
-        default_factory=deque, init=False, repr=False
+        default_factory=lambda: deque(maxlen=1000), init=False, repr=False
     )
 
     _lock: RLock = field(repr=False, default_factory=RLock)
@@ -812,8 +812,6 @@ class Progress(JupyterMixin):
 
             popleft = _progress.popleft
             while _progress and _progress[0].timestamp < old_sample_time:
-                popleft()
-            while len(_progress) > 1000:
                 popleft()
             if update_completed > 0:
                 _progress.append(ProgressSample(current_time, update_completed))


### PR DESCRIPTION
…o avoid run-time while loop to trim to length 1000

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [X] Other - Performance

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

Instead of explicitly looping over task._progress to trim down to 1000 items, declare _progress with a factory method `lambda: deque(maxlen=1000)` so that deque will do this work for you (presumably at C speed)

No change needed for CONTRIBUTORS.md.  No change to CHANGELOG.md since this change is not externally visible.