### PR TITLE
Fall back to `sys.__stderr__` on non-Windows OS to get size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fall back to `sys.__stderr__` on POSIX systems when trying to get the terminal size (fix issues when Rich is piped to another process)
+
 ## [12.2.0] - 2022-04-05
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,6 +27,7 @@ The following people have contributed to the development of Rich:
 - [Nathan Page](https://github.com/nathanrpage97)
 - [Avi Perl](https://github.com/avi-perl)
 - [Laurent Peuch](https://github.com/psycojoker)
+- [Olivier Philippon](https://github.com/DrBenton)
 - [Kylian Point](https://github.com/p0lux)
 - [Kyle Pollina](https://github.com/kylepollina)
 - [Clément Robert](https://github.com/neutrinoceros)

--- a/rich/console.py
+++ b/rich/console.py
@@ -1102,12 +1102,16 @@ class Console:
             except OSError:  # Probably not a terminal
                 pass
         else:
-            try:
-                width, height = os.get_terminal_size(sys.__stdin__.fileno())
-            except (AttributeError, ValueError, OSError):
+            posix_std_descriptors = (
+                sys.__stdin__,  # try this one first...
+                sys.__stdout__,  # ...then that one...
+                sys.__stderr__,  # ...and ultimately try to fall back to this one
+            )
+            for descriptor in posix_std_descriptors:
                 try:
-                    width, height = os.get_terminal_size(sys.__stdout__.fileno())
-                except (AttributeError, ValueError, OSError):
+                    width, height = os.get_terminal_size(descriptor.fileno())
+                    break
+                except (AttributeError, ValueError, OSError) as err:
                     pass
 
         columns = self._environ.get("COLUMNS")

--- a/rich/console.py
+++ b/rich/console.py
@@ -1109,9 +1109,10 @@ class Console:
             for file_descriptor in _STD_STREAMS:
                 try:
                     width, height = os.get_terminal_size(file_descriptor)
-                    break
                 except (AttributeError, ValueError, OSError):
                     pass
+                else:
+                    break
 
         columns = self._environ.get("COLUMNS")
         if columns is not None and columns.isdigit():


### PR DESCRIPTION
This fixes the "pipe" bug, where we could not determine the available size correctly when the output of Rich is piped to another process

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review. :sweat_smile: 

## Description

This should (:crossed_fingers:) fix this bug: https://github.com/Textualize/rich/issues/2154
