### PR TITLE
Forward the internal handle name wrapped in `rich.progress._Reader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change SVG export to create a simpler SVG
 - Fix render_lines crash when render height was negative https://github.com/Textualize/rich/pull/2246
+- Make objects from `rich.progress.open` forward the name of the internal handle https://github.com/Textualize/rich/pull/2254
 
 ### Added
 

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -216,6 +216,10 @@ class _Reader(RawIOBase, BinaryIO):
     def isatty(self) -> bool:
         return self.handle.isatty()
 
+    @property
+    def name(self) -> Optional[str]:
+        return self.handle.name
+
     def readable(self) -> bool:
         return self.handle.readable()
 

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -217,7 +217,7 @@ class _Reader(RawIOBase, BinaryIO):
         return self.handle.isatty()
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str:
         return self.handle.name
 
     def readable(self) -> bool:

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -600,6 +600,7 @@ def test_open_text_mode() -> None:
     try:
         with rich.progress.open(filename, "r") as f:
             assert f.read() == "Hello, World!"
+            assert f.name == filename
         assert f.closed
     finally:
         os.remove(filename)
@@ -613,6 +614,7 @@ def test_wrap_file() -> None:
         with open(filename, "rb") as file:
             with rich.progress.wrap_file(file, total=total) as f:
                 assert f.read() == b"Hello, World!"
+                assert f.name == filename
             assert f.closed
             assert not f.handle.closed
             assert not file.closed


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Hi all!

This is just a quick follow-up patch for file/progress so that the reader takes the `name` attribute from the internal handle. Currently, the `_Reader` has a `name` attribute (inherited from `RawIOBase`) but it's always `None`.