### PR TITLE
Fix red extension

### DIFF
--- a/examples/tree.py
+++ b/examples/tree.py
@@ -34,7 +34,7 @@ def walk_directory(directory: pathlib.Path, tree: Tree) -> None:
             walk_directory(path, branch)
         else:
             text_filename = Text(path.name, "green")
-            text_filename.highlight_regex(r"\..*$", "bold red")
+            text_filename.highlight_regex(r"\.([^.]*)$", "bold red")
             text_filename.stylize(f"link file://{path}")
             file_size = path.stat().st_size
             text_filename.append(f" ({decimal(file_size)})", "blue")


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
```
$ black examples/tree.py
All done! ✨ 🍰 ✨
1 file left unchanged.
```
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

When file has a lot of dots in filename, new version of `examples/tree.py` matches file extension in less surprising way.

old version:  The **.Silence.of.the.Lambs.mp4**
new version: The.Silence.of.the.Lambs **.mp4**