### PR TITLE
Pass Console parameters passed to logging.RichHandler constructor

### DIFF
--- a/rich/logging.py
+++ b/rich/logging.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 from logging import Handler, LogRecord
 from pathlib import Path
-from typing import ClassVar, List, Optional, Type, Union
+from typing import Any, ClassVar, List, Mapping, Optional, Type, Union
 
 from . import get_console
 from ._log_render import LogRender, FormatTimeCallable
@@ -58,7 +58,7 @@ class RichHandler(Handler):
     def __init__(
         self,
         level: Union[int, str] = logging.NOTSET,
-        console: Optional[Console] = None,
+        console: Optional[Union[Console, Mapping[str, Any]]] = None,
         *,
         show_time: bool = True,
         omit_repeated_times: bool = True,
@@ -78,7 +78,13 @@ class RichHandler(Handler):
         log_time_format: Union[str, FormatTimeCallable] = "[%x %X]",
     ) -> None:
         super().__init__(level=level)
-        self.console = console or get_console()
+        self.console = (
+            console
+            if isinstance(console, Console)
+            else Console(**console)
+            if console
+            else get_console()
+        )
         self.highlighter = highlighter or self.HIGHLIGHTER_CLASS()
         self._log_render = LogRender(
             show_time=show_time,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -162,6 +162,11 @@ def test_markup_and_highlight():
     assert log_message in render_plain
 
 
+def test_console_params():
+    handler = RichHandler(console=dict(stderr=True))
+    assert handler.console.stderr
+
+
 if __name__ == "__main__":
     render = make_log()
     print(render)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [X] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Enable to pass ``Console`` constructor parameters to the ``RichHandler`` constructor.
This way, through the ``logging.config.dictConfig``, without dependency to the Rich project, a module can redirect its logs the the ``stderr`` with
```
{
  "handlers": {
    "rich": {
      "class": "rich.logging.RichHandler",
      "console": "cfg://stderr_console"
    }
  },
  "stderr_console": {
    "stderr": true
  }
}
```