### PR TITLE
In Jupyter mode have the link target set to "_blank"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- In Jupyter mode make the link target be set to "_blank"
+
 ## [11.2.0] - 2022-02-08
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,3 +29,4 @@ The following people have contributed to the development of Rich:
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)
 - [Patrick Arminio](https://github.com/patrick91)
 - [Michał Górny](https://github.com/mgorny)
+- [Arian Mollik Wasi](https://github.com/wasi-master)

--- a/rich/jupyter.py
+++ b/rich/jupyter.py
@@ -63,7 +63,7 @@ def _render_segments(segments: Iterable[Segment]) -> str:
             rule = style.get_html_style(theme)
             text = f'<span style="{rule}">{text}</span>' if rule else text
             if style.link:
-                text = f'<a href="{style.link}">{text}</a>'
+                text = f'<a href="{style.link}" target="_blank">{text}</a>'
         append_fragment(text)
 
     code = "".join(fragments)


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Closes https://github.com/Textualize/rich/issues/1905

I've yet not updated CHANGELOG.md since I do not know which version of rich with this pr ship with, nor when the version will be released. I have not updated CONTRIBUTORS.md since I do not think this is a significant contribution. If you want I can do those.
