### PR TITLE
Turn "basic usage" progress example into a runnable example

### DIFF
--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -19,12 +19,13 @@ To see how the progress display looks, try this from the command line::
 Basic Usage
 -----------
 
-For basic usage call the :func:`~rich.progress.track` function, which accepts a sequence (such as a list or range object) and an optional description of the job you are working on. The track method will yield values from the sequence and update the progress information on each iteration. Here's an example::
+For basic usage call the :func:`~rich.progress.track` function, which accepts a sequence (such as a list or range object) and an optional description of the job you are working on. The track function will yield values from the sequence and update the progress information on each iteration. Here's an example::
 
+    import time
     from rich.progress import track
 
-    for n in track(range(n), description="Processing..."):
-        do_work(n)
+    for i in track(range(20), description="Processing..."):
+        time.sleep(1)  # Simulate work being done
 
 Advanced usage
 --------------


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The basic example for progress was a little confusing and wouldn't run. It now can be copy-pasted and run to demonstrate the feature.