### PR TITLE
Detect Databricks as Jupyter environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed missing typing extensions dependency on 3.9 https://github.com/Textualize/rich/issues/2386
+- Fixed Databricks Notebook is not detected as Jupyter environment. https://github.com/Textualize/rich/issues/2422
 
 ## [12.5.0] - 2022-07-11
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@ The following people have contributed to the development of Rich:
 - [Oleksis Fraga](https://github.com/oleksis)
 - [Andy Gimblett](https://github.com/gimbo)
 - [Michał Górny](https://github.com/mgorny)
+- [Nok Lam Chan](https://github.com/noklam)
 - [Leron Gray](https://github.com/daddycocoaman)
 - [Kenneth Hoste](https://github.com/boegel)
 - [Lanqing Huang](https://github.com/lqhuang)

--- a/rich/console.py
+++ b/rich/console.py
@@ -516,7 +516,11 @@ def _is_jupyter() -> bool:  # pragma: no cover
         return False
     ipython = get_ipython()  # type: ignore[name-defined]
     shell = ipython.__class__.__name__
-    if "google.colab" in str(ipython.__class__) or shell == "ZMQInteractiveShell":
+    if (
+        "google.colab" in str(ipython.__class__)
+        or os.getenv("DATABRICKS_ROOT_VIRTUALENV_ENV")
+        or shell == "ZMQInteractiveShell"
+    ):
         return True  # Jupyter notebook or qtconsole
     elif shell == "TerminalInteractiveShell":
         return False  # Terminal running IPython

--- a/rich/console.py
+++ b/rich/console.py
@@ -518,7 +518,7 @@ def _is_jupyter() -> bool:  # pragma: no cover
     shell = ipython.__class__.__name__
     if (
         "google.colab" in str(ipython.__class__)
-        or os.getenv("DATABRICKS_ROOT_VIRTUALENV_ENV")
+        or os.getenv("DATABRICKS_RUNTIME_VERSION")
         or shell == "ZMQInteractiveShell"
     ):
         return True  # Jupyter notebook or qtconsole


### PR DESCRIPTION
## Type of changes
Detect Databricks as Jupyter environment, although it is kind of a weird breed of Jupyter Notebook. This should make `JUPYTER_LINES` and `JUPYTER_COLUMNS` configurations useful for Databricks

- [x] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
Added a condition to check for Databricks environment variable. Fix #2422 