### PR TITLE
Add support to control pytest test, verbosity and coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
+TEST_KW?=
+VERBOSE?=1
+COVERAGE?=1
+
 test:
-	TERM=unknown pytest --cov-report term-missing --cov=rich tests/ -vv
+	TERM=unknown pytest \
+	$(if $(findstring 1,$(COVERAGE)),--cov-report term-missing --cov=rich) \
+	$(if $(findstring 1,$(VERBOSE)),-vv) \
+	-k $(TEST_KW) \
+	tests/
 format-check:
 	black --check .
 format:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [X] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate. --> I've added it in earlier PR
- [] I've added tests for new code. --> Infra change. No need for added tests
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Added ability to control which tests are executed (all by default), in what verbosity level to run (`-vv` by default), and whether to run code coverage (run coverage by default) when running `make test`.

Example:
```
$ make test VERBOSE=1 COVERAGE=0 TEST_KW=test_highlight_iso8601_regex
```
