### PR TITLE
Add missing `Args:` to docstring

### DIFF
--- a/rich/logging.py
+++ b/rich/logging.py
@@ -166,8 +166,9 @@ class RichHandler(Handler):
     def render_message(self, record: LogRecord, message: str) -> "ConsoleRenderable":
         """Render message text in to Text.
 
-        record (LogRecord): logging Record.
-        message (str): String containing log message.
+        Args:
+            record (LogRecord): logging Record.
+            message (str): String containing log message.
 
         Returns:
             ConsoleRenderable: Renderable to display log message.


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Add `Args:` to docstring of `render_message` so that https://rich.readthedocs.io/en/stable/reference/logging.html#rich.logging.RichHandler.render_message looks nice.