### PR TITLE
[console][typing] Extract color-system-as-a-string to a type literal

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -522,14 +522,19 @@ def _is_jupyter() -> bool:  # pragma: no cover
         return False  # Other type (?)
 
 
-COLOR_SYSTEMS = {
+ConsoleColorSystem = Literal["auto", "standard", "256", "truecolor", "windows"]
+
+
+COLOR_SYSTEMS: Dict[ConsoleColorSystem, ColorSystem] = {
     "standard": ColorSystem.STANDARD,
     "256": ColorSystem.EIGHT_BIT,
     "truecolor": ColorSystem.TRUECOLOR,
     "windows": ColorSystem.WINDOWS,
 }
 
-_COLOR_SYSTEMS_NAMES = {system: name for name, system in COLOR_SYSTEMS.items()}
+_COLOR_SYSTEMS_NAMES: Dict[ColorSystem, ConsoleColorSystem] = {
+    system: name for name, system in COLOR_SYSTEMS.items()
+}
 
 
 @dataclass
@@ -619,9 +624,7 @@ class Console:
     def __init__(
         self,
         *,
-        color_system: Optional[
-            Literal["auto", "standard", "256", "truecolor", "windows"]
-        ] = "auto",
+        color_system: Optional[ConsoleColorSystem] = "auto",
         force_terminal: Optional[bool] = None,
         force_jupyter: Optional[bool] = None,
         force_interactive: Optional[bool] = None,
@@ -880,11 +883,11 @@ class Console:
         return ThemeContext(self, theme, inherit)
 
     @property
-    def color_system(self) -> Optional[str]:
+    def color_system(self) -> Optional[ConsoleColorSystem]:
         """Get color system string.
 
         Returns:
-            Optional[str]: "standard", "256" or "truecolor".
+            Optional[ConsoleColorSystem]: "standard", "256", "truecolor" or "windows".
         """
 
         if self._color_system is not None:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code. _(typing-only modification, so not really testable)_
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

While working on integration tests on Textual I found myself duplicating the `Literal["auto", "standard", "256", "truecolor", "windows"]` literal of the Console in my derived class. This is because we're using an inline literal type for the color-system-as-a-string argument we can pass to the Console constructor.
As it's inlined in the constructor signature, we cannot re-use this literal it elsewhere (in Textual for example).

With this tiny PR, Python code outside of Rich can now use this literal :slightly_smiling_face: 