### PR TITLE
chore(types): include error code on type ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ files = ["rich"]
 warn_unused_configs = true
 show_error_codes = true
 strict = true
+enable_error_code = ["ignore-without-code"]
 
 [[tool.mypy.overrides]]
 module = ["pygments.*", "IPython.*", "commonmark.*", "ipywidgets.*"]

--- a/rich/color.py
+++ b/rich/color.py
@@ -607,7 +607,7 @@ if __name__ == "__main__":  # pragma: no cover
         if color_number < 16:
             table.add_row(color_cell, f"{color_number}", Text(f'"{name}"'))
         else:
-            color = EIGHT_BIT_PALETTE[color_number]  # type: ignore
+            color = EIGHT_BIT_PALETTE[color_number]  # type: ignore[has-type]
             table.add_row(
                 color_cell, str(color_number), Text(f'"{name}"'), color.hex, color.rgb
             )

--- a/rich/console.py
+++ b/rich/console.py
@@ -524,10 +524,10 @@ def group(fit: bool = True) -> Callable[..., Callable[..., Group]]:
 def _is_jupyter() -> bool:  # pragma: no cover
     """Check if we're running in a Jupyter notebook."""
     try:
-        get_ipython  # type: ignore
+        get_ipython  # type: ignore[name-defined]
     except NameError:
         return False
-    ipython = get_ipython()  # type: ignore
+    ipython = get_ipython()  # type: ignore[name-defined]
     shell = ipython.__class__.__name__
     if "google.colab" in str(ipython.__class__) or shell == "ZMQInteractiveShell":
         return True  # Jupyter notebook or qtconsole
@@ -1249,7 +1249,7 @@ class Console:
 
         renderable = rich_cast(renderable)
         if hasattr(renderable, "__rich_console__") and not isclass(renderable):
-            render_iterable = renderable.__rich_console__(self, _options)  # type: ignore
+            render_iterable = renderable.__rich_console__(self, _options)  # type: ignore[union-attr]
         elif isinstance(renderable, str):
             text_renderable = self.render_str(
                 renderable, highlight=_options.highlight, markup=_options.markup

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -29,7 +29,7 @@ from rich.repr import RichReprResult
 try:
     import attr as _attr_module
 except ImportError:  # pragma: no cover
-    _attr_module = None  # type: ignore
+    _attr_module = None  # type: ignore[assignment]
 
 from . import get_console
 from ._loop import loop_last
@@ -207,7 +207,7 @@ def install(
         """Replacement sys.displayhook which prettifies objects with Rich."""
         if value is not None:
             assert console is not None
-            builtins._ = None  # type: ignore
+            builtins._ = None  # type: ignore[attr-defined]
             console.print(
                 value
                 if _safe_isinstance(value, RichRenderable)
@@ -221,13 +221,13 @@ def install(
                 ),
                 crop=crop,
             )
-            builtins._ = value  # type: ignore
+            builtins._ = value  # type: ignore[attr-defined]
 
     try:  # pragma: no cover
-        ip = get_ipython()  # type: ignore
+        ip = get_ipython()  # type: ignore[name-defined]
         from IPython.core.formatters import BaseFormatter
 
-        class RichFormatter(BaseFormatter):  # type: ignore
+        class RichFormatter(BaseFormatter):  # type: ignore[misc]
             pprint: bool = True
 
             def __call__(self, value: Any) -> Any:
@@ -984,7 +984,7 @@ if __name__ == "__main__":  # pragma: no cover
         ),
         "Broken": BrokenRepr(),
     }
-    data["foo"].append(data)  # type: ignore
+    data["foo"].append(data)  # type: ignore[attr-defined]
 
     from rich import print
 

--- a/rich/repr.py
+++ b/rich/repr.py
@@ -48,8 +48,8 @@ def auto(
             repr_str: List[str] = []
             append = repr_str.append
 
-            angular: bool = getattr(self.__rich_repr__, "angular", False)  # type: ignore
-            for arg in self.__rich_repr__():  # type: ignore
+            angular: bool = getattr(self.__rich_repr__, "angular", False)  # type: ignore[attr-defined]
+            for arg in self.__rich_repr__():  # type: ignore[attr-defined]
                 if isinstance(arg, tuple):
                     if len(arg) == 1:
                         append(repr(arg[0]))
@@ -90,12 +90,12 @@ def auto(
 
         if not hasattr(cls, "__rich_repr__"):
             auto_rich_repr.__doc__ = "Build a rich repr"
-            cls.__rich_repr__ = auto_rich_repr  # type: ignore
+            cls.__rich_repr__ = auto_rich_repr  # type: ignore[attr-defined]
 
         auto_repr.__doc__ = "Return repr(self)"
-        cls.__repr__ = auto_repr  # type: ignore
+        cls.__repr__ = auto_repr  # type: ignore[assignment]
         if angular is not None:
-            cls.__rich_repr__.angular = angular  # type: ignore
+            cls.__rich_repr__.angular = angular  # type: ignore[attr-defined]
         return cls
 
     if cls is None:
@@ -144,7 +144,7 @@ if __name__ == "__main__":
     console.print(foo, width=30)
 
     console.rule("Angular repr")
-    Foo.__rich_repr__.angular = True  # type: ignore
+    Foo.__rich_repr__.angular = True  # type: ignore[attr-defined]
 
     console.print(foo)
 

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -130,7 +130,7 @@ def install(
 
     try:  # pragma: no cover
         # if within ipython, use customized traceback
-        ip = get_ipython()  # type: ignore
+        ip = get_ipython()  # type: ignore[name-defined]
         ipy_excepthook_closure(ip)
         return sys.excepthook
     except Exception:
@@ -669,7 +669,7 @@ if __name__ == "__main__":  # pragma: no cover
             try:
                 foo(0)
             except:
-                slfkjsldkfj  # type: ignore
+                slfkjsldkfj  # type: ignore[name-defined]
         except:
             console.print_exception(show_locals=True)
 


### PR DESCRIPTION
Signed-off-by: Henry Schreiner <henryschreineriii@gmail.com>

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This adds type ignore codes to all type ignores, and activates the (new in MyPy
0.94x) feature to verify that all type ignores have error codes. Unlike
previous methods of requiring error codes (like pre-commit's pygrep hook), mypy
will actually tell you what the correct error code is in the error message,
which is quite nice for adding them.

Having the error codes improves the readability, since you get a hint as to why
the type ignore is there (actual human readable hint, unlike flake8's numeric
codes), and it also keeps one type ignore from hiding another problem. This was
used in the last few PRs to see type ignores that were pretty easy to work
around.
