### PR TITLE
Support pyinstaller relative paths in Traceback (#2251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crash on IDLE and forced is_terminal detection to False because IDLE can't do escape codes https://github.com/Textualize/rich/issues/2222
 - Fixed missing blank line in traceback rendering https://github.com/Textualize/rich/issues/2206
 - Fixed running Rich with the current working dir was deleted https://github.com/Textualize/rich/issues/2197
+- Fixed traceback missing file errors when running Rich from a pyinstaller bundle https://github.com/Textualize/rich/issues/2251
 
 ### Changed
 

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -366,7 +366,22 @@ class Traceback:
                 filename = frame_summary.f_code.co_filename
                 if filename and not filename.startswith("<"):
                     if not os.path.isabs(filename):
-                        filename = os.path.join(_IMPORT_CWD, filename)
+                        # py2exe doesn't set the _MEIPASS attr and we don't
+                        # know if py2exe has the same behavior as pyinstaller,
+                        # so we check if it exists to avoid errors in py2exe.
+                        if (
+                            hasattr(sys, "frozen")
+                            and hasattr(sys, "_MEIPASS")
+                            and getattr(sys, "frozen", False) == True
+                        ):
+                            # Use a custom filename when we're running with pyinstaller,
+                            # this avoids raising OSErrors later. See issue #2251.
+                            mod_name = os.path.splitext(filename)[0].replace(
+                                os.path.sep, "."
+                            )
+                            filename = f"<pyinstaller module ({mod_name})>"
+                        else:
+                            filename = os.path.join(_IMPORT_CWD, filename)
                 if frame_summary.f_locals.get("_rich_traceback_omit", False):
                     continue
                 frame = Frame(


### PR DESCRIPTION
## Type of changes

- [X] Bug fix

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

In `rich.traceback.Traceback.extract`, if `frame_summary.f_code.co_filename` isn't an absolute path, we now check if we're running in a pyinstaller bundle, and will fabricate a file name to avoid errors. See #2251 for details.
