### PR TITLE
Add support for a "fuzzy" choice matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `FuzzyPrompt` to support partial and case-insensitive matches for choice-based prompts
+
 ### Fixed
 
 - Fall back to `sys.__stderr__` on POSIX systems when trying to get the terminal size (fix issues when Rich is piped to another process)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ The following people have contributed to the development of Rich:
 <!-- Add your name below, sort alphabetically by surname. Link to Github profile / your home page. -->
 
 - [Patrick Arminio](https://github.com/patrick91)
+- [Azeem Bande-Ali](https://github.com/azeemba)
 - [Gregory Beauregard](https://github.com/GBeauregard/pyffstream)
 - [Dennis Brakhane](https://github.com/brakhane)
 - [Darren Burns](https://github.com/darrenburns)

--- a/docs/source/prompt.rst
+++ b/docs/source/prompt.rst
@@ -18,6 +18,8 @@ If you supply a list of choices, the prompt will loop until the user enters one 
     >>> from rich.prompt import Prompt
     >>> name = Prompt.ask("Enter your name", choices=["Paul", "Jessica", "Duncan"], default="Paul")
 
+If you would like to support "fuzzy" matching on the choices, you can use :class:`~rich.prompt.FuzzyPrompt`.
+
 In addition to :class:`~rich.prompt.Prompt` which returns strings, you can also use :class:`~rich.prompt.IntPrompt` which asks the user for an integer, and :class:`~rich.prompt.FloatPrompt` for floats.
 
 The :class:`~rich.prompt.Confirm` class is a specialized prompt which may be used to ask the user a simple yes / no question. Here's an example::

--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -319,6 +319,28 @@ class FloatPrompt(PromptBase[int]):
     validate_error_message = "[prompt.invalid]Please enter a number"
 
 
+class FuzzyPrompt(PromptBase[str]):
+    """A Choice prompt that matches partial strings and ignores case.
+
+    For example, this matcher will match input 'fo' for choice Foo."""
+
+    response_type = str
+
+    def process_response(self, value: str) -> str:
+        """Check if the input is similar to exactly 1 choice"""
+        if not self.choices:
+            return PromptBase.process_response(self, value)
+        matches = []
+        for choice in self.choices:
+            if choice.lower().startswith(value.lower()):
+                matches.append(choice)
+
+        if len(matches) == 1:
+            return matches.pop()
+
+        raise InvalidResponse(self.illegal_choice_message)
+
+
 class Confirm(PromptBase[bool]):
     """A yes / no confirmation prompt.
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,13 +1,30 @@
 import io
 
 from rich.console import Console
-from rich.prompt import Prompt, IntPrompt, Confirm
+from rich.prompt import Prompt, IntPrompt, Confirm, FuzzyPrompt
 
 
 def test_prompt_str():
     INPUT = "egg\nfoo"
     console = Console(file=io.StringIO())
     name = Prompt.ask(
+        "what is your name",
+        console=console,
+        choices=["foo", "bar"],
+        default="baz",
+        stream=io.StringIO(INPUT),
+    )
+    assert name == "foo"
+    expected = "what is your name [foo/bar] (baz): Please select one of the available options\nwhat is your name [foo/bar] (baz): "
+    output = console.file.getvalue()
+    print(repr(output))
+    assert output == expected
+
+
+def test_prompt_fuzzy_choice():
+    INPUT = "egg\nFO"
+    console = Console(file=io.StringIO())
+    name = FuzzyPrompt.ask(
         "what is your name",
         console=console,
         choices=["foo", "bar"],


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

When choices are pretty distinct, it is nice to let the user only type
part of the choice and automatically match the rest. For example
if the choices are "Strike" and "Ball", then if the user types "b" we
know they meant ball.

This commit adds a new Prompt subclass to support this fuzzy matching.