### PR TITLE
logging render_message: Use message as-is if already Text

### DIFF
--- a/rich/logging.py
+++ b/rich/logging.py
@@ -173,7 +173,10 @@ class RichHandler(Handler):
             ConsoleRenderable: Renderable to display log message.
         """
         use_markup = getattr(record, "markup", self.markup)
-        message_text = Text.from_markup(message) if use_markup else Text(message)
+        if isinstance(message, Text):
+            message_text = message
+        else:
+            message_text = Text.from_markup(message) if use_markup else Text(message)
 
         highlighter = getattr(record, "highlighter", self.highlighter)
         if highlighter:


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

If logging a message that is already rich Text, use it as is. This allows styling your log messages with rich which was required for my [rainbow hexdumps](https://twitter.com/jevinskie/status/1541193014785110018).
