### PR TITLE
Windows output capture fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.0.1] - 2022-03-14
+
+### Fixed
+
+- Fix capturing stdout on legacy Windows https://github.com/Textualize/rich/pull/2055
+
 ## [12.0.0] - 2022-03-10
 
 ### Added

--- a/rich/_win32_console.py
+++ b/rich/_win32_console.py
@@ -367,7 +367,7 @@ class LegacyWindowsTerm:
         15,  # bright white
     ]
 
-    def __init__(self) -> None:
+    def __init__(self, file: IO[str]) -> None:
         handle = GetStdHandle(STDOUT)
         self._handle = handle
         default_text = GetConsoleScreenBufferInfo(handle).wAttributes
@@ -376,6 +376,10 @@ class LegacyWindowsTerm:
         self._default_fore = default_text & 7
         self._default_back = (default_text >> 4) & 7
         self._default_attrs = self._default_fore | (self._default_back << 4)
+
+        self._file = file
+        self.write = file.write
+        self.flush = file.flush
 
     @property
     def cursor_position(self) -> WindowsCoordinates:
@@ -405,7 +409,8 @@ class LegacyWindowsTerm:
         Args:
             text (str): The text to write to the console
         """
-        WriteConsole(self._handle, text)
+        self.write(text)
+        self.flush()
 
     def write_styled(self, text: str, style: Style) -> None:
         """Write styled text to the terminal.
@@ -576,7 +581,7 @@ if __name__ == "__main__":
 
     console = Console()
 
-    term = LegacyWindowsTerm()
+    term = LegacyWindowsTerm(sys.stdout)
     term.set_title("Win32 Console Examples")
 
     style = Style(color="black", bgcolor="red")

--- a/rich/_win32_console.py
+++ b/rich/_win32_console.py
@@ -302,40 +302,6 @@ def SetConsoleTitle(title: str) -> bool:
     return bool(_SetConsoleTitle(title))
 
 
-_WriteConsole = windll.kernel32.WriteConsoleW
-_WriteConsole.argtypes = [
-    wintypes.HANDLE,
-    wintypes.LPWSTR,
-    wintypes.DWORD,
-    wintypes.LPDWORD,
-    wintypes.LPVOID,
-]
-_WriteConsole.restype = wintypes.BOOL
-
-
-def WriteConsole(std_handle: wintypes.HANDLE, text: str) -> bool:
-    """Write a string of text to the console, starting at the current cursor position
-
-    Args:
-        std_handle (wintypes.HANDLE): A handle to the console input buffer or the console screen buffer.
-        text (str): The text to write.
-
-    Returns:
-        bool: True if the function succeeds, otherwise False.
-    """
-    buffer = wintypes.LPWSTR(text)
-    num_chars_written = wintypes.LPDWORD()
-    return bool(
-        _WriteConsole(
-            std_handle,
-            buffer,
-            wintypes.DWORD(len(text)),
-            num_chars_written,
-            wintypes.LPVOID(None),
-        )
-    )
-
-
 class LegacyWindowsTerm:
     """This class allows interaction with the legacy Windows Console API. It should only be used in the context
     of environments where virtual terminal processing is not available. However, if it is used in a Windows environment,

--- a/rich/_windows.py
+++ b/rich/_windows.py
@@ -63,33 +63,10 @@ else:
 
 
 if __name__ == "__main__":
-    # import platform
-    #
-    # features = get_windows_console_features()
-    # from rich import print
-    #
-    # print(f'platform="{platform.system()}"')
-    # print(repr(features))
+    import platform
 
-    import subprocess
-    import sys
+    features = get_windows_console_features()
+    from rich import print
 
-    code = """import sys
-from rich.console import Console
-
-console = Console(file=sys.stdout)
-console.print("spam")
-    """
-    err_code = code.replace("sys.stdout", "sys.stderr")
-    cmd = [sys.executable, "-"]
-
-    print("[capture_output=True via sys.stdout]")
-    proc = subprocess.run(cmd, input=code, capture_output=True, encoding="utf-8")
-    print(f"{proc.stdout=} {proc.stderr=}")
-
-    print("[capture_output=True via sys.stderr]")
-    proc = subprocess.run(cmd, input=err_code, capture_output=True, encoding="utf-8")
-    print(f"{proc.stdout=} {proc.stderr=}")
-
-    print("[capture_output=False via sys.stdout]")
-    proc = subprocess.run(cmd, input=code, capture_output=False, encoding="utf-8")
+    print(f'platform="{platform.system()}"')
+    print(repr(features))

--- a/rich/_windows.py
+++ b/rich/_windows.py
@@ -63,10 +63,33 @@ else:
 
 
 if __name__ == "__main__":
-    import platform
+    # import platform
+    #
+    # features = get_windows_console_features()
+    # from rich import print
+    #
+    # print(f'platform="{platform.system()}"')
+    # print(repr(features))
 
-    features = get_windows_console_features()
-    from rich import print
+    import subprocess
+    import sys
 
-    print(f'platform="{platform.system()}"')
-    print(repr(features))
+    code = """import sys
+from rich.console import Console
+
+console = Console(file=sys.stdout)
+console.print("spam")
+    """
+    err_code = code.replace("sys.stdout", "sys.stderr")
+    cmd = [sys.executable, "-"]
+
+    print("[capture_output=True via sys.stdout]")
+    proc = subprocess.run(cmd, input=code, capture_output=True, encoding="utf-8")
+    print(f"{proc.stdout=} {proc.stderr=}")
+
+    print("[capture_output=True via sys.stderr]")
+    proc = subprocess.run(cmd, input=err_code, capture_output=True, encoding="utf-8")
+    print(f"{proc.stdout=} {proc.stderr=}")
+
+    print("[capture_output=False via sys.stdout]")
+    proc = subprocess.run(cmd, input=code, capture_output=False, encoding="utf-8")

--- a/rich/console.py
+++ b/rich/console.py
@@ -1932,7 +1932,10 @@ class Console:
                             from rich._win32_console import LegacyWindowsTerm
                             from rich._windows_renderer import legacy_windows_render
 
-                            legacy_windows_render(self._buffer[:], LegacyWindowsTerm())
+                            with open(file_no, "w") as output_file:
+                                legacy_windows_render(
+                                    self._buffer[:], LegacyWindowsTerm(output_file)
+                                )
 
                         output_capture_enabled = bool(self._buffer_index)
                         if not legacy_windows_stdout or output_capture_enabled:

--- a/tests/test_win32_console.py
+++ b/tests/test_win32_console.py
@@ -166,9 +166,7 @@ if sys.platform == "win32":
     @patch.object(
         _win32_console, "GetConsoleScreenBufferInfo", return_value=StubScreenBufferInfo
     )
-    def test_write_styled_no_background_color(
-        _, SetConsoleTextAttribute, __, win32_handle
-    ):
+    def test_write_styled_no_background_color(_, SetConsoleTextAttribute, win32_handle):
         style = Style.parse("blue")
         text = "Hello, world!"
         term = LegacyWindowsTerm(sys.stdout)

--- a/tests/test_win32_console.py
+++ b/tests/test_win32_console.py
@@ -76,7 +76,6 @@ if sys.platform == "win32":
 
         term.write_styled(text, style)
 
-        # Check that we've called the Console API to write the text
         captured = capsys.readouterr()
         assert captured.out == text
 
@@ -91,12 +90,11 @@ if sys.platform == "win32":
         assert second_args == (win32_handle,)
         assert second_kwargs["attributes"] == DEFAULT_STYLE_ATTRIBUTE
 
-    @patch.object(_win32_console, "WriteConsole", return_value=True)
     @patch.object(_win32_console, "SetConsoleTextAttribute")
     @patch.object(
         _win32_console, "GetConsoleScreenBufferInfo", return_value=StubScreenBufferInfo
     )
-    def test_write_styled_bold(_, SetConsoleTextAttribute, __, win32_handle):
+    def test_write_styled_bold(_, SetConsoleTextAttribute, win32_handle):
         style = Style.parse("bold black on red")
         text = "Hello, world!"
         term = LegacyWindowsTerm(sys.stdout)
@@ -110,12 +108,11 @@ if sys.platform == "win32":
         assert first_args == (win32_handle,)
         assert first_kwargs["attributes"].value == expected_attr
 
-    @patch.object(_win32_console, "WriteConsole", return_value=True)
     @patch.object(_win32_console, "SetConsoleTextAttribute")
     @patch.object(
         _win32_console, "GetConsoleScreenBufferInfo", return_value=StubScreenBufferInfo
     )
-    def test_write_styled_reverse(_, SetConsoleTextAttribute, __, win32_handle):
+    def test_write_styled_reverse(_, SetConsoleTextAttribute, win32_handle):
         style = Style.parse("reverse red on blue")
         text = "Hello, world!"
         term = LegacyWindowsTerm(sys.stdout)
@@ -129,12 +126,11 @@ if sys.platform == "win32":
         assert first_args == (win32_handle,)
         assert first_kwargs["attributes"].value == expected_attr
 
-    @patch.object(_win32_console, "WriteConsole", return_value=True)
     @patch.object(_win32_console, "SetConsoleTextAttribute")
     @patch.object(
         _win32_console, "GetConsoleScreenBufferInfo", return_value=StubScreenBufferInfo
     )
-    def test_write_styled_reverse(_, SetConsoleTextAttribute, __, win32_handle):
+    def test_write_styled_reverse(_, SetConsoleTextAttribute, win32_handle):
         style = Style.parse("dim bright_red on blue")
         text = "Hello, world!"
         term = LegacyWindowsTerm(sys.stdout)
@@ -148,14 +144,11 @@ if sys.platform == "win32":
         assert first_args == (win32_handle,)
         assert first_kwargs["attributes"].value == expected_attr
 
-    @patch.object(_win32_console, "WriteConsole", return_value=True)
     @patch.object(_win32_console, "SetConsoleTextAttribute")
     @patch.object(
         _win32_console, "GetConsoleScreenBufferInfo", return_value=StubScreenBufferInfo
     )
-    def test_write_styled_no_foreground_color(
-        _, SetConsoleTextAttribute, __, win32_handle
-    ):
+    def test_write_styled_no_foreground_color(_, SetConsoleTextAttribute, win32_handle):
         style = Style.parse("on blue")
         text = "Hello, world!"
         term = LegacyWindowsTerm(sys.stdout)
@@ -169,7 +162,6 @@ if sys.platform == "win32":
         assert first_args == (win32_handle,)
         assert first_kwargs["attributes"].value == expected_attr
 
-    @patch.object(_win32_console, "WriteConsole", return_value=True)
     @patch.object(_win32_console, "SetConsoleTextAttribute")
     @patch.object(
         _win32_console, "GetConsoleScreenBufferInfo", return_value=StubScreenBufferInfo


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes #2053 

Moves from Windows Console API for writing to stdout, to using stdout.write.

Also opens stdout directly as requested to avoid issues with wrapped file objects passed into Console.
