### PR TITLE
Print json type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix syntax lexer guessing.
 - Fixed Pretty measure not respecting expand_all https://github.com/Textualize/rich/issues/1998
 - Collapsed definitions for single-character spinners, to save memory and reduce import time.
+- Fix print_json indent type in __init__.py
 
 ### Changed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,6 +30,7 @@ The following people have contributed to the development of Rich:
 - [Clément Robert](https://github.com/neutrinoceros)
 - [Brian Rutledge](https://github.com/bhrutledge)
 - [Tushar Sadhwani](https://github.com/tusharsadhwani)
+- [Paul Sanders](https://github.com/sanders41)
 - [Tim Savage](https://github.com/timsavage)
 - [Nicolas Simonds](https://github.com/0xDEC0DE)
 - [Aaron Stephens](https://github.com/aaronst)

--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -1,7 +1,7 @@
 """Rich text and beautiful formatting in the terminal."""
 
 import os
-from typing import Callable, IO, TYPE_CHECKING, Any, Optional
+from typing import Callable, IO, TYPE_CHECKING, Any, Optional, Union
 
 from ._extension import load_ipython_extension
 
@@ -73,7 +73,7 @@ def print_json(
     json: Optional[str] = None,
     *,
     data: Any = None,
-    indent: int = 2,
+    indent: Union[None, int, str] = 2,
     highlight: bool = True,
     skip_keys: bool = False,
     ensure_ascii: bool = True,


### PR DESCRIPTION
## Type of changes

Closes #2028

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Changes the type for `print_json` indent in the __init__.py file to `Union[None, int, str]`
