### PR TITLE
[console] namespace SVG elements to avoid conflicts with surrounding HTML page

### DIFF
--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -1,7 +1,7 @@
 """Rich text and beautiful formatting in the terminal."""
 
 import os
-from typing import Callable, IO, TYPE_CHECKING, Any, Optional, Union
+from typing import IO, TYPE_CHECKING, Any, Callable, Optional, Union
 
 from ._extension import load_ipython_extension  # noqa: F401
 
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from .console import Console
 
 # Global console used by alternative print
-_console: Optional["Console"] = None
+_console_default_singleton: Optional["Console"] = None
 
 _IMPORT_CWD = os.path.abspath(os.getcwd())
 
@@ -23,13 +23,13 @@ def get_console() -> "Console":
     Returns:
         Console: A console instance.
     """
-    global _console
-    if _console is None:
+    global _console_default_singleton
+    if _console_default_singleton is None:
         from .console import Console
 
-        _console = Console()
+        _console_default_singleton = Console()
 
-    return _console
+    return _console_default_singleton
 
 
 def reconfigure(*args: Any, **kwargs: Any) -> None:

--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from .console import Console
 
 # Global console used by alternative print
-_console_default_singleton: Optional["Console"] = None
+_console: Optional["Console"] = None
 
 _IMPORT_CWD = os.path.abspath(os.getcwd())
 
@@ -23,13 +23,13 @@ def get_console() -> "Console":
     Returns:
         Console: A console instance.
     """
-    global _console_default_singleton
-    if _console_default_singleton is None:
+    global _console
+    if _console is None:
         from .console import Console
 
-        _console_default_singleton = Console()
+        _console = Console()
 
-    return _console_default_singleton
+    return _console
 
 
 def reconfigure(*args: Any, **kwargs: Any) -> None:

--- a/rich/_console.py
+++ b/rich/_console.py
@@ -1,0 +1,141 @@
+CONSOLE_HTML_FORMAT = """\
+<!DOCTYPE html>
+<head>
+<meta charset="UTF-8">
+<style>
+{stylesheet}
+body {{
+    color: {foreground};
+    background-color: {background};
+}}
+</style>
+</head>
+<html>
+<body>
+    <code>
+        <pre style="font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace">{code}</pre>
+    </code>
+</body>
+</html>
+"""
+
+CONSOLE_SVG_FORMAT = """\
+<svg width="{total_width}" height="{total_height}" viewBox="0 0 {total_width} {total_height}"
+     xmlns="http://www.w3.org/2000/svg">
+    <style>
+        @font-face {{
+            font-family: "{font_family}";
+            src: local("FiraCode-Regular"),
+                 url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                 url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+            font-style: normal;
+            font-weight: 400;
+        }}
+        @font-face {{
+            font-family: "{font_family}";
+            src: local("FiraCode-Bold"),
+                 url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                 url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+            font-style: bold;
+            font-weight: 700;
+        }}
+        #{wrapper_id} span {{
+            display: inline-block;
+            white-space: pre;
+            vertical-align: top;
+            font-size: {font_size}px;
+            font-family:'{font_family}','Cascadia Code',Monaco,Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace;
+        }}
+        #{wrapper_id} a {{
+            text-decoration: none;
+            color: inherit;
+        }}
+        #{wrapper_id} .blink {{
+           animation: {wrapper_id}-blinker 1s infinite;
+        }}
+        @keyframes {wrapper_id}-blinker {{
+            from {{ opacity: 1.0; }}
+            50% {{ opacity: 0.3; }}
+            to {{ opacity: 1.0; }}
+        }}
+        #{wrapper_id} {{
+            padding: {margin}px;
+            padding-top: 100px;
+        }}
+        #{wrapper_id} #terminal {{
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            background-color: {theme_background_color};
+            border-radius: 14px;
+            outline: 1px solid #484848;
+        }}
+        #{wrapper_id} #terminal:after {{
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            content: '';
+            border-radius: 14px;
+            background: rgb(71,77,102);
+            background: linear-gradient(90deg, #804D69 0%, #4E4B89 100%);
+            transform: rotate(-4.5deg);
+            z-index: -1;
+        }}
+        #{wrapper_id} #terminal-header {{
+            position: relative;
+            width: 100%;
+            background-color: #2e2e2e;
+            margin-bottom: 12px;
+            font-weight: bold;
+            border-radius: 14px 14px 0 0;
+            color: {theme_foreground_color};
+            font-size: 18px;
+            box-shadow: inset 0px -1px 0px 0px #4e4e4e,
+                        inset 0px -4px 8px 0px #1a1a1a;
+        }}
+        #{wrapper_id} #terminal-title-tab {{
+            display: inline-block;
+            margin-top: 14px;
+            margin-left: 124px;
+            font-family: sans-serif;
+            padding: 14px 28px;
+            border-radius: 6px 6px 0 0;
+            background-color: {theme_background_color};
+            box-shadow: inset 0px 1px 0px 0px #4e4e4e,
+                        0px -4px 4px 0px #1e1e1e,
+                        inset 1px 0px 0px 0px #4e4e4e,
+                        inset -1px 0px 0px 0px #4e4e4e;
+        }}
+        #{wrapper_id} #terminal-traffic-lights {{
+            position: absolute;
+            top: 24px;
+            left: 20px;
+        }}
+        #{wrapper_id} #terminal-body {{
+            line-height: {line_height}px;
+            padding: 14px;
+        }}
+        {stylesheet}
+    </style>
+    <foreignObject x="0" y="0" width="100%" height="100%">
+        <body xmlns="http://www.w3.org/1999/xhtml">
+            <div id="{wrapper_id}">
+                <div id="terminal">
+                    <div id='terminal-header'>
+                        <svg id="terminal-traffic-lights" width="90" height="21" viewBox="0 0 90 21" xmlns="http://www.w3.org/2000/svg">
+                            <circle cx="14" cy="8" r="8" fill="#ff6159"/>
+                            <circle cx="38" cy="8" r="8" fill="#ffbd2e"/>
+                            <circle cx="62" cy="8" r="8" fill="#28c941"/>
+                        </svg>
+                        <div id="terminal-title-tab">{title}</div>
+                    </div>
+                    <div id='terminal-body'>
+                        {code}
+                    </div>
+                </div>
+            </div>
+        </body>
+    </foreignObject>
+</svg>
+"""

--- a/rich/_console.py
+++ b/rich/_console.py
@@ -1,3 +1,5 @@
+import zlib
+
 CONSOLE_HTML_FORMAT = """\
 <!DOCTYPE html>
 <head>
@@ -139,6 +141,11 @@ CONSOLE_SVG_FORMAT = """\
     </foreignObject>
 </svg>
 """
+
+
+def _svg_hash(svg_main_code: str) -> str:
+    return str(zlib.adler32(svg_main_code.encode()))
+
 
 _SVG_FONT_FAMILY = "Rich Fira Code"
 _SVG_CLASSES_PREFIX = "rich-svg"

--- a/rich/_console.py
+++ b/rich/_console.py
@@ -39,30 +39,30 @@ CONSOLE_SVG_FORMAT = """\
             font-style: bold;
             font-weight: 700;
         }}
-        #{wrapper_id} span {{
+        .{classes_prefix}-terminal-wrapper span {{
             display: inline-block;
             white-space: pre;
             vertical-align: top;
             font-size: {font_size}px;
             font-family:'{font_family}','Cascadia Code',Monaco,Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace;
         }}
-        #{wrapper_id} a {{
+        .{classes_prefix}-terminal-wrapper a {{
             text-decoration: none;
             color: inherit;
         }}
-        #{wrapper_id} .blink {{
-           animation: {wrapper_id}-blinker 1s infinite;
+        .{classes_prefix}-terminal-body .blink {{
+           animation: {classes_prefix}-blinker 1s infinite;
         }}
-        @keyframes {wrapper_id}-blinker {{
+        @keyframes {classes_prefix}-blinker {{
             from {{ opacity: 1.0; }}
             50% {{ opacity: 0.3; }}
             to {{ opacity: 1.0; }}
         }}
-        #{wrapper_id} {{
+        .{classes_prefix}-terminal-wrapper {{
             padding: {margin}px;
             padding-top: 100px;
         }}
-        #{wrapper_id} #terminal {{
+        .{classes_prefix}-terminal {{
             position: relative;
             display: flex;
             flex-direction: column;
@@ -71,7 +71,7 @@ CONSOLE_SVG_FORMAT = """\
             border-radius: 14px;
             outline: 1px solid #484848;
         }}
-        #{wrapper_id} #terminal:after {{
+        .{classes_prefix}-terminal:after {{
             position: absolute;
             width: 100%;
             height: 100%;
@@ -82,7 +82,7 @@ CONSOLE_SVG_FORMAT = """\
             transform: rotate(-4.5deg);
             z-index: -1;
         }}
-        #{wrapper_id} #terminal-header {{
+        .{classes_prefix}-terminal-header {{
             position: relative;
             width: 100%;
             background-color: #2e2e2e;
@@ -94,7 +94,7 @@ CONSOLE_SVG_FORMAT = """\
             box-shadow: inset 0px -1px 0px 0px #4e4e4e,
                         inset 0px -4px 8px 0px #1a1a1a;
         }}
-        #{wrapper_id} #terminal-title-tab {{
+        .{classes_prefix}-terminal-title-tab {{
             display: inline-block;
             margin-top: 14px;
             margin-left: 124px;
@@ -107,12 +107,12 @@ CONSOLE_SVG_FORMAT = """\
                         inset 1px 0px 0px 0px #4e4e4e,
                         inset -1px 0px 0px 0px #4e4e4e;
         }}
-        #{wrapper_id} #terminal-traffic-lights {{
+        .{classes_prefix}-terminal-traffic-lights {{
             position: absolute;
             top: 24px;
             left: 20px;
         }}
-        #{wrapper_id} #terminal-body {{
+        .{classes_prefix}-terminal-body {{
             line-height: {line_height}px;
             padding: 14px;
         }}
@@ -120,17 +120,17 @@ CONSOLE_SVG_FORMAT = """\
     </style>
     <foreignObject x="0" y="0" width="100%" height="100%">
         <body xmlns="http://www.w3.org/1999/xhtml">
-            <div id="{wrapper_id}">
-                <div id="terminal">
-                    <div id='terminal-header'>
-                        <svg id="terminal-traffic-lights" width="90" height="21" viewBox="0 0 90 21" xmlns="http://www.w3.org/2000/svg">
+            <div class="{classes_prefix}-terminal-wrapper">
+                <div class="{classes_prefix}-terminal">
+                    <div class="{classes_prefix}-terminal-header">
+                        <svg class="{classes_prefix}-terminal-traffic-lights" width="90" height="21" viewBox="0 0 90 21" xmlns="http://www.w3.org/2000/svg">
                             <circle cx="14" cy="8" r="8" fill="#ff6159"/>
                             <circle cx="38" cy="8" r="8" fill="#ffbd2e"/>
                             <circle cx="62" cy="8" r="8" fill="#28c941"/>
                         </svg>
-                        <div id="terminal-title-tab">{title}</div>
+                        <div class="{classes_prefix}-terminal-title-tab">{title}</div>
                     </div>
-                    <div id='terminal-body'>
+                    <div class="{classes_prefix}-terminal-body">
                         {code}
                     </div>
                 </div>
@@ -139,3 +139,6 @@ CONSOLE_SVG_FORMAT = """\
     </foreignObject>
 </svg>
 """
+
+_SVG_FONT_FAMILY = "Rich Fira Code"
+_SVG_CLASSES_PREFIX = "rich-svg"

--- a/rich/_export_format.py
+++ b/rich/_export_format.py
@@ -1,5 +1,3 @@
-import zlib
-
 CONSOLE_HTML_FORMAT = """\
 <!DOCTYPE html>
 <head>
@@ -141,11 +139,6 @@ CONSOLE_SVG_FORMAT = """\
     </foreignObject>
 </svg>
 """
-
-
-def _svg_hash(svg_main_code: str) -> str:
-    return str(zlib.adler32(svg_main_code.encode()))
-
 
 _SVG_FONT_FAMILY = "Rich Fira Code"
 _SVG_CLASSES_PREFIX = "rich-svg"

--- a/rich/console.py
+++ b/rich/console.py
@@ -4,6 +4,7 @@ import os
 import platform
 import sys
 import threading
+import zlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -42,14 +43,13 @@ else:
     )  # pragma: no cover
 
 from . import errors, themes
-from ._console import (
+from ._emoji_replace import _emoji_replace
+from ._export_format import (
     _SVG_CLASSES_PREFIX,
     _SVG_FONT_FAMILY,
     CONSOLE_HTML_FORMAT,
     CONSOLE_SVG_FORMAT,
-    _svg_hash,
 )
-from ._emoji_replace import _emoji_replace
 from ._log_render import FormatTimeCallable, LogRender
 from .align import Align, AlignMethod
 from .color import ColorSystem
@@ -2349,6 +2349,18 @@ class Console:
         )
         with open(path, "wt", encoding="utf-8") as write_file:
             write_file.write(svg)
+
+
+def _svg_hash(svg_main_code: str) -> str:
+    """Returns a unique hash for the given SVG main code.
+
+    Args:
+        svg_main_code (str): The content we're going to inject in the SVG envelope.
+
+    Returns:
+        str: a hash of the given content
+    """
+    return str(zlib.adler32(svg_main_code.encode()))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/rich/console.py
+++ b/rich/console.py
@@ -47,6 +47,7 @@ from ._console import (
     _SVG_FONT_FAMILY,
     CONSOLE_HTML_FORMAT,
     CONSOLE_SVG_FORMAT,
+    _svg_hash,
 )
 from ._emoji_replace import _emoji_replace
 from ._log_render import FormatTimeCallable, LogRender
@@ -2265,11 +2266,14 @@ class Console:
 
                 fragments.append(f"<div>{''.join(line_spans)}</div>")
 
+            main_code = "\n".join(fragments)
+            classes_prefix = f"{_SVG_CLASSES_PREFIX}-{_svg_hash(main_code)}"
+
             stylesheet_rules = []
             for style_rule, style_number in styles.items():
                 if style_rule:
                     stylesheet_rules.append(
-                        f".{_SVG_CLASSES_PREFIX}-terminal-body .r{style_number} {{{ style_rule }}}"
+                        f".{classes_prefix}-terminal-body .r{style_number} {{{ style_rule }}}"
                     )
             stylesheet = "\n".join(stylesheet_rules)
 
@@ -2301,7 +2305,7 @@ class Console:
         total_width = terminal_width + 2 * margin
 
         rendered_code = code_format.format(
-            code="\n".join(fragments),
+            code=main_code,
             total_height=total_height,
             total_width=total_width,
             theme_foreground_color=theme_foreground_color,
@@ -2309,7 +2313,7 @@ class Console:
             margin=margin,
             font_size=font_size,
             font_family=_SVG_FONT_FAMILY,
-            classes_prefix=_SVG_CLASSES_PREFIX,
+            classes_prefix=classes_prefix,
             line_height=line_height,
             title=title,
             stylesheet=stylesheet,

--- a/rich/console.py
+++ b/rich/console.py
@@ -42,7 +42,12 @@ else:
     )  # pragma: no cover
 
 from . import errors, themes
-from ._console import CONSOLE_HTML_FORMAT, CONSOLE_SVG_FORMAT
+from ._console import (
+    _SVG_CLASSES_PREFIX,
+    _SVG_FONT_FAMILY,
+    CONSOLE_HTML_FORMAT,
+    CONSOLE_SVG_FORMAT,
+)
 from ._emoji_replace import _emoji_replace
 from ._log_render import FormatTimeCallable, LogRender
 from .align import Align, AlignMethod
@@ -2177,8 +2182,6 @@ class Console:
         theme: Optional[TerminalTheme] = None,
         clear: bool = True,
         code_format: str = CONSOLE_SVG_FORMAT,
-        font_family: str = "Rich Fira Code",
-        wrapper_id: str = "rich-svg-wrapper",
     ) -> str:
         """Generate an SVG string from the console contents (requires record=True in Console constructor)
 
@@ -2189,10 +2192,6 @@ class Console:
             code_format (str): Format string used to generate the SVG. Rich will inject a number of variables
                 into the string in order to form the final SVG output. The default template used and the variables
                 injected by Rich can be found by inspecting the ``console.CONSOLE_SVG_FORMAT`` variable.
-            font_family (str): The name of the CSS font family used in the SVG. Defaults to ``"Rich Fira Code"``,
-                in order to avoid contaminating the other fonts when the SVG is embedded into an HTML page.
-            wrapper_id (str): The ID of the SVG's root element. Defaults to ``"rich-svg-wrapper"``,
-                in order to avoid contaminating the other CSS selectors when the SVG is embedded into an HTML page.
 
         Returns:
             str: The string representation of the SVG. That is, the ``code_format`` template with content injected.
@@ -2270,7 +2269,7 @@ class Console:
             for style_rule, style_number in styles.items():
                 if style_rule:
                     stylesheet_rules.append(
-                        f"#{wrapper_id} .r{style_number} {{{ style_rule }}}"
+                        f".{_SVG_CLASSES_PREFIX}-terminal-body .r{style_number} {{{ style_rule }}}"
                     )
             stylesheet = "\n".join(stylesheet_rules)
 
@@ -2309,8 +2308,8 @@ class Console:
             theme_background_color=theme_background_color,
             margin=margin,
             font_size=font_size,
-            font_family=font_family,
-            wrapper_id=wrapper_id,
+            font_family=_SVG_FONT_FAMILY,
+            classes_prefix=_SVG_CLASSES_PREFIX,
             line_height=line_height,
             title=title,
             stylesheet=stylesheet,
@@ -2326,8 +2325,6 @@ class Console:
         theme: Optional[TerminalTheme] = None,
         clear: bool = True,
         code_format: str = CONSOLE_SVG_FORMAT,
-        font_family: str = "Rich Fira Code",
-        wrapper_id: str = "rich-svg-wrapper",
     ) -> None:
         """Generate an SVG file from the console contents (requires record=True in Console constructor).
 
@@ -2339,18 +2336,12 @@ class Console:
             code_format (str): Format string used to generate the SVG. Rich will inject a number of variables
                 into the string in order to form the final SVG output. The default template used and the variables
                 injected by Rich can be found by inspecting the ``console.CONSOLE_SVG_FORMAT`` variable.
-            font_family (str): The name of the CSS font family used in the SVG. Defaults to ``"Rich Fira Code"``,
-                in order to avoid contaminating the other fonts when the SVG is embedded into an HTML page.
-            wrapper_id (str): The ID of the SVG's root element. Defaults to ``"rich-svg-wrapper"``,
-                in order to avoid contaminating the other CSS selectors when the SVG is embedded into an HTML page.
         """
         svg = self.export_svg(
             title=title,
             theme=theme,
             clear=clear,
             code_format=code_format,
-            font_family=font_family,
-            wrapper_id=wrapper_id,
         )
         with open(path, "wt", encoding="utf-8") as write_file:
             write_file.write(svg)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -455,7 +455,7 @@ EXPECTED_SVG = """\
      xmlns="http://www.w3.org/2000/svg">
     <style>
         @font-face {
-            font-family: "Fira Code";
+            font-family: "Rich Fira Code";
             src: local("FiraCode-Regular"),
                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
@@ -463,37 +463,37 @@ EXPECTED_SVG = """\
             font-weight: 400;
         }
         @font-face {
-            font-family: "Fira Code";
+            font-family: "Rich Fira Code";
             src: local("FiraCode-Bold"),
                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
                  url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
             font-style: bold;
             font-weight: 700;
         }
-        span {
+        #rich-svg-wrapper span {
             display: inline-block;
             white-space: pre;
             vertical-align: top;
             font-size: 18px;
-            font-family:'Fira Code','Cascadia Code',Monaco,Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace;
+            font-family:'Rich Fira Code','Cascadia Code',Monaco,Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace;
         }
-        a {
+        #rich-svg-wrapper a {
             text-decoration: none;
             color: inherit;
         }
-        .blink {
-           animation: blinker 1s infinite;
+        #rich-svg-wrapper .blink {
+           animation: rich-svg-wrapper-blinker 1s infinite;
         }
-        @keyframes blinker {
+        @keyframes rich-svg-wrapper-blinker {
             from { opacity: 1.0; }
             50% { opacity: 0.3; }
             to { opacity: 1.0; }
         }
-        #wrapper {
+        #rich-svg-wrapper {
             padding: 140px;
             padding-top: 100px;
         }
-        #terminal {
+        #rich-svg-wrapper #terminal {
             position: relative;
             display: flex;
             flex-direction: column;
@@ -502,7 +502,7 @@ EXPECTED_SVG = """\
             border-radius: 14px;
             outline: 1px solid #484848;
         }
-        #terminal:after {
+        #rich-svg-wrapper #terminal:after {
             position: absolute;
             width: 100%;
             height: 100%;
@@ -513,7 +513,7 @@ EXPECTED_SVG = """\
             transform: rotate(-4.5deg);
             z-index: -1;
         }
-        #terminal-header {
+        #rich-svg-wrapper #terminal-header {
             position: relative;
             width: 100%;
             background-color: #2e2e2e;
@@ -525,7 +525,7 @@ EXPECTED_SVG = """\
             box-shadow: inset 0px -1px 0px 0px #4e4e4e,
                         inset 0px -4px 8px 0px #1a1a1a;
         }
-        #terminal-title-tab {
+        #rich-svg-wrapper #terminal-title-tab {
             display: inline-block;
             margin-top: 14px;
             margin-left: 124px;
@@ -538,22 +538,22 @@ EXPECTED_SVG = """\
                         inset 1px 0px 0px 0px #4e4e4e,
                         inset -1px 0px 0px 0px #4e4e4e;
         }
-        #terminal-traffic-lights {
+        #rich-svg-wrapper #terminal-traffic-lights {
             position: absolute;
             top: 24px;
             left: 20px;
         }
-        #terminal-body {
+        #rich-svg-wrapper #terminal-body {
             line-height: 22px;
             padding: 14px;
         }
-        .r1 {color: #f2f2f2; text-decoration-color: #f2f2f2;background-color: #0c0c0c;}
-.r2 {color: #2472c8; text-decoration-color: #2472c8; background-color: #cd3131; font-weight: bold}
-.r3 {;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
+        #rich-svg-wrapper .r1 {color: #f2f2f2; text-decoration-color: #f2f2f2;background-color: #0c0c0c;}
+#rich-svg-wrapper .r2 {color: #2472c8; text-decoration-color: #2472c8; background-color: #cd3131; font-weight: bold}
+#rich-svg-wrapper .r3 {;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
     </style>
     <foreignObject x="0" y="0" width="100%" height="100%">
         <body xmlns="http://www.w3.org/1999/xhtml">
-            <div id="wrapper">
+            <div id="rich-svg-wrapper">
                 <div id="terminal">
                     <div id='terminal-header'>
                         <svg id="terminal-traffic-lights" width="90" height="21" viewBox="0 0 90 21" xmlns="http://www.w3.org/2000/svg">

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -470,30 +470,30 @@ EXPECTED_SVG = """\
             font-style: bold;
             font-weight: 700;
         }
-        .rich-svg-terminal-wrapper span {
+        .rich-svg-${SVG_HASH}-terminal-wrapper span {
             display: inline-block;
             white-space: pre;
             vertical-align: top;
             font-size: 18px;
             font-family:'Rich Fira Code','Cascadia Code',Monaco,Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace;
         }
-        .rich-svg-terminal-wrapper a {
+        .rich-svg-${SVG_HASH}-terminal-wrapper a {
             text-decoration: none;
             color: inherit;
         }
-        .rich-svg-terminal-body .blink {
-           animation: rich-svg-blinker 1s infinite;
+        .rich-svg-${SVG_HASH}-terminal-body .blink {
+           animation: rich-svg-${SVG_HASH}-blinker 1s infinite;
         }
-        @keyframes rich-svg-blinker {
+        @keyframes rich-svg-${SVG_HASH}-blinker {
             from { opacity: 1.0; }
             50% { opacity: 0.3; }
             to { opacity: 1.0; }
         }
-        .rich-svg-terminal-wrapper {
+        .rich-svg-${SVG_HASH}-terminal-wrapper {
             padding: 140px;
             padding-top: 100px;
         }
-        .rich-svg-terminal {
+        .rich-svg-${SVG_HASH}-terminal {
             position: relative;
             display: flex;
             flex-direction: column;
@@ -502,7 +502,7 @@ EXPECTED_SVG = """\
             border-radius: 14px;
             outline: 1px solid #484848;
         }
-        .rich-svg-terminal:after {
+        .rich-svg-${SVG_HASH}-terminal:after {
             position: absolute;
             width: 100%;
             height: 100%;
@@ -513,7 +513,7 @@ EXPECTED_SVG = """\
             transform: rotate(-4.5deg);
             z-index: -1;
         }
-        .rich-svg-terminal-header {
+        .rich-svg-${SVG_HASH}-terminal-header {
             position: relative;
             width: 100%;
             background-color: #2e2e2e;
@@ -525,7 +525,7 @@ EXPECTED_SVG = """\
             box-shadow: inset 0px -1px 0px 0px #4e4e4e,
                         inset 0px -4px 8px 0px #1a1a1a;
         }
-        .rich-svg-terminal-title-tab {
+        .rich-svg-${SVG_HASH}-terminal-title-tab {
             display: inline-block;
             margin-top: 14px;
             margin-left: 124px;
@@ -538,32 +538,32 @@ EXPECTED_SVG = """\
                         inset 1px 0px 0px 0px #4e4e4e,
                         inset -1px 0px 0px 0px #4e4e4e;
         }
-        .rich-svg-terminal-traffic-lights {
+        .rich-svg-${SVG_HASH}-terminal-traffic-lights {
             position: absolute;
             top: 24px;
             left: 20px;
         }
-        .rich-svg-terminal-body {
+        .rich-svg-${SVG_HASH}-terminal-body {
             line-height: 22px;
             padding: 14px;
         }
-        .rich-svg-terminal-body .r1 {color: #f2f2f2; text-decoration-color: #f2f2f2;background-color: #0c0c0c;}
-.rich-svg-terminal-body .r2 {color: #2472c8; text-decoration-color: #2472c8; background-color: #cd3131; font-weight: bold}
-.rich-svg-terminal-body .r3 {;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
+        .rich-svg-${SVG_HASH}-terminal-body .r1 {color: #f2f2f2; text-decoration-color: #f2f2f2;background-color: #0c0c0c;}
+.rich-svg-${SVG_HASH}-terminal-body .r2 {color: #2472c8; text-decoration-color: #2472c8; background-color: #cd3131; font-weight: bold}
+.rich-svg-${SVG_HASH}-terminal-body .r3 {;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
     </style>
     <foreignObject x="0" y="0" width="100%" height="100%">
         <body xmlns="http://www.w3.org/1999/xhtml">
-            <div class="rich-svg-terminal-wrapper">
-                <div class="rich-svg-terminal">
-                    <div class="rich-svg-terminal-header">
-                        <svg class="rich-svg-terminal-traffic-lights" width="90" height="21" viewBox="0 0 90 21" xmlns="http://www.w3.org/2000/svg">
+            <div class="rich-svg-${SVG_HASH}-terminal-wrapper">
+                <div class="rich-svg-${SVG_HASH}-terminal">
+                    <div class="rich-svg-${SVG_HASH}-terminal-header">
+                        <svg class="rich-svg-${SVG_HASH}-terminal-traffic-lights" width="90" height="21" viewBox="0 0 90 21" xmlns="http://www.w3.org/2000/svg">
                             <circle cx="14" cy="8" r="8" fill="#ff6159"/>
                             <circle cx="38" cy="8" r="8" fill="#ffbd2e"/>
                             <circle cx="62" cy="8" r="8" fill="#28c941"/>
                         </svg>
-                        <div class="rich-svg-terminal-title-tab">Rich</div>
+                        <div class="rich-svg-${SVG_HASH}-terminal-title-tab">Rich</div>
                     </div>
-                    <div class="rich-svg-terminal-body">
+                    <div class="rich-svg-${SVG_HASH}-terminal-body">
                         <div><span class="r2">foo</span><span class="r1"> </span><span class="r3"><span class="blink"><a href="https://example.org">Click</a></span></span><span class="r1">                                                                                           </span></div>
 <div><span class="r1"></span><span class="r1">                                                                                                    </span></div>
                     </div>
@@ -581,7 +581,11 @@ def test_export_svg():
         "[b red on blue reverse]foo[/] [blink][link=https://example.org]Click[/link]"
     )
     svg = console.export_svg()
-    assert svg == EXPECTED_SVG
+    svg_main_code_hash = (
+        "857433718"  # hard-coded here after the 1st time we ran this test
+    )
+    expected_svg = EXPECTED_SVG.replace("${SVG_HASH}", svg_main_code_hash)
+    assert svg == expected_svg
 
 
 def test_save_svg():
@@ -589,11 +593,13 @@ def test_save_svg():
     console.print(
         "[b red on blue reverse]foo[/] [blink][link=https://example.org]Click[/link]"
     )
+    svg_main_code_hash = "857433718"
+    expected_svg = EXPECTED_SVG.replace("${SVG_HASH}", svg_main_code_hash)
     with tempfile.TemporaryDirectory() as path:
         export_path = os.path.join(path, "example.svg")
         console.save_svg(export_path)
         with open(export_path, "rt") as svg_file:
-            assert svg_file.read() == EXPECTED_SVG
+            assert svg_file.read() == expected_svg
 
 
 def test_save_text():

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -470,30 +470,30 @@ EXPECTED_SVG = """\
             font-style: bold;
             font-weight: 700;
         }
-        #rich-svg-wrapper span {
+        .rich-svg-terminal-wrapper span {
             display: inline-block;
             white-space: pre;
             vertical-align: top;
             font-size: 18px;
             font-family:'Rich Fira Code','Cascadia Code',Monaco,Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace;
         }
-        #rich-svg-wrapper a {
+        .rich-svg-terminal-wrapper a {
             text-decoration: none;
             color: inherit;
         }
-        #rich-svg-wrapper .blink {
-           animation: rich-svg-wrapper-blinker 1s infinite;
+        .rich-svg-terminal-body .blink {
+           animation: rich-svg-blinker 1s infinite;
         }
-        @keyframes rich-svg-wrapper-blinker {
+        @keyframes rich-svg-blinker {
             from { opacity: 1.0; }
             50% { opacity: 0.3; }
             to { opacity: 1.0; }
         }
-        #rich-svg-wrapper {
+        .rich-svg-terminal-wrapper {
             padding: 140px;
             padding-top: 100px;
         }
-        #rich-svg-wrapper #terminal {
+        .rich-svg-terminal {
             position: relative;
             display: flex;
             flex-direction: column;
@@ -502,7 +502,7 @@ EXPECTED_SVG = """\
             border-radius: 14px;
             outline: 1px solid #484848;
         }
-        #rich-svg-wrapper #terminal:after {
+        .rich-svg-terminal:after {
             position: absolute;
             width: 100%;
             height: 100%;
@@ -513,7 +513,7 @@ EXPECTED_SVG = """\
             transform: rotate(-4.5deg);
             z-index: -1;
         }
-        #rich-svg-wrapper #terminal-header {
+        .rich-svg-terminal-header {
             position: relative;
             width: 100%;
             background-color: #2e2e2e;
@@ -525,7 +525,7 @@ EXPECTED_SVG = """\
             box-shadow: inset 0px -1px 0px 0px #4e4e4e,
                         inset 0px -4px 8px 0px #1a1a1a;
         }
-        #rich-svg-wrapper #terminal-title-tab {
+        .rich-svg-terminal-title-tab {
             display: inline-block;
             margin-top: 14px;
             margin-left: 124px;
@@ -538,32 +538,32 @@ EXPECTED_SVG = """\
                         inset 1px 0px 0px 0px #4e4e4e,
                         inset -1px 0px 0px 0px #4e4e4e;
         }
-        #rich-svg-wrapper #terminal-traffic-lights {
+        .rich-svg-terminal-traffic-lights {
             position: absolute;
             top: 24px;
             left: 20px;
         }
-        #rich-svg-wrapper #terminal-body {
+        .rich-svg-terminal-body {
             line-height: 22px;
             padding: 14px;
         }
-        #rich-svg-wrapper .r1 {color: #f2f2f2; text-decoration-color: #f2f2f2;background-color: #0c0c0c;}
-#rich-svg-wrapper .r2 {color: #2472c8; text-decoration-color: #2472c8; background-color: #cd3131; font-weight: bold}
-#rich-svg-wrapper .r3 {;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
+        .rich-svg-terminal-body .r1 {color: #f2f2f2; text-decoration-color: #f2f2f2;background-color: #0c0c0c;}
+.rich-svg-terminal-body .r2 {color: #2472c8; text-decoration-color: #2472c8; background-color: #cd3131; font-weight: bold}
+.rich-svg-terminal-body .r3 {;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
     </style>
     <foreignObject x="0" y="0" width="100%" height="100%">
         <body xmlns="http://www.w3.org/1999/xhtml">
-            <div id="rich-svg-wrapper">
-                <div id="terminal">
-                    <div id='terminal-header'>
-                        <svg id="terminal-traffic-lights" width="90" height="21" viewBox="0 0 90 21" xmlns="http://www.w3.org/2000/svg">
+            <div class="rich-svg-terminal-wrapper">
+                <div class="rich-svg-terminal">
+                    <div class="rich-svg-terminal-header">
+                        <svg class="rich-svg-terminal-traffic-lights" width="90" height="21" viewBox="0 0 90 21" xmlns="http://www.w3.org/2000/svg">
                             <circle cx="14" cy="8" r="8" fill="#ff6159"/>
                             <circle cx="38" cy="8" r="8" fill="#ffbd2e"/>
                             <circle cx="62" cy="8" r="8" fill="#28c941"/>
                         </svg>
-                        <div id="terminal-title-tab">Rich</div>
+                        <div class="rich-svg-terminal-title-tab">Rich</div>
                     </div>
-                    <div id='terminal-body'>
+                    <div class="rich-svg-terminal-body">
                         <div><span class="r2">foo</span><span class="r1"> </span><span class="r3"><span class="blink"><a href="https://example.org">Click</a></span></span><span class="r1">                                                                                           </span></div>
 <div><span class="r1"></span><span class="r1">                                                                                                    </span></div>
                     </div>


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The name of the font and the ID of the wrapper we use for the generated SVG code are now dynamic, and their default value contain "rich" in order to avoid conflicts with people's own resources if they embed such generated SVGs in an HTML page.
All the CSS selectors are also prefixed with the ID of the wrapper now, which should isolate then from the other ones defined in a surrounding HTML page.

Issue: https://github.com/Textualize/rich/issues/2147

On this annotated screenshot we can see this namespacing in action:
![Screenshot from 2022-04-04 16-23-13-annotated](https://user-images.githubusercontent.com/722388/161782078-24a952eb-937c-49d3-a464-ee4149e51717.png)

