### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,5 +1,8 @@
 name: codespell
 on: [pull_request, push]
+permissions:
+  contents: read
+
 jobs:
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/readmechanged.yml
+++ b/.github/workflows/readmechanged.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'README.md'
 
+permissions:
+  contents: read
+
 jobs:
   send_notification:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
