### PR TITLE
Add missing `end` keyword argument to `Text.from_markup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Add missing `end` keyword argument to `Text.from_markup`
+
 ## [12.0.1] - 2022-03-22
 
 ### Changed

--- a/rich/text.py
+++ b/rich/text.py
@@ -253,6 +253,7 @@ class Text(JupyterMixin):
         emoji_variant: Optional[EmojiVariant] = None,
         justify: Optional["JustifyMethod"] = None,
         overflow: Optional["OverflowMethod"] = None,
+        end: str = "\n",
     ) -> "Text":
         """Create Text instance from markup.
 
@@ -261,6 +262,7 @@ class Text(JupyterMixin):
             emoji (bool, optional): Also render emoji code. Defaults to True.
             justify (str, optional): Justify method: "left", "center", "full", "right". Defaults to None.
             overflow (str, optional): Overflow method: "crop", "fold", "ellipsis". Defaults to None.
+            end (str, optional): Character to end text with. Defaults to "\\\\n".
 
         Returns:
             Text: A Text instance with markup rendered.
@@ -270,6 +272,7 @@ class Text(JupyterMixin):
         rendered_text = render(text, style, emoji=emoji, emoji_variant=emoji_variant)
         rendered_text.justify = justify
         rendered_text.overflow = overflow
+        rendered_text.end = end
         return rendered_text
 
     @classmethod

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -297,11 +297,13 @@ def test_append_text():
     assert str(test) == "foobar"
     assert test._spans == [Span(3, 6, "bold")]
 
+
 def test_end():
     console = Console(width=20, file=StringIO())
     test = Group(Text.from_markup("foo", end=" "), Text.from_markup("bar"))
     console.print(test)
-    assert console.file.getvalue()  == "foo bar\n"
+    assert console.file.getvalue() == "foo bar\n"
+
 
 def test_split():
     test = Text()

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,7 +1,7 @@
 from io import StringIO
 import pytest
 
-from rich.console import Console
+from rich.console import Console, Group
 from rich.text import Span, Text
 from rich.measure import Measurement
 from rich.style import Style
@@ -297,6 +297,11 @@ def test_append_text():
     assert str(test) == "foobar"
     assert test._spans == [Span(3, 6, "bold")]
 
+def test_end():
+    console = Console(width=20, file=StringIO())
+    test = Group(Text.from_markup("foo", end=" "), Text.from_markup("bar"))
+    console.print(test)
+    assert console.file.getvalue()  == "foo bar\n"
 
 def test_split():
     test = Text()


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes https://github.com/Textualize/rich/issues/2054
