### PR TITLE
Fix date in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [12.2.0] - 2022-05-05
+## [12.2.0] - 2022-04-05
 
 ### Changed
 


### PR DESCRIPTION
Fix date in CHANGELOG

## Type of changes

- [X] Documentation / docstrings

## Checklist

- [X] I've updated CHANGELOG.md
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixing the date in the CHANGELOG. It's currently April, which is the 4th month. (The incorrect date had month 5, which is May... that's next month.)
