### PR TITLE
refactor: remove mypy generics workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ include = ["rich/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.6.2"
-typing-extensions = { version = ">=3.7.4, <5.0", python = "<3.8" }
+typing-extensions = { version = ">=3.7.4, <5.0", python = "<3.9" }
 dataclasses = { version = ">=0.7,<0.9", python = "<3.7" }
 pygments = "^2.6.0"
 commonmark = "^0.9.0"

--- a/rich/_lru_cache.py
+++ b/rich/_lru_cache.py
@@ -1,12 +1,16 @@
-from collections import OrderedDict
-from typing import Dict, Generic, TypeVar
-
+from typing import Dict, Generic, TypeVar, TYPE_CHECKING
+import sys
 
 CacheKey = TypeVar("CacheKey")
 CacheValue = TypeVar("CacheValue")
 
+if sys.version_info < (3, 9):
+    from typing_extensions import OrderedDict
+else:
+    from collections import OrderedDict
 
-class LRUCache(Generic[CacheKey, CacheValue], OrderedDict):  # type: ignore # https://github.com/python/mypy/issues/6904
+
+class LRUCache(OrderedDict[CacheKey, CacheValue]):
     """
     A dictionary-like container that stores a given maximum items.
 
@@ -17,18 +21,18 @@ class LRUCache(Generic[CacheKey, CacheValue], OrderedDict):  # type: ignore # ht
 
     def __init__(self, cache_size: int) -> None:
         self.cache_size = cache_size
-        super(LRUCache, self).__init__()
+        super().__init__()
 
     def __setitem__(self, key: CacheKey, value: CacheValue) -> None:
         """Store a new views, potentially discarding an old value."""
         if key not in self:
             if len(self) >= self.cache_size:
                 self.popitem(last=False)
-        OrderedDict.__setitem__(self, key, value)
+        super().__setitem__(key, value)
 
-    def __getitem__(self: Dict[CacheKey, CacheValue], key: CacheKey) -> CacheValue:
+    def __getitem__(self, key: CacheKey) -> CacheValue:
         """Gets the item, but also makes it most recent."""
-        value: CacheValue = OrderedDict.__getitem__(self, key)
-        OrderedDict.__delitem__(self, key)
-        OrderedDict.__setitem__(self, key, value)
+        value: CacheValue = super().__getitem__(key)
+        super().__delitem__(key)
+        super().__setitem__(key, value)
         return value


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Refactor to remove the workaround for https://github.com/python/mypy/issues/6904 - you can use `typing_extensions.OrderedDict` here on 3.6-3.8 (naturally supported 3.9+) and avoid the multiple inheritance & type ignore. From #2084.