### PR TITLE
fix link

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,7 +27,7 @@ The following people have contributed to the development of Rich:
 - [Tim Savage](https://github.com/timsavage)
 - [Nicolas Simonds](https://github.com/0xDEC0DE)
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)
-- [Patrick Arminio](https://github.com/patrick9)
+- [Patrick Arminio](https://github.com/patrick91)
 - [Dennis Brakhane](https://github.com/brakhane)
 - [Michał Górny](https://github.com/mgorny)
 - [Arian Mollik Wasi](https://github.com/wasi-master)


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Description

I just noticed that somehow a merge in my PR #1920 broke the link of a contributor. Not sure how it happened, but here's the fix.