### PR TITLE
Fix documentaion to show how to use progress bars with open files #2204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fall back to `sys.__stderr__` on POSIX systems when trying to get the terminal size (fix issues when Rich is piped to another process)
 - Fixed markup escaping issue https://github.com/Textualize/rich/issues/2187
 - Safari - Box appearing around SVG export https://github.com/Textualize/rich/pull/2201
+- Fixed documenation regarding how to use progress bars with an file object https://github.com/Textualize/rich/pull/2205
 
 ## [12.2.0] - 2022-04-05
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ The following people have contributed to the development of Rich:
 - [Pete Davison](https://github.com/pd93)
 - [James Estevez](https://github.com/jstvz)
 - [Oleksis Fraga](https://github.com/oleksis)
+- [Olaf Gladis](https://github.com/hwmrocker)
 - [Michał Górny](https://github.com/mgorny)
 - [Leron Gray](https://github.com/daddycocoaman)
 - [Kenneth Hoste](https://github.com/boegel)

--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -27,13 +27,16 @@ For basic usage call the :func:`~rich.progress.track` function, which accepts a 
         do_work(n)
 
 
-To get a progress bar while reading from a file, you may consider using the :func:`~rich.progress.read` function, which accepts a path, or a *file-like* object. It will return a *file-like* object in *binary mode* that will update the progress information as it's being read from. Here's an example, tracking the progresses made by :func:`json.load` to load a file::
+Rich provides an easy way to generate a progress bar for reading a file. If you call :func:`~rich.progress.open` it will return a context manager which displays a progress bar while you read. This is particularly useful when you can't easily modify the code that does the reading.
+
+The following example shows how we might show progress for reading a JSON file::
 
     import json
-    from rich.progress import read
+    import rich.progress
 
-    with read("data.json", description="Loading data...") as f:
-        data = json.load(f)
+    with rich.progress.open("data.json", "rb") as file:
+        data = json.load(file)
+    print(data)
 
 
 Advanced usage
@@ -209,19 +212,8 @@ If the :class:`~rich.progress.Progress` class doesn't offer exactly what you nee
         def get_renderables(self):
             yield Panel(self.make_tasks_table(self.tasks))
 
-Reading from a file
-~~~~~~~~~~~~~~~~~~~
-
-Rich provides an easy way to generate a progress bar for reading a file. If you call :func:`~rich.progress.open` it will return a context manager which displays a progress bar while you read. This is particularly useful when you can't easily modify the code that does the reading.
-
-The following example shows how we might show progress for reading a JSON file::
-
-    import json
-    import rich.progress
-
-    with rich.progress.open("data.json", "rb") as file:
-        data = json.load(file)
-    print(data)
+Wrapping a file
+~~~~~~~~~~~~~~~
 
 If you already have a file object, you can call :func:`~rich.progress.wrap_file` which returns a context manager that wraps your file so that it displays a progress bar. If you use this function you will need to set the number of bytes or characters you expect to read.
 


### PR DESCRIPTION
The docs are still mentioning `rich.progress.read` but the new way is `rich.progress.open`
I move the docs handling files to top.

I you think progress for reading a file is not basic usage please decline this PR.
To have a progress when reading a file is very useful for me, and I personally think this it is a great selling point.

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate. (I just updated this via the github ui, if the change is generally welcome I check it out and update it, but I only have time for it tomorrow)
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
