### PR TITLE
[win32] Use initial cursor size when hiding or showing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix Rich clobbering cursor style on Windows https://github.com/Textualize/rich/pull/2339
 - Fix text wrapping edge case https://github.com/Textualize/rich/pull/2296
 - Allow exceptions that are raised while a Live is rendered to be displayed and/or processed https://github.com/Textualize/rich/pull/2305
 - Fix crashes that can happen with `inspect` when docstrings contain some special control codes https://github.com/Textualize/rich/pull/2294


### PR DESCRIPTION
By doing this the users get their original cursor style back when Rich gives control back to the terminal, rather than a "full size" one

Fixes #2333 

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code. _(new code is tested by existing "show/hide cursor" tests 🙂 )_
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

#### Before the fix:

We can see the cursor is no longer the same (converted to a "thick" one) after Rich gives control back to the terminal:

https://user-images.githubusercontent.com/722388/173618989-275d0802-fc29-4830-8c19-e63bd3c9b401.mp4

#### After the fix:

Cursor-after-Rich is well and truly the same than cursor-before-Rich:

https://user-images.githubusercontent.com/722388/173619377-9db1605d-a6fb-4df2-aad4-a50b4b873a69.mp4

(I also tested with Powershell, and the fix looks to work there too :-)
