### PR TITLE
Use `reversed` instead of `[::-1]` to reverse in chop_cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve performance of cell_length https://github.com/Textualize/rich/pull/2061
+- Improve performance of chop_cells https://github.com/Textualize/rich/pull/2077
 
 ## [12.0.1] - 2022-03-14
 

--- a/rich/cells.py
+++ b/rich/cells.py
@@ -113,14 +113,12 @@ def chop_cells(text: str, max_size: int, position: int = 0) -> List[str]:
     _get_character_cell_size = get_character_cell_size
     characters = [
         (character, _get_character_cell_size(character)) for character in text
-    ][::-1]
+    ]
     total_size = position
     lines: List[List[str]] = [[]]
     append = lines[-1].append
 
-    pop = characters.pop
-    while characters:
-        character, size = pop()
+    for character, size in reversed(characters):
         if total_size + size > max_size:
             lines.append([character])
             append = lines[-1].append
@@ -128,6 +126,7 @@ def chop_cells(text: str, max_size: int, position: int = 0) -> List[str]:
         else:
             total_size += size
             append(character)
+
     return ["".join(line) for line in lines]
 
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Use `reversed` instead of `[::-1]` to reverse in chop_cells