### PR TITLE
Allow default Console parameters to be configured with environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing `end` keyword argument to `Text.from_markup`
 - Fixed issue with decoding ANSI reset https://github.com/Textualize/rich/issues/2112
 
+### Added
+
+- Allow the default values for `Console` prameters `force_jupyter`, `force_terminal` & `force_interactive` to be set using environment variables
+
 ## [12.0.1] - 2022-03-22
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@ The following people have contributed to the development of Rich:
 - [Oleksis Fraga](https://github.com/oleksis)
 - [Michał Górny](https://github.com/mgorny)
 - [Leron Gray](https://github.com/daddycocoaman)
+- [Josiah Outram Halstead](https://github.com/joouha)
 - [Kenneth Hoste](https://github.com/boegel)
 - [Finn Hughes](https://github.com/finnhughes)
 - [Josh Karpel](https://github.com/JoshKarpel)

--- a/rich/console.py
+++ b/rich/console.py
@@ -5,6 +5,7 @@ import platform
 import sys
 import threading
 from abc import ABC, abstractmethod
+from ast import literal_eval
 from dataclasses import dataclass, field
 from datetime import datetime
 from functools import wraps
@@ -670,7 +671,12 @@ class Console:
         if _environ is not None:
             self._environ = _environ
 
+        if force_jupyter is None:
+            env_var = self._environ.get("RICH_FORCE_JUPYTER")
+            if env_var is not None:
+                force_jupyter = env_var.strip().lower() == "true"
         self.is_jupyter = _is_jupyter() if force_jupyter is None else force_jupyter
+
         if self.is_jupyter:
             width = width or 93
             height = height or 100
@@ -703,7 +709,12 @@ class Console:
         self._height = height
 
         self._color_system: Optional[ColorSystem]
+        if force_terminal is None:
+            env_var = self._environ.get("RICH_FORCE_TERMINAL")
+            if env_var is not None:
+                force_terminal = env_var.strip().lower() == "true"
         self._force_terminal = force_terminal
+
         self._file = file
         self.quiet = quiet
         self.stderr = stderr
@@ -729,6 +740,10 @@ class Console:
         self.no_color = (
             no_color if no_color is not None else "NO_COLOR" in self._environ
         )
+        if force_interactive is None:
+            env_var = self._environ.get("RICH_FORCE_INTERACTIVE")
+            if env_var is not None:
+                force_interactive = env_var.strip().lower() == "true"
         self.is_interactive = (
             (self.is_terminal and not self.is_dumb_terminal)
             if force_interactive is None

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -658,6 +658,41 @@ def test_lines_env():
     console = Console(width=40, _environ={"LINES": "broken"})
 
 
+def test_options_default_env_overrides(monkeypatch):
+    import rich.console
+
+    def _mock_is_jupyter():
+        return True
+
+    def _mock_isnt_jupyter():
+        return True
+
+    mock_file = io.StringIO()
+
+    def _mock_isatty():
+        return True
+
+    monkeypatch.setattr(rich.console, "_is_jupyter", _mock_isnt_jupyter)
+    console = Console(_environ={"RICH_FORCE_JUPYTER": "True"})
+    assert console.is_jupyter == True
+
+    monkeypatch.setattr(rich.console, "_is_jupyter", _mock_is_jupyter)
+    console = Console(_environ={"RICH_FORCE_JUPYTER": "False"})
+    assert console.is_jupyter == False
+
+    console = Console(_environ={"RICH_FORCE_TERMINAL": "True"})
+    assert console._force_terminal == True
+    console = Console(_environ={"RICH_FORCE_TERMINAL": "False"})
+    assert console._force_terminal == False
+
+    console = Console(file=mock_file, _environ={"RICH_FORCE_INTERACTIVE": "True"})
+    assert console.is_interactive == True
+
+    mock_file.isatty = _mock_isatty
+    console = Console(file=mock_file, _environ={"RICH_FORCE_INTERACTIVE": "False"})
+    assert console.is_interactive == False
+
+
 def test_screen_update_class():
     screen_update = ScreenUpdate([[Segment("foo")], [Segment("bar")]], 5, 10)
     assert screen_update.x == 5


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This allows the default values of the `Console` parameters `force_jupyter`, `force_terminal` & `force_interactive` to be overridden by setting the environment variables `RICH_FORCE_JUPYTER`, `RICH_FORCE_TERMINAL` & `RICH_FORCE_INTERACTIVE`.

Fixes issue #2119 
