### PR TITLE
Provide `exclude_locals` mechanism to exclude certain regex patterns from Traceback output 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `inspect` will prefix coroutine functions with `async def`
 - `Style.__add__` will no longer return `NotImplemented`
 - Remove rich.\_lru_cache
-- Ability to 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added the ability to exclude certain variables from the `show_locals=True` Traceback output via the `exclude_locals=("regex*")` parameter.
+
 ## [12.5.1] - 2022-07-11
 
 ### Fixed
@@ -20,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `inspect` will prefix coroutine functions with `async def`
 - `Style.__add__` will no longer return `NotImplemented`
 - Remove rich.\_lru_cache
+- Ability to 
 
 ### Changed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,3 +48,4 @@ The following people have contributed to the development of Rich:
 - [za](https://github.com/za)
 - [Motahhar Mokfi](https://github.com/motahhar)
 - [Tomer Shalev](https://github.com/tomers)
+- [Joel Schwarzmann](https://github.com/datajoely/)

--- a/docs/source/traceback.rst
+++ b/docs/source/traceback.rst
@@ -96,12 +96,21 @@ Here's an example of printing a recursive error::
     except Exception:
         console.print_exception(max_frames=20)
 
-Excluding locals
+Mask locals
 ----------------
 
-Exclude certain local variables by providing regular expressions to the ``exclude_locals`` parameter. The expressions will be applied to all variable names and their string content.
+Mask certain local variables by providing regular expressions to the ``mask_locals`` parameter. The expressions will be applied to all variable names and their string content.
 
 Add the following code to the file::
 
     from rich.traceback import install
-    install(show_locals=True, exclude_locals=('password.*'))
+    install(show_locals=True, mask_locals=('password.*'))
+
+This will produce output that looks as follows:
+
+.. raw:: text
+    ╭────────────────────── locals ──────────────────────╮
+    │         password = <redacted variable name>        │
+    │          my_list = [1, 2, 3]                       │
+    │ credentials_dict = <redacted variable content>     │
+    ╰────────────────────────────────────────────────────╯

--- a/docs/source/traceback.rst
+++ b/docs/source/traceback.rst
@@ -96,3 +96,12 @@ Here's an example of printing a recursive error::
     except Exception:
         console.print_exception(max_frames=20)
 
+Excluding locals
+----------------
+
+Exclude certain local variables by providing regular expressions to the ``exclude_locals`` parameter. The expressions will be applied to all variable names and their string content.
+
+Add the following code to the file::
+
+    from rich.traceback import install
+    install(show_locals=True, exclude_locals=('password.*'))

--- a/rich/console.py
+++ b/rich/console.py
@@ -1816,7 +1816,7 @@ class Console:
         theme: Optional[str] = None,
         word_wrap: bool = False,
         show_locals: bool = False,
-        exclude_locals: Optional[Tuple[str]] = None,
+        mask_locals: Optional[Iterable[str]] = None,
         suppress: Iterable[Union[str, ModuleType]] = (),
         max_frames: int = 100,
     ) -> None:
@@ -1828,7 +1828,7 @@ class Console:
             theme (str, optional): Override pygments theme used in traceback
             word_wrap (bool, optional): Enable word wrapping of long lines. Defaults to False.
             show_locals (bool, optional): Enable display of local variables. Defaults to False.
-            exclude_locals (Optional[Tuple[str]], optional): List patterns to exclude from local variables output.
+            mask_locals (Optional[Iterable[str]], optional): List patterns to mask from local variables output.
                 Defaults to None.
             suppress (Iterable[Union[str, ModuleType]]): Optional sequence of modules or paths to exclude from traceback.
             max_frames (int): Maximum number of frames to show in a traceback, 0 for no maximum. Defaults to 100.
@@ -1841,7 +1841,7 @@ class Console:
             theme=theme,
             word_wrap=word_wrap,
             show_locals=show_locals,
-            exclude_locals=exclude_locals,
+            mask_locals=mask_locals,
             suppress=suppress,
             max_frames=max_frames,
         )

--- a/rich/console.py
+++ b/rich/console.py
@@ -1816,6 +1816,7 @@ class Console:
         theme: Optional[str] = None,
         word_wrap: bool = False,
         show_locals: bool = False,
+        exclude_locals: Optional[Tuple[str]] = None,
         suppress: Iterable[Union[str, ModuleType]] = (),
         max_frames: int = 100,
     ) -> None:
@@ -1827,6 +1828,8 @@ class Console:
             theme (str, optional): Override pygments theme used in traceback
             word_wrap (bool, optional): Enable word wrapping of long lines. Defaults to False.
             show_locals (bool, optional): Enable display of local variables. Defaults to False.
+            exclude_locals (Optional[Tuple[str]], optional): List patterns to exclude from local variables output.
+                Defaults to None.
             suppress (Iterable[Union[str, ModuleType]]): Optional sequence of modules or paths to exclude from traceback.
             max_frames (int): Maximum number of frames to show in a traceback, 0 for no maximum. Defaults to 100.
         """
@@ -1838,6 +1841,7 @@ class Console:
             theme=theme,
             word_wrap=word_wrap,
             show_locals=show_locals,
+            exclude_locals=exclude_locals,
             suppress=suppress,
             max_frames=max_frames,
         )

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -139,6 +139,26 @@ def test_print_exception_locals():
     assert "console = <console width=100 None>" in exception_text
 
 
+def test_print_exception_locals_exclude():
+    console = Console(width=100, file=io.StringIO())
+    my_dict = {"key_1": "a", "illegal_value": "b", "key_3": "c"}
+    my_list = [1, 2, 3]
+    my_nested_dict = {1: "a", 2: "b", 3: {"credentials": {"test": "some thing"}}}
+    try:
+        1 / 0
+    except Exception:
+        console.print_exception(
+            show_locals=True, exclude_locals=("cred.+", "illegal_value")
+        )
+    exception_text = console.file.getvalue()
+    locals_exception_text = exception_text.split("─── locals ──")[1]
+
+    assert "console = " in locals_exception_text
+    assert "my_dict = " not in locals_exception_text
+    assert "my_list = " in locals_exception_text
+    assert "my_nested_dict =" not in locals_exception_text
+
+
 def test_syntax_error():
     console = Console(width=100, file=io.StringIO())
     try:

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -141,22 +141,24 @@ def test_print_exception_locals():
 
 def test_print_exception_locals_exclude():
     console = Console(width=100, file=io.StringIO())
-    my_dict = {"key_1": "a", "key_2": "illegal_value", "key_3": "c"}
+    my_dict = {"key_1": "a", "key_2": "illegal_name", "key_3": "c"}
     my_list = [1, 2, 3]
+    credentials = "test"
     my_nested_dict = {1: "a", 2: "b", 3: {"credentials": {"test": "some thing"}}}
+    illegal_name = {"credentials"}
     try:
         1 / 0
     except Exception:
-        console.print_exception(
-            show_locals=True, exclude_locals=("cred.+", "illegal_value")
-        )
+        console.print_exception(show_locals=True, mask_locals=(r"cred.+", r"illegal_"))
     exception_text = console.file.getvalue()
     locals_exception_text = exception_text.split("─── locals ──")[1]
 
-    assert "console = " in locals_exception_text
-    assert "my_dict = " not in locals_exception_text
-    assert "my_list = " in locals_exception_text
-    assert "my_nested_dict =" not in locals_exception_text
+    assert "console = <console width=100 None>" in locals_exception_text
+    assert "credentials = <redacted variable name>" in locals_exception_text
+    assert "my_dict = <redacted variable content>" in locals_exception_text
+    assert "my_list = [1, 2, 3]" in locals_exception_text
+    assert "my_nested_dict = <redacted variable content>" in locals_exception_text
+    assert "illegal_name = <redacted variable name, content>" in locals_exception_text
 
 
 def test_syntax_error():

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -141,7 +141,7 @@ def test_print_exception_locals():
 
 def test_print_exception_locals_exclude():
     console = Console(width=100, file=io.StringIO())
-    my_dict = {"key_1": "a", "illegal_value": "b", "key_3": "c"}
+    my_dict = {"key_1": "a", "key_2": "illegal_value", "key_3": "c"}
     my_list = [1, 2, 3]
     my_nested_dict = {1: "a", 2: "b", 3: {"credentials": {"test": "some thing"}}}
     try:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [x] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Provide `exclude_locals` mechanism to exclude certain regex patterns from Traceback output. Refers to #2408 .
