### PR TITLE
Add condensed time column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added options to TimeRemainingColumn to render a compact time format and render elapsed time when a task is
+  finished. https://github.com/Textualize/rich/pull/1992
 - Added ProgressColumn `MofNCompleteColumn` to display raw `completed/total` column (similar to DownloadColumn,
-  but displays values as ints, does not convert to floats or add bit/bytes units). 
+  but displays values as ints, does not convert to floats or add bit/bytes units).
   https://github.com/Textualize/rich/pull/1941
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,4 +31,4 @@ The following people have contributed to the development of Rich:
 - [Dennis Brakhane](https://github.com/brakhane)
 - [Michał Górny](https://github.com/mgorny)
 - [Arian Mollik Wasi](https://github.com/wasi-master)
-
+- [Brian Rutledge](https://github.com/bhrutledge)

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -357,6 +357,30 @@ class TimeRemainingColumn(ProgressColumn):
         return Text(str(remaining_delta), style="progress.remaining")
 
 
+class CondensedTimeColumn(ProgressColumn):
+    """Renders estimated time remaining, or elapsed time when the task is finished."""
+
+    # Only refresh twice a second to prevent jitter
+    max_refresh = 0.5
+
+    def render(self, task: "Task") -> Text:
+        """Show time."""
+        style = "progress.elapsed" if task.finished else "progress.remaining"
+        task_time = task.finished_time if task.finished else task.time_remaining
+        if task_time is None:
+            return Text("--:--", style=style)
+
+        # Based on https://github.com/tqdm/tqdm/blob/master/tqdm/std.py
+        minutes, seconds = divmod(int(task_time), 60)
+        hours, minutes = divmod(minutes, 60)
+        if hours:
+            formatted = f"{hours:d}:{minutes:02d}:{seconds:02d}"
+        else:
+            formatted = f"{minutes:02d}:{seconds:02d}"
+
+        return Text(formatted, style=style)
+
+
 class FileSizeColumn(ProgressColumn):
     """Renders completed filesize."""
 

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -343,40 +343,46 @@ class TimeElapsedColumn(ProgressColumn):
 
 
 class TimeRemainingColumn(ProgressColumn):
-    """Renders estimated time remaining."""
+    """Renders estimated time remaining.
+
+    Args:
+        compact (bool, optional): Render MM:SS when time remaining is less than an hour. Defaults to False.
+        elapsed_when_finished (bool, optional): Render time elapsed when the task is finished. Defaults to False.
+    """
 
     # Only refresh twice a second to prevent jitter
     max_refresh = 0.5
+
+    def __init__(
+        self,
+        compact: bool = False,
+        elapsed_when_finished: bool = False,
+        table_column: Optional[Column] = None,
+    ):
+        self.compact = compact
+        self.elapsed_when_finished = elapsed_when_finished
+        super().__init__(table_column=table_column)
 
     def render(self, task: "Task") -> Text:
         """Show time remaining."""
-        remaining = task.time_remaining
-        if remaining is None:
-            return Text("-:--:--", style="progress.remaining")
-        remaining_delta = timedelta(seconds=int(remaining))
-        return Text(str(remaining_delta), style="progress.remaining")
+        if self.elapsed_when_finished and task.finished:
+            task_time = task.finished_time
+            style = "progress.elapsed"
+        else:
+            task_time = task.time_remaining
+            style = "progress.remaining"
 
-
-class CondensedTimeColumn(ProgressColumn):
-    """Renders estimated time remaining, or elapsed time when the task is finished."""
-
-    # Only refresh twice a second to prevent jitter
-    max_refresh = 0.5
-
-    def render(self, task: "Task") -> Text:
-        """Show time."""
-        style = "progress.elapsed" if task.finished else "progress.remaining"
-        task_time = task.finished_time if task.finished else task.time_remaining
         if task_time is None:
-            return Text("--:--", style=style)
+            return Text("--:--" if self.compact else "-:--:--", style=style)
 
         # Based on https://github.com/tqdm/tqdm/blob/master/tqdm/std.py
         minutes, seconds = divmod(int(task_time), 60)
         hours, minutes = divmod(minutes, 60)
-        if hours:
-            formatted = f"{hours:d}:{minutes:02d}:{seconds:02d}"
-        else:
+
+        if self.compact and not hours:
             formatted = f"{minutes:02d}:{seconds:02d}"
+        else:
+            formatted = f"{hours:d}:{minutes:02d}:{seconds:02d}"
 
         return Text(formatted, style=style)
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -2,6 +2,7 @@
 
 import io
 from time import sleep
+from types import SimpleNamespace
 
 import pytest
 
@@ -22,6 +23,7 @@ from rich.progress import (
     TextColumn,
     TimeElapsedColumn,
     TimeRemainingColumn,
+    CondensedTimeColumn,
     track,
     _TrackThread,
     TaskID,
@@ -87,6 +89,27 @@ def test_time_remaining_column():
 
     text = column(FakeTask(1, "test", 100, 20, _get_time=lambda: 1.0))
     assert str(text) == "0:01:00"
+
+
+@pytest.mark.parametrize("finished", [False, True])
+@pytest.mark.parametrize(
+    "task_time, formatted",
+    [
+        (None, "--:--"),
+        (0, "00:00"),
+        (59, "00:59"),
+        (71, "01:11"),
+        (4210, "1:10:10"),
+    ],
+)
+def test_condensed_time_column(finished, task_time, formatted):
+    if finished:
+        task = SimpleNamespace(finished=finished, finished_time=task_time)
+    else:
+        task = SimpleNamespace(finished=finished, time_remaining=task_time)
+
+    column = CondensedTimeColumn()
+    assert str(column.render(task)) == formatted
 
 
 def test_renderable_column():

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -23,7 +23,6 @@ from rich.progress import (
     TextColumn,
     TimeElapsedColumn,
     TimeRemainingColumn,
-    CondensedTimeColumn,
     track,
     _TrackThread,
     TaskID,
@@ -91,7 +90,6 @@ def test_time_remaining_column():
     assert str(text) == "0:01:00"
 
 
-@pytest.mark.parametrize("finished", [False, True])
 @pytest.mark.parametrize(
     "task_time, formatted",
     [
@@ -102,13 +100,20 @@ def test_time_remaining_column():
         (4210, "1:10:10"),
     ],
 )
-def test_condensed_time_column(finished, task_time, formatted):
-    if finished:
-        task = SimpleNamespace(finished=finished, finished_time=task_time)
-    else:
-        task = SimpleNamespace(finished=finished, time_remaining=task_time)
+def test_compact_time_remaining_column(task_time, formatted):
+    task = SimpleNamespace(finished=False, time_remaining=task_time)
+    column = TimeRemainingColumn(compact=True)
 
-    column = CondensedTimeColumn()
+    assert str(column.render(task)) == formatted
+
+
+def test_time_remaining_column_elapsed_when_finished():
+    task_time = 71
+    formatted = "0:01:11"
+
+    task = SimpleNamespace(finished=True, finished_time=task_time)
+    column = TimeRemainingColumn(elapsed_when_finished=True)
+
     assert str(column.render(task)) == formatted
 
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

While [replacing Twine's progress bar with Rich](https://github.com/pypa/twine/pull/877), I got into some bike-shedding/yak-shaving to declutter the time column. After looking at several download progress indicators (e.g. Chrome, Firefox, `wget`, `scp`), it seems more common to show time remaining than time elapsed. Both `wget` and `scp` show time remaining until the download is finished, then switch to time elapsed. So, I implemented that behavior here.

For example:


https://user-images.githubusercontent.com/1326704/155128465-783d6866-006b-4e9c-bcae-45267b787e24.mp4


