### PR TITLE
Respect dim style on SVG export

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ The following people have contributed to the development of Rich:
 <!-- Add your name below, sort alphabetically by surname. Link to Github profile / your home page. -->
 
 - [Patrick Arminio](https://github.com/patrick91)
+- [Sebastian Barrios](https://github.com/sbarrios93)
 - [Gregory Beauregard](https://github.com/GBeauregard/pyffstream)
 - [Dennis Brakhane](https://github.com/brakhane)
 - [Darren Burns](https://github.com/darrenburns)

--- a/rich/console.py
+++ b/rich/console.py
@@ -2297,10 +2297,13 @@ class Console:
                                 f"background-color: {theme_foreground_color};"
                             )
 
-                        if style.color is None:
-                            rules += f";{foreground_css}"
-                        if style.bgcolor is None:
-                            rules += f";{background_css}"
+                        if (
+                            not style.dim
+                        ):  # style.color is set as None when dim style is active. This will issue a problem where more than one color is applied to the span, overwriting the dimmed color for the foreground color.
+                            if style.color is None:
+                                rules += f";{foreground_css}"
+                            if style.bgcolor is None:
+                                rules += f";{background_css}"
 
                         style_number = styles.setdefault(rules, len(styles) + 1)
                         text = f'<span class="r{style_number}">{text}</span>'


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated ~CHANGELOG.md~ and CONTRIBUTORS.md where appropriate.
- [_Not sure if needed_ ] I've added tests for new code. 
- [x] I accept that @willmcgugan may be pedantic in the code review. (Please do!!)🥸

## Description

Fixes #2237 

`dim` style has property `self.color` as `None`, making [this block](https://github.com/Textualize/rich/blob/bb00fc96ee09525e5b5f2ffe7762138b5999e949/rich/console.py#L2300) append a new color style after the correct one. (Look at the `r2` style on a svg file where the dim style is not being formatted correctly. There is more than one foreground attribute being set)



