### PR TITLE
[bugfix] solve crash when using `inspect()` on the "pyparsing" package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow exceptions that are raised while a Live is rendered to be displayed and/or processed https://github.com/Textualize/rich/pull/2305
+- Fix crashes that can happen with `inspect` when docstrings contain some special control codes https://github.com/Textualize/rich/pull/2294
 
 ## [12.4.4] - 2022-05-24
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,6 @@ enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 [[tool.mypy.overrides]]
 module = ["pygments.*", "IPython.*", "commonmark.*", "ipywidgets.*"]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/rich/_inspect.py
+++ b/rich/_inspect.py
@@ -5,25 +5,13 @@ from inspect import cleandoc, getdoc, getfile, isclass, ismodule, signature
 from typing import Any, Iterable, Optional, Tuple
 
 from .console import Group, RenderableType
+from .control import make_control_codes_readable
 from .highlighter import ReprHighlighter
 from .jupyter import JupyterMixin
 from .panel import Panel
 from .pretty import Pretty
 from .table import Table
 from .text import Text, TextType
-
-_SPECIAL_CHARACTERS_TRANSLATION_TABLE = str.maketrans(
-    # Some special characters (such as "\b", aka "Backspace") are stripped from the docstrings when
-    # we display them, and also mess up our processing
-    # --> let's replace them with a readable "non-special" version of them (i.e. "\b" -> "\\b"):
-    {
-        "\a": "\\a",  # ASCII Bell
-        "\b": "\\b",  # ASCII Backspace
-        "\f": "\\f",  # ASCII Formfeed
-        "\r": "\\r",  # ASCII Carriage Return
-        "\v": "\\v",  # ASCII Vertical Tab
-    }
-)
 
 
 def _first_paragraph(doc: str) -> str:
@@ -230,5 +218,4 @@ class Inspect(JupyterMixin):
         docs = cleandoc(docs).strip()
         if not self.help:
             docs = _first_paragraph(docs)
-        docs = docs.translate(_SPECIAL_CHARACTERS_TRANSLATION_TABLE)
-        return docs
+        return make_control_codes_readable(docs)

--- a/rich/_inspect.py
+++ b/rich/_inspect.py
@@ -5,7 +5,7 @@ from inspect import cleandoc, getdoc, getfile, isclass, ismodule, signature
 from typing import Any, Iterable, Optional, Tuple
 
 from .console import Group, RenderableType
-from .control import make_control_codes_readable
+from .control import escape_control_codes
 from .highlighter import ReprHighlighter
 from .jupyter import JupyterMixin
 from .panel import Panel
@@ -212,10 +212,22 @@ class Inspect(JupyterMixin):
             )
 
     def _get_formatted_doc(self, object_: Any) -> Optional[str]:
+        """
+        Extract the docstring of an object, process it and returns it.
+        The processing consists in cleaning up the doctring's indentation,
+        taking only its 1st paragraph if `self.help` is not True,
+        and escape its control codes.
+
+        Args:
+            object_ (Any): the object to get the docstring from.
+
+        Returns:
+            Optional[str]: the processed docstring, or None if no docstring was found.
+        """
         docs = getdoc(object_)
         if docs is None:
             return None
         docs = cleandoc(docs).strip()
         if not self.help:
             docs = _first_paragraph(docs)
-        return make_control_codes_readable(docs)
+        return escape_control_codes(docs)

--- a/rich/control.py
+++ b/rich/control.py
@@ -1,19 +1,35 @@
+import sys
 import time
 from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Union
+
+if sys.version_info >= (3, 8):
+    from typing import Final
+else:
+    from typing_extensions import Final  # pragma: no cover
 
 from .segment import ControlCode, ControlType, Segment
 
 if TYPE_CHECKING:
     from .console import Console, ConsoleOptions, RenderResult
 
-STRIP_CONTROL_CODES = [
+STRIP_CONTROL_CODES: Final = [
+    7,  # Bell
     8,  # Backspace
     11,  # Vertical tab
     12,  # Form feed
     13,  # Carriage return
 ]
-_CONTROL_TRANSLATE = {_codepoint: None for _codepoint in STRIP_CONTROL_CODES}
+_CONTROL_STRIP_TRANSLATE: Final = {
+    _codepoint: None for _codepoint in STRIP_CONTROL_CODES
+}
 
+_CONTROL_MAKE_READABLE_TRANSLATE: Final = {
+    7: "\\a",
+    8: "\\b",
+    11: "\\v",
+    12: "\\f",
+    13: "\\r",
+}
 
 CONTROL_CODES_FORMAT: Dict[int, Callable[..., str]] = {
     ControlType.BELL: lambda: "\x07",
@@ -169,7 +185,7 @@ class Control:
 
 
 def strip_control_codes(
-    text: str, _translate_table: Dict[int, None] = _CONTROL_TRANSLATE
+    text: str, _translate_table: Dict[int, None] = _CONTROL_STRIP_TRANSLATE
 ) -> str:
     """Remove control codes from text.
 
@@ -178,6 +194,22 @@ def strip_control_codes(
 
     Returns:
         str: String with control codes removed.
+    """
+    return text.translate(_translate_table)
+
+
+def make_control_codes_readable(
+    text: str,
+    _translate_table: Dict[int, str] = _CONTROL_MAKE_READABLE_TRANSLATE,
+) -> str:
+    """Replace control codes with their "readable" equivalent in the given text.
+    (e.g. "\b" becomes "\\b")
+
+    Args:
+        text (str): A string possibly contain control codes.
+
+    Returns:
+        str: String with control codes replaced with a readable version.
     """
     return text.translate(_translate_table)
 

--- a/rich/control.py
+++ b/rich/control.py
@@ -23,7 +23,7 @@ _CONTROL_STRIP_TRANSLATE: Final = {
     _codepoint: None for _codepoint in STRIP_CONTROL_CODES
 }
 
-_CONTROL_MAKE_READABLE_TRANSLATE: Final = {
+CONTROL_ESCAPE: Final = {
     7: "\\a",
     8: "\\b",
     11: "\\v",
@@ -198,18 +198,18 @@ def strip_control_codes(
     return text.translate(_translate_table)
 
 
-def make_control_codes_readable(
+def escape_control_codes(
     text: str,
-    _translate_table: Dict[int, str] = _CONTROL_MAKE_READABLE_TRANSLATE,
+    _translate_table: Dict[int, str] = CONTROL_ESCAPE,
 ) -> str:
-    """Replace control codes with their "readable" equivalent in the given text.
+    """Replace control codes with their "escaped" equivalent in the given text.
     (e.g. "\b" becomes "\\b")
 
     Args:
-        text (str): A string possibly contain control codes.
+        text (str): A string possibly containing control codes.
 
     Returns:
-        str: String with control codes replaced with a readable version.
+        str: String with control codes replaced with their escaped version.
     """
     return text.translate(_translate_table)
 

--- a/rich/text.py
+++ b/rich/text.py
@@ -2,7 +2,6 @@ import re
 from functools import partial, reduce
 from math import gcd
 from operator import itemgetter
-from rich.emoji import EmojiVariant
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -141,7 +140,8 @@ class Text(JupyterMixin):
         tab_size: Optional[int] = 8,
         spans: Optional[List[Span]] = None,
     ) -> None:
-        self._text = [strip_control_codes(text)]
+        sanitized_text = strip_control_codes(text)
+        self._text = [sanitized_text]
         self.style = style
         self.justify: Optional["JustifyMethod"] = justify
         self.overflow: Optional["OverflowMethod"] = overflow
@@ -149,7 +149,7 @@ class Text(JupyterMixin):
         self.end = end
         self.tab_size = tab_size
         self._spans: List[Span] = spans or []
-        self._length: int = len(text)
+        self._length: int = len(sanitized_text)
 
     def __len__(self) -> int:
         return self._length
@@ -394,9 +394,10 @@ class Text(JupyterMixin):
     def plain(self, new_text: str) -> None:
         """Set the text to a new value."""
         if new_text != self.plain:
-            self._text[:] = [new_text]
+            sanitized_text = strip_control_codes(new_text)
+            self._text[:] = [sanitized_text]
             old_length = self._length
-            self._length = len(new_text)
+            self._length = len(sanitized_text)
             if old_length > self._length:
                 self._trim_spans()
 
@@ -906,10 +907,10 @@ class Text(JupyterMixin):
 
         if len(text):
             if isinstance(text, str):
-                text = strip_control_codes(text)
-                self._text.append(text)
+                sanitized_text = strip_control_codes(text)
+                self._text.append(sanitized_text)
                 offset = len(self)
-                text_length = len(text)
+                text_length = len(sanitized_text)
                 if style is not None:
                     self._spans.append(Span(offset, offset + text_length, style))
                 self._length += text_length

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,4 +1,4 @@
-from rich.control import Control, strip_control_codes
+from rich.control import Control, make_control_codes_readable, strip_control_codes
 from rich.segment import ControlType, Segment
 
 
@@ -11,6 +11,15 @@ def test_strip_control_codes():
     assert strip_control_codes("") == ""
     assert strip_control_codes("foo\rbar") == "foobar"
     assert strip_control_codes("Fear is the mind killer") == "Fear is the mind killer"
+
+
+def test_make_control_codes_readable():
+    assert make_control_codes_readable("") == ""
+    assert make_control_codes_readable("foo\rbar") == "foo\\rbar"
+    assert (
+        make_control_codes_readable("Fear is the mind killer")
+        == "Fear is the mind killer"
+    )
 
 
 def test_control_move_to():

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,4 +1,4 @@
-from rich.control import Control, make_control_codes_readable, strip_control_codes
+from rich.control import Control, escape_control_codes, strip_control_codes
 from rich.segment import ControlType, Segment
 
 
@@ -13,13 +13,10 @@ def test_strip_control_codes():
     assert strip_control_codes("Fear is the mind killer") == "Fear is the mind killer"
 
 
-def test_make_control_codes_readable():
-    assert make_control_codes_readable("") == ""
-    assert make_control_codes_readable("foo\rbar") == "foo\\rbar"
-    assert (
-        make_control_codes_readable("Fear is the mind killer")
-        == "Fear is the mind killer"
-    )
+def test_escape_control_codes():
+    assert escape_control_codes("") == ""
+    assert escape_control_codes("foo\rbar") == "foo\\rbar"
+    assert escape_control_codes("Fear is the mind killer") == "Fear is the mind killer"
 
 
 def test_control_move_to():

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -299,3 +299,41 @@ def test_inspect_module_with_class():
         "╰──────────────────────────────────────────╯\n"
     )
     assert render(module, methods=True) == expected
+
+
+@pytest.mark.parametrize(
+    "special_character,expected_replacement",
+    (
+        ("\a", "\\a"),
+        ("\b", "\\b"),
+        ("\f", "\\f"),
+        ("\r", "\\r"),
+        ("\v", "\\v"),
+    ),
+)
+def test_can_handle_special_characters_in_docstrings(
+    special_character: str, expected_replacement: str
+):
+    class Something:
+        class Thing:
+            pass
+
+    Something.Thing.__doc__ = f"""
+    Multiline docstring
+    with {special_character} should be handled
+    """
+
+    expected = """\
+╭─ <class 'tests.test_inspect.test_can_handle_sp─╮
+│ class test_can_handle_special_characters_in_do │
+│ cstrings.<locals>.Something():                 │
+│                                                │
+│ Thing = class Thing():                         │
+│         Multiline docstring                    │
+│         with %s should be handled              │
+╰────────────────────────────────────────────────╯
+""" % (
+        expected_replacement
+    )
+
+    assert render(Something, methods=True) == expected


### PR DESCRIPTION
## Type of changes

- [x] Bug fix - fixes #2284 
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

:warning: This PR introduces a (minor) breaking change, in order to fix a (minor) issued described with the screenshots below. :point_down: 
But we can of course choose to keep the existing behaviour as-is instead :slightly_smiling_face: 

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate. `(N/A)`
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

As reported [there](https://github.com/Textualize/rich/issues/2284), running this command was making Rich crash:
```py
python3 -c "import pyparsing; from rich import inspect; inspect(pyparsing, methods=True)"
```

It took me a while to understand what was going wrong, as the code from which the exception pops is in `Text.divide(offsets)` which is quite a complex part :exploding_head: 
But in the end I identified the culprits :ninja: : special ASCII characters! (in docstrings)

We were removing them from the content of the textual content of the `Text` class, but when caching the length of this content we were using the length of the non-sanitised text - which causes issues in some cases, as the text we're splitting into several lines doesn't actually have the length we think it has.

### Should we make control characters contained in docstrings visible in the inspection?

I first solved the bug by just making sure the cached length of the text is the one of the sanitised version of it, but then I noticed that the result was looking a bit odd with docstrings that contains such special characters, such as the `WordStart` class of this pyparsing package.

 - When dumped with `inspect` we were ending up with _"To emulate the ```` behavior of regular expressions"_, with 4 backticks in a row without content:
![Screenshot from 2022-05-25 10-56-56](https://user-images.githubusercontent.com/722388/170235974-023b89dc-bcd3-489a-aed7-077da98f36d9.png)

 - That's why I opted for another strategy: replacing these control codes with their "readable" equivalents, so `\b` is displayed as "\b":
![Screenshot from 2022-05-25 10-58-53](https://user-images.githubusercontent.com/722388/170236339-3ddc4c9d-dfb6-47b7-8f19-f5b86dd54882.png)

However, although it's rather unlikely I appreciate that doing such a change in Rich's behaviour could break people's code if they were using some parsing over the result of `rich.inspect` for example.
It depends I guess on whether or not we consider the stripping of control codes in docstrings, when inspecting code, as a feature of a bug? :thinking: 
If it's feature we may rather choose to keep the existing behaviour for the moment, and potentially change it later on with a major version bump, or an opt-in flag somewhere in Rich? :slightly_smiling_face: 

