### PR TITLE
Handle case inspect fails on repl-defined objects

### DIFF
--- a/rich/_inspect.py
+++ b/rich/_inspect.py
@@ -98,7 +98,8 @@ class Inspect(JupyterMixin):
         source_filename: Optional[str] = None
         try:
             source_filename = getfile(obj)
-        except TypeError:
+        except (OSError, TypeError):
+            # OSError is raised if obj has no source file, e.g. when defined in REPL.
             pass
 
         callable_name = Text(name, style="inspect.callable")


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Objects defined in a REPL are part of the `__main__` scope, which doesn't have a corresponding file, and so `rich.inspect` was failing when trying to find this filename.

`inspect.getfile` raises an `OSError` in this case.

We catch the `OSError` and ignore it, as the rest of the code already handles the case where there is no `source_filename` available.