### PR TITLE
Fix lexer guessing for rich.syntax cli.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - In Jupyter mode make the link target be set to "_blank"
 - Fix some issues with markup handling around "[" characters https://github.com/Textualize/rich/pull/1950
+- Fix syntax lexer guessing.
 
 ### Added
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ The following people have contributed to the development of Rich:
 
 - [Gregory Beauregard](https://github.com/GBeauregard/pyffstream)
 - [Darren Burns](https://github.com/darrenburns)
+- [Ed Davis](https://github.com/davised)
 - [Pete Davison](https://github.com/pd93)
 - [James Estevez](https://github.com/jstvz)
 - [Oleksis Fraga](https://github.com/oleksis)

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -735,7 +735,7 @@ if __name__ == "__main__":  # pragma: no cover
     parser.add_argument(
         "-x",
         "--lexer",
-        default="default",
+        default=None,
         dest="lexer_name",
         help="Lexer name",
     )


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

Changes default arg for lexer_name so 'default' doesn't override guessing.