### PR TITLE
fix(types): typing fixes exposed by extra checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,10 +54,9 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 files = ["rich"]
-warn_unused_configs = true
 show_error_codes = true
 strict = true
-enable_error_code = ["ignore-without-code"]
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 
 [[tool.mypy.overrides]]
 module = ["pygments.*", "IPython.*", "commonmark.*", "ipywidgets.*"]

--- a/rich/console.py
+++ b/rich/console.py
@@ -1947,7 +1947,7 @@ class Console:
         frame = currentframe()
         if frame is not None:
             # Use the faster currentframe where implemented
-            while offset and frame:
+            while offset and frame is not None:
                 frame = frame.f_back
                 offset -= 1
             assert frame is not None

--- a/rich/jupyter.py
+++ b/rich/jupyter.py
@@ -1,4 +1,7 @@
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, TYPE_CHECKING, Sequence
+
+if TYPE_CHECKING:
+    from rich.console import ConsoleRenderable
 
 from . import get_console
 from .segment import Segment
@@ -20,7 +23,7 @@ class JupyterRenderable:
         self.text = text
 
     def _repr_mimebundle_(
-        self, include: Iterable[str], exclude: Iterable[str], **kwargs: Any
+        self, include: Sequence[str], exclude: Sequence[str], **kwargs: Any
     ) -> Dict[str, str]:
         data = {"text/plain": self.text, "text/html": self.html}
         if include:
@@ -37,8 +40,8 @@ class JupyterMixin:
 
     def _repr_mimebundle_(
         self: "ConsoleRenderable",
-        include: Iterable[str],
-        exclude: Iterable[str],
+        include: Sequence[str],
+        exclude: Sequence[str],
         **kwargs: Any,
     ) -> Dict[str, str]:
         console = get_console()

--- a/rich/measure.py
+++ b/rich/measure.py
@@ -1,5 +1,5 @@
 from operator import itemgetter
-from typing import TYPE_CHECKING, Callable, Iterable, NamedTuple, Optional
+from typing import TYPE_CHECKING, Callable, NamedTuple, Optional, Sequence
 
 from . import errors
 from .protocol import is_renderable, rich_cast
@@ -125,7 +125,7 @@ class Measurement(NamedTuple):
 def measure_renderables(
     console: "Console",
     options: "ConsoleOptions",
-    renderables: Iterable["RenderableType"],
+    renderables: Sequence["RenderableType"],
 ) -> "Measurement":
     """Get a measurement that would fit a number of renderables.
 

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -19,6 +19,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Union,
@@ -28,8 +29,10 @@ from rich.repr import RichReprResult
 
 try:
     import attr as _attr_module
+
+    _has_attrs = True
 except ImportError:  # pragma: no cover
-    _attr_module = None  # type: ignore[assignment]
+    _has_attrs = False
 
 from . import get_console
 from ._loop import loop_last
@@ -54,12 +57,12 @@ if TYPE_CHECKING:
 
 def _is_attr_object(obj: Any) -> bool:
     """Check if an object was created with attrs module."""
-    return _attr_module is not None and _attr_module.has(type(obj))
+    return _has_attrs and _attr_module.has(type(obj))
 
 
-def _get_attr_fields(obj: Any) -> Iterable["_attr_module.Attribute[Any]"]:
+def _get_attr_fields(obj: Any) -> Sequence["_attr_module.Attribute[Any]"]:
     """Get fields for an attrs object."""
-    return _attr_module.fields(type(obj)) if _attr_module is not None else []
+    return _attr_module.fields(type(obj)) if _has_attrs else []
 
 
 def _is_dataclass_repr(obj: object) -> bool:

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -643,9 +643,7 @@ class Progress(JupyterMixin):
         disable: bool = False,
         expand: bool = False,
     ) -> None:
-        assert (
-            refresh_per_second is None or refresh_per_second > 0
-        ), "refresh_per_second must be > 0"
+        assert refresh_per_second > 0, "refresh_per_second must be > 0"
         self._lock = RLock()
         self.columns = columns or self.get_default_columns()
         self.speed_estimate_period = speed_estimate_period

--- a/rich/spinner.py
+++ b/rich/spinner.py
@@ -79,7 +79,8 @@ class Spinner:
             self.speed = self._update_speed
             self._update_speed = 0.0
 
-        if not self.text:
+        # This normally can't be str, unless someone assigned it later.
+        if not self.text:  # type: ignore[truthy-bool]
             return frame
         elif isinstance(self.text, (str, Text)):
             return Text.assemble(frame, " ", self.text)

--- a/rich/spinner.py
+++ b/rich/spinner.py
@@ -1,4 +1,4 @@
-from typing import cast, List, Optional, TYPE_CHECKING
+from typing import cast, List, Optional, TYPE_CHECKING, Union
 
 from ._spinners import SPINNERS
 from .measure import Measurement
@@ -34,7 +34,9 @@ class Spinner:
             spinner = SPINNERS[name]
         except KeyError:
             raise KeyError(f"no spinner called {name!r}")
-        self.text = Text.from_markup(text) if isinstance(text, str) else text
+        self.text: "Union[RenderableType, Text]" = (
+            Text.from_markup(text) if isinstance(text, str) else text
+        )
         self.frames = cast(List[str], spinner["frames"])[:]
         self.interval = cast(float, spinner["interval"])
         self.start_time: Optional[float] = None
@@ -79,8 +81,7 @@ class Spinner:
             self.speed = self._update_speed
             self._update_speed = 0.0
 
-        # This normally can't be str, unless someone assigned it later.
-        if not self.text:  # type: ignore[truthy-bool]
+        if not self.text:
             return frame
         elif isinstance(self.text, (str, Text)):
             return Text.assemble(frame, " ", self.text)

--- a/rich/style.py
+++ b/rich/style.py
@@ -740,7 +740,7 @@ class Style:
         new_style._link = style._link or self._link
         new_style._link_id = style._link_id or self._link_id
         new_style._hash = style._hash
-        new_style._null = self._null or style._null
+        new_style._null = style._null
         if self._meta and style._meta:
             new_style._meta = dumps({**self.meta, **style.meta})
         else:

--- a/rich/tree.py
+++ b/rich/tree.py
@@ -45,7 +45,7 @@ class Tree(JupyterMixin):
         style: Optional[StyleType] = None,
         guide_style: Optional[StyleType] = None,
         expanded: bool = True,
-        highlight: bool = False,
+        highlight: Optional[bool] = False,
     ) -> "Tree":
         """Add a child tree.
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This enables a few extra mypy checks, and fixes type bugs exposed by those. There were three features enabled, but I've left one off: `warn_unrachable = true`. While it is really useful, and helped expose a couple of the issues fixed here, it also requires type ignoring in about 5-7 places unavoidably, so I've left it off. The most irritating one is `if sys.platform.startswith("win")` constructs, which it will notice are unreachable if you are typing targeting a different platform. MyPy might fix this in https://github.com/python/mypy/issues/12286, which would run all platforms/versions in parallel and then combine the results (which would be really fantastic!), but until then, it's likely better just to manually add `--warn-unreachable` once in a while and make sure the errors reported are expected. (Depending on your preference, of course - I've been turning it on mostly, but I usually don't have quite as many ignores due to it - I thik I counted at least 7 here. If you want to see it, let me know, and I'll PR it).

I'll comment inline on the others, but this is one fix:

```python
x: Iterable[Any] = ...
len(x)
```

is invalid. You can't take the length of an iterator. Someone could correctly put an iterator function in here, and this will break. Either this should be `Sequence` (which is what I've used here), or you should iterate over the iterator and build a sequence like a list or a tuple and then use that.


