### PR TITLE
Add the `log_omit_repeated_times` option to `Console`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ProgressColumn `MofNCompleteColumn` to display raw `completed/total` column (similar to DownloadColumn,
   but displays values as ints, does not convert to floats or add bit/bytes units).
   https://github.com/Textualize/rich/pull/1941
+- Added the `log_omit_repeated_times` option to `Console`.
 
 ### Fixed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,3 +35,4 @@ The following people have contributed to the development of Rich:
 - [Aaron Stephens](https://github.com/aaronst)
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)
 - [Arian Mollik Wasi](https://github.com/wasi-master)
+- [Antonio Camargo](https://github.com/apcamargo)

--- a/rich/console.py
+++ b/rich/console.py
@@ -602,6 +602,7 @@ class Console:
         emoji (bool, optional): Enable emoji code. Defaults to True.
         emoji_variant (str, optional): Optional emoji variant, either "text" or "emoji". Defaults to None.
         highlight (bool, optional): Enable automatic highlighting. Defaults to True.
+        log_omit_repeated_times (bool, optional): Boolean to omit the repetition of the same time by :meth:`log` methods. Defaults to True.
         log_time (bool, optional): Boolean to enable logging of time by :meth:`log` methods. Defaults to True.
         log_path (bool, optional): Boolean to enable the logging of the caller by :meth:`log`. Defaults to True.
         log_time_format (Union[str, TimeFormatterCallable], optional): If ``log_time`` is enabled, either string for strftime or callable that formats the time. Defaults to "[%X] ".
@@ -639,6 +640,7 @@ class Console:
         emoji: bool = True,
         emoji_variant: Optional[EmojiVariant] = None,
         highlight: bool = True,
+        log_omit_repeated_times: bool = True,
         log_time: bool = True,
         log_path: bool = True,
         log_time_format: Union[str, FormatTimeCallable] = "[%X]",
@@ -700,6 +702,7 @@ class Console:
 
         self._lock = threading.RLock()
         self._log_render = LogRender(
+            omit_repeated_times=log_omit_repeated_times,
             show_time=log_time,
             show_path=log_path,
             time_format=log_time_format,


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This PR adds a `log_omit_repeated_times` option to the `Console` constructor. When set to `False`, the omission of repeated times by `log()` methods is disabled.
