### PR TITLE
Add support for named tuples to pretty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -14,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ProgressColumn `MofNCompleteColumn` to display raw `completed/total` column (similar to DownloadColumn,
   but displays values as ints, does not convert to floats or add bit/bytes units).
   https://github.com/Textualize/rich/pull/1941
+- Add support for namedtuples to `Pretty` https://github.com/Textualize/rich/pull/2031
 
 ### Fixed
 

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -527,7 +527,7 @@ class _Line:
 def _is_namedtuple(obj: Any) -> bool:
     """Checks if an object is most likely a namedtuple. It is possible
     to craft an object that passes this check and isn't a namedtuple, but
-    there is only a miniscule chance of this happening unintentionally.
+    there is only a minuscule chance of this happening unintentionally.
 
     Args:
         obj (Any): The object to test

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -79,7 +79,7 @@ def _is_dataclass_repr(obj: object) -> bool:
         return False
 
 
-_dummy_namedtuple = collections.namedtuple("dummy", [])
+_dummy_namedtuple = collections.namedtuple("_dummy_namedtuple", [])
 
 
 def _has_default_namedtuple_repr(obj: object) -> bool:

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -525,6 +525,16 @@ class _Line:
 
 
 def _is_namedtuple(obj: Any) -> bool:
+    """Checks if an object is most likely a namedtuple. It is possible
+    to craft an object that passes this check and isn't a namedtuple, but
+    there is only a miniscule chance of this happening unintentionally.
+
+    Args:
+        obj (Any): The object to test
+
+    Returns:
+        bool: True if the object is a namedtuple. False otherwise.
+    """
     base_classes = getattr(type(obj), "__bases__", [])
     if len(base_classes) != 1 or base_classes[0] != tuple:
         return False

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -744,12 +744,6 @@ def traverse(
 
                 pop_visited(obj_id)
         elif _is_namedtuple(obj):
-            obj_id = id(obj)
-            if obj_id in visited_ids:
-                # Recursion detected
-                return Node(value_repr="...")
-            push_visited(obj_id)
-
             children = []
             append = children.append
             if reached_max_depth:
@@ -760,15 +754,12 @@ def traverse(
                     close_brace=")",
                     children=children,
                 )
-
                 for last, (key, value) in loop_last(obj._asdict().items()):
                     child_node = _traverse(value, depth=depth + 1)
                     child_node.key_repr = key
                     child_node.last = last
                     child_node.key_separator = "="
                     append(child_node)
-
-                pop_visited(obj_id)
         elif _safe_isinstance(obj, _CONTAINERS):
             for container_type in _CONTAINERS:
                 if _safe_isinstance(obj, container_type):

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -92,17 +92,13 @@ def _has_default_namedtuple_repr(obj: object) -> bool:
         bool: True if the default repr is used, False if there's a custom repr.
     """
     obj_file = None
-    default_repr_file = None
     try:
         obj_file = inspect.getfile(obj.__repr__)
     except (OSError, TypeError):
         # OSError handles case where object is defined in __main__ scope, e.g. REPL - no filename available.
         # TypeError trapped defensively, in case of object without filename slips through.
         pass
-    try:
-        default_repr_file = inspect.getfile(_dummy_namedtuple.__repr__)
-    except (OSError, TypeError):
-        pass
+    default_repr_file = inspect.getfile(_dummy_namedtuple.__repr__)
     return obj_file == default_repr_file
 
 
@@ -563,7 +559,11 @@ def _is_namedtuple(obj: Any) -> bool:
     Returns:
         bool: True if the object is a namedtuple. False otherwise.
     """
-    fields = getattr(obj, "_fields", None)
+    try:
+        fields = getattr(obj, "_fields", None)
+    except Exception:
+        # Being very defensive - if we cannot get the attr then its not a namedtuple
+        return False
     return isinstance(obj, tuple) and isinstance(fields, tuple)
 
 
@@ -775,16 +775,18 @@ def traverse(
 
                 pop_visited(obj_id)
         elif _is_namedtuple(obj) and _has_default_namedtuple_repr(obj):
-            children = []
-            append = children.append
             if reached_max_depth:
                 node = Node(value_repr="...")
             else:
+                children = []
+                class_name = obj.__class__.__name__
                 node = Node(
-                    open_brace=f"{obj.__class__.__name__}(",
+                    open_brace=f"{class_name}(",
                     close_brace=")",
                     children=children,
+                    empty=f"{class_name}()",
                 )
+                append = children.append
                 for last, (key, value) in loop_last(obj._asdict().items()):
                     child_node = _traverse(value, depth=depth + 1)
                     child_node.key_repr = key

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -3,7 +3,7 @@ import sys
 from array import array
 from collections import UserDict, defaultdict
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, NamedTuple
 
 import attr
 import pytest
@@ -169,17 +169,17 @@ def test_pretty_dataclass():
     assert result == "ExampleDataclass(foo=1000, bar=..., baz=['foo', 'bar', 'baz'])"
 
 
+class StockKeepingUnit(NamedTuple):
+    name: str
+    description: str
+    price: float
+    category: str
+    reviews: List[str]
+
+
 def test_pretty_namedtuple():
     console = Console(color_system=None)
     console.begin_capture()
-    from typing import NamedTuple
-
-    class StockKeepingUnit(NamedTuple):
-        name: str
-        description: str
-        price: float
-        category: str
-        reviews: List[str]
 
     example_namedtuple = StockKeepingUnit(
         "Sparkling British Spring Water",
@@ -202,6 +202,21 @@ def test_pretty_namedtuple():
     reviews=['its amazing!', 'its terrible!']
 )"""
     )
+
+
+def test_pretty_namedtuple_fields_invalid_type():
+    class LooksLikeANamedTupleButIsnt(tuple):
+        _fields = "blah"
+
+    instance = LooksLikeANamedTupleButIsnt()
+    result = pretty_repr(instance)
+    assert result == "()"  # Treated as tuple
+
+
+def test_pretty_namedtuple_max_depth():
+    instance = {"unit": StockKeepingUnit("a", "b", 1.0, "c", ["d", "e"])}
+    result = pretty_repr(instance, max_depth=1)
+    assert result == "{'unit': ...}"
 
 
 def test_small_width():

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -1,3 +1,4 @@
+import collections
 import io
 import sys
 from array import array
@@ -202,6 +203,24 @@ def test_pretty_namedtuple():
     reviews=['its amazing!', 'its terrible!']
 )"""
     )
+
+
+def test_pretty_namedtuple_length_one_no_trailing_comma():
+    instance = collections.namedtuple("Thing", ["name"])(name="Bob")
+    assert pretty_repr(instance) == "Thing(name='Bob')"
+
+
+def test_pretty_namedtuple_empty():
+    instance = collections.namedtuple("Thing", [])()
+    assert pretty_repr(instance) == "Thing()"
+
+
+def test_pretty_namedtuple_custom_repr():
+    class Thing(NamedTuple):
+        def __repr__(self):
+            return "XX"
+
+    assert pretty_repr(Thing()) == "XX"
 
 
 def test_pretty_namedtuple_fields_invalid_type():

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -169,6 +169,41 @@ def test_pretty_dataclass():
     assert result == "ExampleDataclass(foo=1000, bar=..., baz=['foo', 'bar', 'baz'])"
 
 
+def test_pretty_namedtuple():
+    console = Console(color_system=None)
+    console.begin_capture()
+    from typing import NamedTuple
+
+    class StockKeepingUnit(NamedTuple):
+        name: str
+        description: str
+        price: float
+        category: str
+        reviews: List[str]
+
+    example_namedtuple = StockKeepingUnit(
+        "Sparkling British Spring Water",
+        "Carbonated spring water",
+        0.9,
+        "water",
+        ["its amazing!", "its terrible!"],
+    )
+
+    result = pretty_repr(example_namedtuple)
+
+    print(result)
+    assert (
+        result
+        == """StockKeepingUnit(
+    name='Sparkling British Spring Water',
+    description='Carbonated spring water',
+    price=0.9,
+    category='water',
+    reviews=['its amazing!', 'its terrible!']
+)"""
+    )
+
+
 def test_small_width():
     test = ["Hello world! 12345"]
     result = pretty_repr(test, max_width=10)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Closes #2012 

Named tuples will be formatted similarly to dataclasses when formatted using the `pretty` module. The code for handling this is very similar to dataclasses, but I opted not to try and factor it out as I think it will reduce readability.