### PR TITLE
Fix import of OrderedDict on Python <3.9

### DIFF
--- a/rich/_lru_cache.py
+++ b/rich/_lru_cache.py
@@ -5,7 +5,7 @@ CacheKey = TypeVar("CacheKey")
 CacheValue = TypeVar("CacheValue")
 
 if sys.version_info < (3, 9):
-    from typing_extensions import OrderedDict
+    from typing import OrderedDict
 else:
     from collections import OrderedDict
 


### PR DESCRIPTION
We're getting a failure in our CI now where twine uses rich:
`ImportError: cannot import name 'OrderedDict' from 'typing_extensions'`

I'm guessing that typing_extensions have removed OrderedDict as it is already available in all supported versions of Python. This should instead be imported from the standard library.