### PR TITLE
[traceback] Add traceback frame opt-out via a `_rich_traceback_omit = True` machinery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ability to change terminal window title https://github.com/Textualize/rich/pull/2200
 - Added show_speed parameter to progress.track which will show the speed when the total is not known
+- Python blocks can now opt out from being rendered in tracebacks's frames, by setting a `_rich_traceback_omit = True` in their local scope https://github.com/Textualize/rich/issues/2207
 
 ### Fixed
 

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -367,6 +367,8 @@ class Traceback:
                 if filename and not filename.startswith("<"):
                     if not os.path.isabs(filename):
                         filename = os.path.join(_IMPORT_CWD, filename)
+                if frame_summary.f_locals.get("_rich_traceback_omit", False) is True:
+                    continue
                 frame = Frame(
                     filename=filename or "?",
                     lineno=line_no,

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -367,7 +367,7 @@ class Traceback:
                 if filename and not filename.startswith("<"):
                     if not os.path.isabs(filename):
                         filename = os.path.join(_IMPORT_CWD, filename)
-                if frame_summary.f_locals.get("_rich_traceback_omit", False) is True:
+                if frame_summary.f_locals.get("_rich_traceback_omit", False):
                     continue
                 frame = Frame(
                     filename=filename or "?",
@@ -385,7 +385,7 @@ class Traceback:
                     else None,
                 )
                 append(frame)
-                if "_rich_traceback_guard" in frame_summary.f_locals:
+                if frame_summary.f_locals.get("_rich_traceback_guard", False):
                     del stack.frames[:]
 
             cause = getattr(exc_value, "__cause__", None)

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -326,7 +326,8 @@ def test_rich_traceback_omit_optional_local_flag(
         return level2()
 
     def level2():
-        _rich_traceback_omit = rich_traceback_omit_for_level2
+        # true-ish values are enough to trigger the opt-out:
+        _rich_traceback_omit = 1 if rich_traceback_omit_for_level2 else 0
         return level3()
 
     def level3():


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

closes #2207