### PR TITLE
fix: keep pycln from removing load_ipython_extension

### DIFF
--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -3,7 +3,7 @@
 import os
 from typing import Callable, IO, TYPE_CHECKING, Any, Optional, Union
 
-from ._extension import load_ipython_extension
+from ._extension import load_ipython_extension  # noqa: F401
 
 __all__ = ["get_console", "reconfigure", "print", "inspect"]
 

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -5,7 +5,7 @@ import platform
 import sys
 from dataclasses import dataclass, field
 from traceback import walk_tb
-from types import FrameType, ModuleType, TracebackType
+from types import ModuleType, TracebackType
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Type, Union
 
 from pygments.lexers import guess_lexer_for_filename


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixing over-cleaning from https://github.com/Textualize/rich/pull/2001. This is an intentional unused import, so using the appropriate noqa. Reran pycln to ensure it is working.

See https://github.com/Textualize/rich/pull/2001#issuecomment-1079102117
