### PR TITLE
Use "kB" for `DownloadColumn`

### DIFF
--- a/rich/progress.py
+++ b/rich/progress.py
@@ -427,7 +427,9 @@ class DownloadColumn(ProgressColumn):
             )
         else:
             unit, suffix = filesize.pick_unit_and_suffix(
-                total, ["bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"], 1000
+                total,
+                ["bytes", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"],
+                1000,
             )
         completed_ratio = completed / unit
         total_ratio = total / unit

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -123,7 +123,7 @@ def test_download_progress_uses_decimal_units() -> None:
     column = DownloadColumn()
     test_task = Task(1, "test", 1000, 500, _get_time=lambda: 1.0)
     rendered_progress = str(column.render(test_task))
-    expected = "0.5/1.0 KB"
+    expected = "0.5/1.0 kB"
     assert rendered_progress == expected
 
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

While working on https://github.com/pypa/twine/pull/877, I noticed that `DownloadColumn` uses `KB` instead of `kB`, even though the divisor is 1000 (like `FileSizeColumn` and `TransferSpeedColumn`).
