### PR TITLE
Add level_width and level_format params to RichHandler

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,3 +40,4 @@ The following people have contributed to the development of Rich:
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)
 - [Arian Mollik Wasi](https://github.com/wasi-master)
 - [Handhika Yanuar Pratama](https://github.com/theDreamer911)
+- [Arthur Le Moigne](https://github.com/arthurlm)

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -43,6 +43,9 @@ class RichHandler(Handler):
             Defaults to 10.
         locals_max_string (int, optional): Maximum length of string before truncating, or None to disable. Defaults to 80.
         log_time_format (Union[str, TimeFormatterCallable], optional): If ``log_time`` is enabled, either string for strftime or callable that formats the time. Defaults to "[%x %X] ".
+        level_width int: Level column size.
+            Defaults to 8.
+        level_format str: format of level column.
         keywords (List[str], optional): List of words to highlight instead of ``RichHandler.KEYWORDS``.
     """
 
@@ -80,6 +83,8 @@ class RichHandler(Handler):
         locals_max_length: int = 10,
         locals_max_string: int = 80,
         log_time_format: Union[str, FormatTimeCallable] = "[%x %X]",
+        level_width: int = 8,
+        level_format: Optional[str] = None,
         keywords: Optional[List[str]] = None,
     ) -> None:
         super().__init__(level=level)
@@ -91,7 +96,7 @@ class RichHandler(Handler):
             show_path=show_path,
             time_format=log_time_format,
             omit_repeated_times=omit_repeated_times,
-            level_width=None,
+            level_width=level_width,
         )
         self.enable_link_path = enable_link_path
         self.markup = markup
@@ -104,6 +109,8 @@ class RichHandler(Handler):
         self.tracebacks_suppress = tracebacks_suppress
         self.locals_max_length = locals_max_length
         self.locals_max_string = locals_max_string
+        self.level_width = level_width
+        self.level_format = level_format or "{{:<{0}.{0}}}".format(level_width)
         self.keywords = keywords
 
     def get_level_text(self, record: LogRecord) -> Text:
@@ -115,9 +122,9 @@ class RichHandler(Handler):
         Returns:
             Text: A tuple of the style and level name.
         """
-        level_name = record.levelname
+        level_name = self.level_format.format(record.levelname)
         level_text = Text.styled(
-            level_name.ljust(8), f"logging.level.{level_name.lower()}"
+            level_name, f"logging.level.{record.levelname.lower()}"
         )
         return level_text
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -162,6 +162,67 @@ def test_markup_and_highlight():
     assert log_message in render_plain
 
 
+def test_level_width():
+    console = Console(
+        file=io.StringIO(),
+        force_terminal=True,
+        width=140,
+        color_system=None,
+        _environ={},
+    )
+    handler_level_width = RichHandler(
+        console=console,
+        level_width=4,
+    )
+    log.setLevel(logging.INFO)
+    log.addHandler(handler_level_width)
+
+    log.info("Great")
+    log.warning("Few warning")
+    log.error("Some error")
+
+    render = handler_level_width.console.file.getvalue()
+    print(render)
+
+    assert "INFO Great" in render
+    assert "WARN Few warning" in render
+    assert "ERRO Some error" in render
+
+    assert "WARNING" not in render
+    assert "ERROR" not in render
+
+
+def test_level_format():
+    console = Console(
+        file=io.StringIO(),
+        force_terminal=True,
+        width=140,
+        color_system=None,
+        _environ={},
+    )
+    handler_level_width = RichHandler(
+        console=console,
+        level_width=10,
+        level_format="[{:>8.8}]",
+        omit_repeated_times=False,
+    )
+    log.setLevel(logging.INFO)
+    log.addHandler(handler_level_width)
+
+    log.info("Great")
+    log.warning("Few warning")
+    log.error("Some error")
+    log.critical("Something terrible happened")
+
+    render = handler_level_width.console.file.getvalue()
+    print(render)
+
+    assert "] [    INFO] Great" in render
+    assert "] [ WARNING] Few warning" in render
+    assert "] [   ERROR] Some error" in render
+    assert "] [CRITICAL] Something terrible happened" in render
+
+
 if __name__ == "__main__":
     render = make_log()
     print(render)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Add `level_width` parameter to `rich.logging.RichHandler`.

Without this parameter it is not possible to reduce level column size properly.
Indeed, if we just override `handler._log_render.level_width`, output will be
```
# level_width = 1
           … GET /favicon.ico 404 242                  logging.py:249
[10:14:56] … JSONRPC request                           logging.py:252

# level_width = 4
           WAR… GET /favicon.ico 404 242               logging.py:249
[10:14:56] DEB… JSONRPC request                        logging.py:252
```

With this new setting, we correctly get level name with valid color rendering and without `…`:
```
# level_width = 1
           W GET /favicon.ico 404 242                  logging.py:249
[10:16:27] D JSONRPC request                           logging.py:252

# level_width = 4
           WARN GET /favicon.ico 404 242               logging.py:249
[10:16:27] DEBU JSONRPC request                        logging.py:252
```

Also adding `level_format` parameter to allow changing alignment of level column.
