### PR TITLE
[progress] The `total` we pass to a Progress renderable can now be `None`

### DIFF
--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -91,7 +91,7 @@ Transient progress displays are useful if you want more minimal output in the te
 Indeterminate progress
 ~~~~~~~~~~~~~~~~~~~~~~
 
-When you add a task it is automatically *started*, which means it will show a progress bar at 0% and the time remaining will be calculated from the current time. This may not work well if there is a long delay before you can start updating progress; you may need to wait for a response from a server or count files in a directory (for example). In these cases you can call :meth:`~rich.progress.Progress.add_task` with ``start=False`` which will display a pulsing animation that lets the user know something is working. This is know as an *indeterminate* progress bar. When you have the number of steps you can call :meth:`~rich.progress.Progress.start_task` which will display the progress bar at 0%, then :meth:`~rich.progress.Progress.update` as normal.
+When you add a task it is automatically *started*, which means it will show a progress bar at 0% and the time remaining will be calculated from the current time. This may not work well if there is a long delay before you can start updating progress; you may need to wait for a response from a server or count files in a directory (for example). In these cases you can call :meth:`~rich.progress.Progress.add_task` with ``start=False`` or ``total=None`` which will display a pulsing animation that lets the user know something is working. This is know as an *indeterminate* progress bar. When you have the number of steps you can call :meth:`~rich.progress.Progress.start_task` which will display the progress bar at 0%, then :meth:`~rich.progress.Progress.update` as normal.
 
 Auto refresh
 ~~~~~~~~~~~~

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -949,7 +949,7 @@ class Task:
         if not speed:
             return None
         remaining = self.remaining
-        if not remaining:
+        if remaining is None:
             return None
         estimate = ceil(remaining / speed)
         return estimate

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -40,7 +40,7 @@ else:
     from typing_extensions import Literal  # pragma: no cover
 
 from . import filesize, get_console
-from .console import Console, JustifyMethod, RenderableType, Group
+from .console import Console, Group, JustifyMethod, RenderableType
 from .highlighter import Highlighter
 from .jupyter import JupyterMixin
 from .live import Live
@@ -651,7 +651,7 @@ class BarColumn(ProgressColumn):
     def render(self, task: "Task") -> ProgressBar:
         """Gets a progress bar widget for a task."""
         return ProgressBar(
-            total=max(0, task.total),
+            total=max(0, task.total) if task.total is not None else None,
             completed=max(0, task.completed),
             width=None if self.bar_width is None else max(1, self.bar_width),
             pulse=not task.started,
@@ -734,7 +734,7 @@ class TotalFileSizeColumn(ProgressColumn):
 
     def render(self, task: "Task") -> Text:
         """Show data completed."""
-        data_size = filesize.decimal(int(task.total))
+        data_size = filesize.decimal(int(task.total)) if task.total is not None else ""
         return Text(data_size, style="progress.filesize.total")
 
 
@@ -757,7 +757,7 @@ class MofNCompleteColumn(ProgressColumn):
     def render(self, task: "Task") -> Text:
         """Show completed/total."""
         completed = int(task.completed)
-        total = int(task.total)
+        total = int(task.total) if task.total is not None else "?"
         total_width = len(str(total))
         return Text(
             f"{completed:{total_width}d}{self.separator}{total}",
@@ -781,24 +781,34 @@ class DownloadColumn(ProgressColumn):
     def render(self, task: "Task") -> Text:
         """Calculate common unit for completed and total."""
         completed = int(task.completed)
-        total = int(task.total)
+
+        unit_and_suffix_calculation_base = (
+            int(task.total) if task.total is not None else completed
+        )
         if self.binary_units:
             unit, suffix = filesize.pick_unit_and_suffix(
-                total,
+                unit_and_suffix_calculation_base,
                 ["bytes", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"],
                 1024,
             )
         else:
             unit, suffix = filesize.pick_unit_and_suffix(
-                total,
+                unit_and_suffix_calculation_base,
                 ["bytes", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"],
                 1000,
             )
-        completed_ratio = completed / unit
-        total_ratio = total / unit
         precision = 0 if unit == 1 else 1
+
+        completed_ratio = completed / unit
         completed_str = f"{completed_ratio:,.{precision}f}"
-        total_str = f"{total_ratio:,.{precision}f}"
+
+        if task.total is not None:
+            total = int(task.total)
+            total_ratio = total / unit
+            total_str = f"{total_ratio:,.{precision}f}"
+        else:
+            total_str = "?"
+
         download_status = f"{completed_str}/{total_str} {suffix}"
         download_text = Text(download_status, style="progress.download")
         return download_text
@@ -839,8 +849,8 @@ class Task:
     description: str
     """str: Description of the task."""
 
-    total: float
-    """str: Total number of steps in this task."""
+    total: Optional[float]
+    """Optional[float]: Total number of steps in this task."""
 
     completed: float
     """float: Number of steps completed"""
@@ -883,8 +893,10 @@ class Task:
         return self.start_time is not None
 
     @property
-    def remaining(self) -> float:
-        """float: Get the number of steps remaining."""
+    def remaining(self) -> Optional[float]:
+        """Optional[float]: Get the number of steps remaining, if a non-None total was set."""
+        if self.total is None:
+            return None
         return self.total - self.completed
 
     @property
@@ -903,7 +915,7 @@ class Task:
 
     @property
     def percentage(self) -> float:
-        """float: Get progress of task as a percentage."""
+        """float: Get progress of task as a percentage. If a None total was set, returns 0"""
         if not self.total:
             return 0.0
         completed = (self.completed / self.total) * 100.0
@@ -936,7 +948,10 @@ class Task:
         speed = self.speed
         if not speed:
             return None
-        estimate = ceil(self.remaining / speed)
+        remaining = self.remaining
+        if not remaining:
+            return None
+        estimate = ceil(remaining / speed)
         return estimate
 
     def _reset(self) -> None:
@@ -1358,7 +1373,11 @@ class Progress(JupyterMixin):
                 popleft()
             if update_completed > 0:
                 _progress.append(ProgressSample(current_time, update_completed))
-            if task.completed >= task.total and task.finished_time is None:
+            if (
+                task.total is not None
+                and task.completed >= task.total
+                and task.finished_time is None
+            ):
                 task.finished_time = task.elapsed
 
         if refresh:
@@ -1423,7 +1442,11 @@ class Progress(JupyterMixin):
             while len(_progress) > 1000:
                 popleft()
             _progress.append(ProgressSample(current_time, update_completed))
-            if task.completed >= task.total and task.finished_time is None:
+            if (
+                task.total is not None
+                and task.completed >= task.total
+                and task.finished_time is None
+            ):
                 task.finished_time = task.elapsed
                 task.finished_speed = task.speed
 
@@ -1484,7 +1507,7 @@ class Progress(JupyterMixin):
         self,
         description: str,
         start: bool = True,
-        total: float = 100.0,
+        total: Optional[float] = 100.0,
         completed: int = 0,
         visible: bool = True,
         **fields: Any,
@@ -1495,7 +1518,7 @@ class Progress(JupyterMixin):
             description (str): A description of the task.
             start (bool, optional): Start the task immediately (to calculate elapsed time). If set to False,
                 you will need to call `start` manually. Defaults to True.
-            total (float, optional): Number of total steps in the progress if know. Defaults to 100.
+            total (float, optional): Number of total steps in the progress if known. Defaults to 100. Set to None to render a pulsing animation.
             completed (int, optional): Number of steps completed so far.. Defaults to 0.
             visible (bool, optional): Enable display of the task. Defaults to True.
             **fields (str): Additional data fields required for rendering.
@@ -1585,12 +1608,12 @@ if __name__ == "__main__":  # pragma: no coverage
         *Progress.get_default_columns(),
         TimeElapsedColumn(),
         console=console,
-        transient=True,
+        transient=False,
     ) as progress:
 
         task1 = progress.add_task("[red]Downloading", total=1000)
         task2 = progress.add_task("[green]Processing", total=1000)
-        task3 = progress.add_task("[yellow]Thinking", total=1000, start=False)
+        task3 = progress.add_task("[yellow]Thinking", total=None)
 
         while not progress.finished:
             progress.update(task1, advance=0.5)

--- a/rich/progress_bar.py
+++ b/rich/progress_bar.py
@@ -19,10 +19,10 @@ class ProgressBar(JupyterMixin):
     """Renders a (progress) bar. Used by rich.progress.
 
     Args:
-        total (float, optional): Number of steps in the bar. Defaults to 100.
+        total (float, optional): Number of steps in the bar. Defaults to 100. Set to None to render a pulsing animation.
         completed (float, optional): Number of steps completed. Defaults to 0.
         width (int, optional): Width of the bar, or ``None`` for maximum width. Defaults to None.
-        pulse (bool, optional): Enable pulse effect. Defaults to False.
+        pulse (bool, optional): Enable pulse effect. Defaults to False. Will pulse if a None total was passed.
         style (StyleType, optional): Style for the bar background. Defaults to "bar.back".
         complete_style (StyleType, optional): Style for the completed bar. Defaults to "bar.complete".
         finished_style (StyleType, optional): Style for a finished bar. Defaults to "bar.done".
@@ -32,7 +32,7 @@ class ProgressBar(JupyterMixin):
 
     def __init__(
         self,
-        total: float = 100.0,
+        total: Optional[float] = 100.0,
         completed: float = 0,
         width: Optional[int] = None,
         pulse: bool = False,
@@ -58,8 +58,10 @@ class ProgressBar(JupyterMixin):
         return f"<Bar {self.completed!r} of {self.total!r}>"
 
     @property
-    def percentage_completed(self) -> float:
+    def percentage_completed(self) -> Optional[float]:
         """Calculate percentage complete."""
+        if self.total is None:
+            return None
         completed = (self.completed / self.total) * 100.0
         completed = min(100, max(0.0, completed))
         return completed
@@ -157,23 +159,29 @@ class ProgressBar(JupyterMixin):
 
         width = min(self.width or options.max_width, options.max_width)
         ascii = options.legacy_windows or options.ascii_only
-        if self.pulse:
+        should_pulse = self.pulse or self.total is None
+        if should_pulse:
             yield from self._render_pulse(console, width, ascii=ascii)
             return
 
-        completed = min(self.total, max(0, self.completed))
+        completed: Optional[float] = (
+            min(self.total, max(0, self.completed)) if self.total is not None else None
+        )
 
         bar = "-" if ascii else "━"
         half_bar_right = " " if ascii else "╸"
         half_bar_left = " " if ascii else "╺"
         complete_halves = (
-            int(width * 2 * completed / self.total) if self.total else width * 2
+            int(width * 2 * completed / self.total)
+            if self.total and completed is not None
+            else width * 2
         )
         bar_count = complete_halves // 2
         half_bar_count = complete_halves % 2
         style = console.get_style(self.style)
+        is_finished = self.total is None or self.completed >= self.total
         complete_style = console.get_style(
-            self.complete_style if self.completed < self.total else self.finished_style
+            self.finished_style if is_finished else self.complete_style
         )
         _Segment = Segment
         if bar_count:

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -20,6 +20,7 @@ from rich.progress import (
     SpinnerColumn,
     Task,
     TaskID,
+    TaskProgressColumn,
     TextColumn,
     TimeElapsedColumn,
     TimeRemainingColumn,
@@ -103,7 +104,7 @@ def test_time_remaining_column():
     ],
 )
 def test_compact_time_remaining_column(task_time, formatted):
-    task = SimpleNamespace(finished=False, time_remaining=task_time)
+    task = SimpleNamespace(finished=False, time_remaining=task_time, total=100)
     column = TimeRemainingColumn(compact=True)
 
     assert str(column.render(task)) == formatted
@@ -113,7 +114,7 @@ def test_time_remaining_column_elapsed_when_finished():
     task_time = 71
     formatted = "0:01:11"
 
-    task = SimpleNamespace(finished=True, finished_time=task_time)
+    task = SimpleNamespace(finished=True, finished_time=task_time, total=100)
     column = TimeRemainingColumn(elapsed_when_finished=True)
 
     assert str(column.render(task)) == formatted
@@ -398,7 +399,7 @@ def test_using_default_columns() -> None:
     expected_default_types = [
         TextColumn,
         BarColumn,
-        TextColumn,
+        TaskProgressColumn,
         TimeRemainingColumn,
     ]
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -3,33 +3,32 @@
 import io
 import os
 import tempfile
-from time import sleep
 from types import SimpleNamespace
 
 import pytest
 
 import rich.progress
-from rich.progress_bar import ProgressBar
 from rich.console import Console
 from rich.highlighter import NullHighlighter
 from rich.progress import (
     BarColumn,
-    FileSizeColumn,
-    TotalFileSizeColumn,
     DownloadColumn,
-    TransferSpeedColumn,
-    RenderableColumn,
-    SpinnerColumn,
+    FileSizeColumn,
     MofNCompleteColumn,
     Progress,
+    RenderableColumn,
+    SpinnerColumn,
     Task,
+    TaskID,
     TextColumn,
     TimeElapsedColumn,
     TimeRemainingColumn,
-    track,
+    TotalFileSizeColumn,
+    TransferSpeedColumn,
     _TrackThread,
-    TaskID,
+    track,
 )
+from rich.progress_bar import ProgressBar
 from rich.text import Text
 
 
@@ -241,6 +240,31 @@ def test_expand_bar() -> None:
     with progress:
         pass
     expected = "\x1b[?25l\x1b[38;5;237m━━━━━━━━━━\x1b[0m\r\x1b[2K\x1b[38;5;237m━━━━━━━━━━\x1b[0m\n\x1b[?25h"
+    render_result = console.file.getvalue()
+    print("RESULT\n", repr(render_result))
+    print("EXPECTED\n", repr(expected))
+    assert render_result == expected
+
+
+def test_progress_with_none_total_renders_a_pulsing_bar() -> None:
+    console = Console(
+        file=io.StringIO(),
+        force_terminal=True,
+        width=10,
+        color_system="truecolor",
+        legacy_windows=False,
+        _environ={},
+    )
+    progress = Progress(
+        BarColumn(bar_width=None),
+        console=console,
+        get_time=lambda: 1.0,
+        auto_refresh=False,
+    )
+    progress.add_task("foo", total=None)
+    with progress:
+        pass
+    expected = "\x1b[?25l\x1b[38;2;153;48;86m━\x1b[0m\x1b[38;2;183;44;94m━\x1b[0m\x1b[38;2;209;42;102m━\x1b[0m\x1b[38;2;230;39;108m━\x1b[0m\x1b[38;2;244;38;112m━\x1b[0m\x1b[38;2;249;38;114m━\x1b[0m\x1b[38;2;244;38;112m━\x1b[0m\x1b[38;2;230;39;108m━\x1b[0m\x1b[38;2;209;42;102m━\x1b[0m\x1b[38;2;183;44;94m━\x1b[0m\r\x1b[2K\x1b[38;2;153;48;86m━\x1b[0m\x1b[38;2;183;44;94m━\x1b[0m\x1b[38;2;209;42;102m━\x1b[0m\x1b[38;2;230;39;108m━\x1b[0m\x1b[38;2;244;38;112m━\x1b[0m\x1b[38;2;249;38;114m━\x1b[0m\x1b[38;2;244;38;112m━\x1b[0m\x1b[38;2;230;39;108m━\x1b[0m\x1b[38;2;209;42;102m━\x1b[0m\x1b[38;2;183;44;94m━\x1b[0m\n\x1b[?25h"
     render_result = console.file.getvalue()
     print("RESULT\n", repr(render_result))
     print("EXPECTED\n", repr(expected))


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature: https://github.com/Textualize/rich/issues/1054
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

With this PR we now render a "pulse" progress bar when the given `total` is None. 
Which is a new possibility we now have: this parameter used to be a `float`, and is now an `Optional[float]` - so it shouldn't bring any compatibility issues, as the type is just widened to a value that was not accepted according to the documentation, and which would raise exceptions before if it was used?

#### Design considerations

To carry the semantic of _"we don't know the 'total' value for my progress bar"_, instead of `None` we could have used other kinds of values, such as:
 - A negative value, like `total=-1`. The benefit would have been that the signature would still have been `float` , but the drawback is that the meaning of this value is less clear when debugging
 - A sentinel value, such as `total=rich.progress.UNDETERMINED` : probably the most explicit option, but a bit more cumbersome for our users than a good old `None`? :thinking: 

