### PR TITLE
Add missing 10.16.2 link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1655,6 +1655,7 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 [11.2.0]: https://github.com/willmcgugan/rich/compare/v11.1.0...v11.2.0
 [11.1.0]: https://github.com/willmcgugan/rich/compare/v11.0.0...v11.1.0
 [11.0.0]: https://github.com/willmcgugan/rich/compare/v10.16.1...v11.0.0
+[10.16.2]: https://github.com/willmcgugan/rich/compare/v10.16.1...v10.16.2
 [10.16.1]: https://github.com/willmcgugan/rich/compare/v10.16.0...v10.16.1
 [10.16.0]: https://github.com/willmcgugan/rich/compare/v10.15.2...v10.16.0
 [10.15.2]: https://github.com/willmcgugan/rich/compare/v10.15.1...v10.15.2


### PR DESCRIPTION
## Type of changes

- [x] Documentation / docstrings

## Checklist

- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The 10.16.2 entry in the changelog does not currently have a link associated with its header 🙂 

![image](https://user-images.githubusercontent.com/25310870/155281240-e95bbbc6-8f03-4709-aee5-2f27c9a9df41.png)