### PR TITLE
Add support for bold, dim, and reverse on legacy Windows consoles

### DIFF
--- a/rich/_win32_console.py
+++ b/rich/_win32_console.py
@@ -253,8 +253,7 @@ class LegacyWindowsTerm:
         15,  # bright white
     ]
 
-    def __init__(self, file: IO[str] = sys.stdout):
-        self.file = file
+    def __init__(self) -> None:
         handle = GetStdHandle(STDOUT)
         self._handle = handle
         default_text = GetConsoleScreenBufferInfo(handle).wAttributes
@@ -262,10 +261,7 @@ class LegacyWindowsTerm:
 
         self._default_fore = default_text & 7
         self._default_back = (default_text >> 4) & 7
-        self._default_attrs = self._default_fore + self._default_back * 16
-
-        self.write = file.write
-        self.flush = file.flush
+        self._default_attrs = self._default_fore | (self._default_back << 4)
 
     @property
     def cursor_position(self) -> WindowsCoordinates:
@@ -322,7 +318,7 @@ class LegacyWindowsTerm:
         assert back is not None
 
         SetConsoleTextAttribute(
-            self._handle, attributes=ctypes.c_ushort(fore + back * 16)
+            self._handle, attributes=ctypes.c_ushort(fore | (back << 4))
         )
         self.write_text(text)
         SetConsoleTextAttribute(self._handle, attributes=self._default_text)
@@ -462,7 +458,7 @@ if __name__ == "__main__":
 
     console = Console()
 
-    term = LegacyWindowsTerm(console.file)
+    term = LegacyWindowsTerm()
     term.set_title("Win32 Console Examples")
 
     style = Style(color="black", bgcolor="red")

--- a/rich/_win32_console.py
+++ b/rich/_win32_console.py
@@ -17,12 +17,15 @@ from ctypes import Structure, byref, wintypes
 
 from rich.color import ColorSystem
 from rich.style import Style
-from rich.text import Text
 
 STDOUT = -11
 ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4
 
 COORD = wintypes._COORD
+
+
+class LegacyWindowsError(Exception):
+    pass
 
 
 class WindowsCoordinates(NamedTuple):
@@ -74,7 +77,7 @@ def GetConsoleMode(std_handle: wintypes.HANDLE) -> int:
     console_mode = wintypes.DWORD()
     success = bool(_GetConsoleMode(std_handle, console_mode))
     if not success:
-        raise WindowsError("Unable to get legacy Windows Console Mode")
+        raise LegacyWindowsError("Unable to get legacy Windows Console Mode")
     return console_mode.value
 
 
@@ -477,9 +480,8 @@ if __name__ == "__main__":
 
     # Check colour output
     console.rule("Checking colour output")
-    # console.print("Checking colour output", style=Style.parse("black on green"))
-    text = Text("Hello world!", style=style)
-    console.print(text)
+    console.print("[on red]on red!")
+    console.print("[blue]blue!")
     console.print("[yellow]yellow!")
     console.print("[bold yellow]bold yellow!")
     console.print("[bright_yellow]bright_yellow!")

--- a/rich/_win32_console.py
+++ b/rich/_win32_console.py
@@ -70,8 +70,12 @@ _GetConsoleMode.argtypes = [wintypes.HANDLE, wintypes.LPDWORD]
 _GetConsoleMode.restype = wintypes.BOOL
 
 
-def GetConsoleMode(std_handle: wintypes.HANDLE, console_mode: wintypes.DWORD) -> bool:
-    return bool(_GetConsoleMode(std_handle, console_mode))
+def GetConsoleMode(std_handle: wintypes.HANDLE) -> int:
+    console_mode = wintypes.DWORD()
+    success = bool(_GetConsoleMode(std_handle, console_mode))
+    if not success:
+        raise WindowsError("Unable to get legacy Windows Console Mode")
+    return console_mode.value
 
 
 _FillConsoleOutputCharacterW = windll.kernel32.FillConsoleOutputCharacterW

--- a/rich/_win32_console.py
+++ b/rich/_win32_console.py
@@ -296,8 +296,6 @@ class LegacyWindowsTerm:
             text (str): The text to write to the console
         """
         WriteConsole(self._handle, text)
-        # self.write(text)
-        # self.flush()
 
     def write_styled(self, text: str, style: Style) -> None:
         """Write styled text to the terminal

--- a/rich/_windows.py
+++ b/rich/_windows.py
@@ -44,9 +44,8 @@ else:
             WindowsConsoleFeatures: An instance of WindowsConsoleFeatures.
         """
         handle = GetStdHandle()
-        console_mode = wintypes.DWORD()
-        result = GetConsoleMode(handle, console_mode)
-        vt = bool(result and console_mode.value & ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+        console_mode = GetConsoleMode(handle)
+        vt = bool(console_mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING)
         truecolor = False
         if vt:
             win_version = sys.getwindowsversion()

--- a/rich/_windows.py
+++ b/rich/_windows.py
@@ -26,6 +26,7 @@ try:
         ENABLE_VIRTUAL_TERMINAL_PROCESSING,
         GetConsoleMode,
         GetStdHandle,
+        LegacyWindowsError,
     )
 
 except (AttributeError, ImportError, ValueError):
@@ -44,8 +45,13 @@ else:
             WindowsConsoleFeatures: An instance of WindowsConsoleFeatures.
         """
         handle = GetStdHandle()
-        console_mode = GetConsoleMode(handle)
-        vt = bool(console_mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+        try:
+            console_mode = GetConsoleMode(handle)
+            success = True
+        except LegacyWindowsError:
+            console_mode = 0
+            success = False
+        vt = bool(success and console_mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING)
         truecolor = False
         if vt:
             win_version = sys.getwindowsversion()

--- a/rich/console.py
+++ b/rich/console.py
@@ -1921,9 +1921,7 @@ class Console:
                             from rich._win32_console import LegacyWindowsTerm
                             from rich._windows_renderer import legacy_windows_render
 
-                            legacy_windows_render(
-                                self._buffer[:], LegacyWindowsTerm(self.file)
-                            )
+                            legacy_windows_render(self._buffer[:], LegacyWindowsTerm())
 
                         output_capture_enabled = bool(self._buffer_index)
                         if not legacy_windows_stdout or output_capture_enabled:


### PR DESCRIPTION
Some fixes for the PR #1993

* Adds support for bold, dim, and reverse on legacy Windows consoles.
* Calls the Windows Console API in order to output text, instead of writing to the `Console.file`
* More docstrings