### PR TITLE
Add Python 3.11.0-beta4 to CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,10 +35,16 @@ jobs:
         run: |
           source $VENV
           make typecheck
-      - name: Test with pytest
+      - if: ${{ matrix.version }} != '3.11.0-beta.4'
+        name: Test with pytest (with coverage)
         run: |
           source $VENV
           pytest tests -v --cov=./rich --cov-report=xml:./coverage.xml --cov-report term-missing
+      - if: ${{ matrix.version }} == '3.11.0-beta.4'
+        name: Test with pytest (no coverage)
+        run: |
+          source $VENV
+          pytest tests -v
       - name: Upload code coverage
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-beta.4"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,12 +35,12 @@ jobs:
         run: |
           source $VENV
           make typecheck
-      - if: ${{ matrix.version }} != '3.11.0-beta.4'
+      - if: ${{ matrix.python-version }} != '3.11.0-beta.4'
         name: Test with pytest (with coverage)
         run: |
           source $VENV
           pytest tests -v --cov=./rich --cov-report=xml:./coverage.xml --cov-report term-missing
-      - if: ${{ matrix.version }} == '3.11.0-beta.4'
+      - if: ${{ matrix.python-version }} == '3.11.0-beta.4'
         name: Test with pytest (no coverage)
         run: |
           source $VENV

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,13 +35,13 @@ jobs:
         run: |
           source $VENV
           make typecheck
-      - if: ${{ matrix.python-version }} != '3.11.0-beta.4'
-        name: Test with pytest (with coverage)
+      - name: Test with pytest (with coverage)
+        if: matrix.python-version != '3.11.0-beta.4'
         run: |
           source $VENV
           pytest tests -v --cov=./rich --cov-report=xml:./coverage.xml --cov-report term-missing
-      - if: ${{ matrix.python-version }} == '3.11.0-beta.4'
-        name: Test with pytest (no coverage)
+      - name: Test with pytest (no coverage)
+        if: matrix.python-version == '3.11.0-beta.4'
         run: |
           source $VENV
           pytest tests -v

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 test:
 	TERM=unknown pytest --cov-report term-missing --cov=rich tests/ -vv
+test-no-cov:
+	TERM=unknown pytest tests/ -vv
 format-check:
 	black --check .
 format:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Typing :: Typed",
 ]
 include = ["rich/py.typed"]

--- a/rich/color.py
+++ b/rich/color.py
@@ -29,6 +29,9 @@ class ColorSystem(IntEnum):
     def __repr__(self) -> str:
         return f"ColorSystem.{self.name}"
 
+    def __str__(self) -> str:
+        return repr(self)
+
 
 class ColorType(IntEnum):
     """Type of color stored in Color class."""

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -38,6 +38,11 @@ skip_py310 = pytest.mark.skipif(
     reason="rendered differently on py3.10",
 )
 
+skip_py311 = pytest.mark.skipif(
+    sys.version_info.minor == 11 and sys.version_info.major == 3,
+    reason="rendered differently on py3.11",
+)
+
 skip_pypy3 = pytest.mark.skipif(
     hasattr(sys, "pypy_version_info"),
     reason="rendered differently on pypy3",
@@ -93,7 +98,7 @@ def test_render():
     result = console.file.getvalue()
     print(repr(result))
     expected = "╭────────────── <class 'tests.test_inspect.Foo'> ──────────────╮\n│ Foo test                                                     │\n│                                                              │\n│   broken = InspectError()                                    │\n│ __init__ = def __init__(foo: int) -> None: constructor docs. │\n│   method = def method(a, b) -> str: Multi line               │\n╰──────────────────────────────────────────────────────────────╯\n"
-    assert expected == result
+    assert result == expected
 
 
 @skip_pypy3
@@ -110,7 +115,7 @@ def test_inspect_text():
         "╰────────────────────────────────────────────────╯\n"
     )
     print(repr(expected))
-    assert expected == render("Hello")
+    assert render("Hello") == expected
 
 
 @skip_py36
@@ -137,8 +142,10 @@ def test_inspect_empty_dict():
     assert render({}).startswith(expected)
 
 
+@skip_py311
 @skip_pypy3
-def test_inspect_builtin_function():
+def test_inspect_builtin_function_except_python311():
+    # Pre-3.11 Python versions - print builtin has no signature available
     expected = (
         "╭────────── <built-in function print> ───────────╮\n"
         "│ def print(...)                                 │\n"
@@ -150,7 +157,28 @@ def test_inspect_builtin_function():
         "│ inspect(inspect) for options.                  │\n"
         "╰────────────────────────────────────────────────╯\n"
     )
-    assert expected == render(print)
+    assert render(print) == expected
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="print builtin signature only available on 3.11+"
+)
+@skip_pypy3
+def test_inspect_builtin_function_only_python311():
+    # On 3.11, the print builtin *does* have a signature, unlike in prior versions
+    expected = (
+        "╭────────── <built-in function print> ───────────╮\n"
+        "│ def print(*args, sep=' ', end='\\n', file=None, │\n"
+        "│ flush=False):                                  │\n"
+        "│                                                │\n"
+        "│ Prints the values to a stream, or to           │\n"
+        "│ sys.stdout by default.                         │\n"
+        "│                                                │\n"
+        "│ 30 attribute(s) not shown. Run                 │\n"
+        "│ inspect(inspect) for options.                  │\n"
+        "╰────────────────────────────────────────────────╯\n"
+    )
+    assert render(print) == expected
 
 
 @skip_pypy3
@@ -187,13 +215,14 @@ def test_inspect_integer_with_value():
     expected = "╭────── <class 'int'> ───────╮\n│ int([x]) -> integer        │\n│ int(x, base=10) -> integer │\n│                            │\n│ ╭────────────────────────╮ │\n│ │ 1                      │ │\n│ ╰────────────────────────╯ │\n│                            │\n│ denominator = 1            │\n│        imag = 0            │\n│   numerator = 1            │\n│        real = 1            │\n╰────────────────────────────╯\n"
     value = render(1, value=True)
     print(repr(value))
-    assert expected == value
+    assert value == expected
 
 
 @skip_py36
 @skip_py37
 @skip_py310
-def test_inspect_integer_with_methods():
+@skip_py311
+def test_inspect_integer_with_methods_python38_and_python39():
     expected = (
         "╭──────────────── <class 'int'> ─────────────────╮\n"
         "│ int([x]) -> integer                            │\n"
@@ -223,14 +252,15 @@ def test_inspect_integer_with_methods():
         "│                    an integer.                 │\n"
         "╰────────────────────────────────────────────────╯\n"
     )
-    assert expected == render(1, methods=True)
+    assert render(1, methods=True) == expected
 
 
 @skip_py36
 @skip_py37
 @skip_py38
 @skip_py39
-def test_inspect_integer_with_methods():
+@skip_py311
+def test_inspect_integer_with_methods_python310only():
     expected = (
         "╭──────────────── <class 'int'> ─────────────────╮\n"
         "│ int([x]) -> integer                            │\n"
@@ -264,7 +294,51 @@ def test_inspect_integer_with_methods():
         "│                    an integer.                 │\n"
         "╰────────────────────────────────────────────────╯\n"
     )
-    assert expected == render(1, methods=True)
+    assert render(1, methods=True) == expected
+
+
+@skip_py36
+@skip_py37
+@skip_py38
+@skip_py39
+@skip_py310
+def test_inspect_integer_with_methods_python311_and_above():
+    # to_bytes and from_bytes methods on int had minor signature change -
+    # they now, as of 3.11, have default values for all of their parameters
+    expected = (
+        "╭──────────────── <class 'int'> ─────────────────╮\n"
+        "│ int([x]) -> integer                            │\n"
+        "│ int(x, base=10) -> integer                     │\n"
+        "│                                                │\n"
+        "│      denominator = 1                           │\n"
+        "│             imag = 0                           │\n"
+        "│        numerator = 1                           │\n"
+        "│             real = 1                           │\n"
+        "│ as_integer_ratio = def as_integer_ratio():     │\n"
+        "│                    Return integer ratio.       │\n"
+        "│        bit_count = def bit_count(): Number of  │\n"
+        "│                    ones in the binary          │\n"
+        "│                    representation of the       │\n"
+        "│                    absolute value of self.     │\n"
+        "│       bit_length = def bit_length(): Number of │\n"
+        "│                    bits necessary to represent │\n"
+        "│                    self in binary.             │\n"
+        "│        conjugate = def conjugate(...) Returns  │\n"
+        "│                    self, the complex conjugate │\n"
+        "│                    of any int.                 │\n"
+        "│       from_bytes = def from_bytes(bytes,       │\n"
+        "│                    byteorder='big', *,         │\n"
+        "│                    signed=False): Return the   │\n"
+        "│                    integer represented by the  │\n"
+        "│                    given array of bytes.       │\n"
+        "│         to_bytes = def to_bytes(length=1,      │\n"
+        "│                    byteorder='big', *,         │\n"
+        "│                    signed=False): Return an    │\n"
+        "│                    array of bytes representing │\n"
+        "│                    an integer.                 │\n"
+        "╰────────────────────────────────────────────────╯\n"
+    )
+    assert render(1, methods=True) == expected
 
 
 @skip_py36
@@ -388,8 +462,10 @@ def test_object_types_mro(obj: object, expected_result: Sequence[Type]):
         [str, ["builtins.str", "builtins.object"]],
         [Foo(1), [f"{__name__}.Foo", "builtins.object"]],
         [Foo, [f"{__name__}.Foo", "builtins.object"]],
-        [FooSubclass(1), [f"{__name__}.FooSubclass", f"{__name__}.Foo", "builtins.object"]],
-        [FooSubclass, [f"{__name__}.FooSubclass", f"{__name__}.Foo", "builtins.object"]],
+        [FooSubclass(1),
+         [f"{__name__}.FooSubclass", f"{__name__}.Foo", "builtins.object"]],
+        [FooSubclass,
+         [f"{__name__}.FooSubclass", f"{__name__}.Foo", "builtins.object"]],
         # fmt: on
     ),
 )

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -98,13 +98,14 @@ def test_render():
 
 @skip_pypy3
 def test_inspect_text():
+    num_attributes = 34 if sys.version_info >= (3, 11) else 33
     expected = (
         "╭──────────────── <class 'str'> ─────────────────╮\n"
         "│ str(object='') -> str                          │\n"
         "│ str(bytes_or_buffer[, encoding[, errors]]) ->  │\n"
         "│ str                                            │\n"
         "│                                                │\n"
-        "│ 33 attribute(s) not shown. Run                 │\n"
+        f"│ {num_attributes} attribute(s) not shown. Run                 │\n"
         "│ inspect(inspect) for options.                  │\n"
         "╰────────────────────────────────────────────────╯\n"
     )

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -36,6 +36,10 @@ skip_py310 = pytest.mark.skipif(
     sys.version_info.minor == 10 and sys.version_info.major == 3,
     reason="rendered differently on py3.10",
 )
+skip_py311 = pytest.mark.skipif(
+    sys.version_info.minor == 11 and sys.version_info.major == 3,
+    reason="rendered differently on py3.11",
+)
 
 
 def test_install():
@@ -493,6 +497,7 @@ def test_attrs_empty():
 
 @skip_py36
 @skip_py310
+@skip_py311
 def test_attrs_broken():
     @attr.define
     class Foo:


### PR DESCRIPTION
* Tests Rich against Python 3.11.0-beta4
* There are issues with `pytest-cov` on 3.11 only. I'm going to minimally reproduce them and, if I can, report it to the pytest team. For now, coverage doesn't run on 3.11, but will continue to run on other versions.
* There were 5 test failures that have been resolved.