### PR TITLE
🐛 Fix type annotations for `@group` decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix edges used in first row of tables when `show_header=False` https://github.com/Textualize/rich/pull/2330
 - Fix interaction between `Capture` contexts and `Console(record=True)` https://github.com/Textualize/rich/pull/2343
 - Fixed hash issue in Styles class https://github.com/Textualize/rich/pull/2346
+- Fix type annotations for the `@group()` decorator https://github.com/Textualize/rich/pull/2383
 
 ### Changed
 

--- a/rich/console.py
+++ b/rich/console.py
@@ -43,6 +43,11 @@ else:
         runtime_checkable,
     )  # pragma: no cover
 
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec  # pragma: no cover
+
 from . import errors, themes
 from ._emoji_replace import _emoji_replace
 from ._export_format import CONSOLE_HTML_FORMAT, CONSOLE_SVG_FORMAT
@@ -71,6 +76,8 @@ if TYPE_CHECKING:
     from ._windows import WindowsConsoleFeatures
     from .live import Live
     from .status import Status
+
+_FuncParams = ParamSpec("_FuncParams")
 
 JUPYTER_DEFAULT_COLUMNS = 115
 JUPYTER_DEFAULT_LINES = 100
@@ -486,7 +493,11 @@ class Group:
         yield from self.renderables
 
 
-def group(fit: bool = True) -> Callable[..., Callable[..., Group]]:
+def group(
+    fit: bool = True,
+) -> Callable[
+    [Callable[_FuncParams, Iterable[RenderableType]]], Callable[_FuncParams, Group]
+]:
     """A decorator that turns an iterable of renderables in to a group.
 
     Args:
@@ -494,12 +505,12 @@ def group(fit: bool = True) -> Callable[..., Callable[..., Group]]:
     """
 
     def decorator(
-        method: Callable[..., Iterable[RenderableType]]
-    ) -> Callable[..., Group]:
+        method: Callable[_FuncParams, Iterable[RenderableType]]
+    ) -> Callable[_FuncParams, Group]:
         """Convert a method that returns an iterable of renderables in to a Group."""
 
         @wraps(method)
-        def _replace(*args: Any, **kwargs: Any) -> Group:
+        def _replace(*args: _FuncParams.args, **kwargs: _FuncParams.kwargs) -> Group:
             renderables = method(*args, **kwargs)
             return Group(*renderables, fit=fit)
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other (type annotations)

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The current type annotations for `rich.console.group` discard any type information in the original function.

This means that calling the function decorated with `@group()` doesn't get autocompletion nor inline errors for the arguments.

This is how it looks right now, notice that it should be showing an error:

![Selection_167](https://user-images.githubusercontent.com/1326112/178086440-37d3809c-ef10-4283-aaef-6f23e3016b1d.png)

And there's no autocompletion for the function parameters:

![Selection_168](https://user-images.githubusercontent.com/1326112/178086444-b7ef7131-5eb8-434b-a4a3-017dd9f50655.png)

This change fixes the type annotations of the resulting function decorated with `@group()`.

Now it shows errors:

![Selection_169](https://user-images.githubusercontent.com/1326112/178086469-b61a959d-fe8a-41f4-ab58-f96017b7ee04.png)

And it shows autocompletion:

![Selection_170](https://user-images.githubusercontent.com/1326112/178086474-ae7eaf61-d23c-4ffd-a78f-9b18c985814d.png)