### PR TITLE
Prompt messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+
+- Adds the ability for users to easily modify the error messages for a prompt.
+
 ## [12.5.2] - 2022-07-18
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@ The following people have contributed to the development of Rich:
 - [Darren Burns](https://github.com/darrenburns)
 - [Ed Davis](https://github.com/davised)
 - [Pete Davison](https://github.com/pd93)
+- [Steven Elliott](https://github.com/sdelliot)
 - [James Estevez](https://github.com/jstvz)
 - [Oleksis Fraga](https://github.com/oleksis)
 - [Andy Gimblett](https://github.com/gimbo)

--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -38,6 +38,10 @@ class PromptBase(Generic[PromptType]):
         choices (List[str], optional): A list of valid choices. Defaults to None.
         show_default (bool, optional): Show default in prompt. Defaults to True.
         show_choices (bool, optional): Show choices in prompt. Defaults to True.
+        validate_error_message (str, optional): Message to user upon an invalid input.
+            Defaults to "[prompt.invalid]Please enter a valid value".
+        illegal_choice_message (str, optional): Message to user upon them not selecting a valid choice.
+            Defaults to "[prompt.invalid.choice]Please select one of the available options".
     """
 
     response_type: type = str
@@ -59,7 +63,11 @@ class PromptBase(Generic[PromptType]):
         choices: Optional[List[str]] = None,
         show_default: bool = True,
         show_choices: bool = True,
+        validate_error_message: Optional[str] = None,
+        illegal_choice_message: Optional[str] = None,
     ) -> None:
+        if validate_error_message is not None:
+            self.validate_error_message = validate_error_message
         self.console = console or get_console()
         self.prompt = (
             Text.from_markup(prompt, style="prompt")
@@ -69,6 +77,8 @@ class PromptBase(Generic[PromptType]):
         self.password = password
         if choices is not None:
             self.choices = choices
+            if illegal_choice_message is not None:
+                self.illegal_choice_message = illegal_choice_message
         self.show_default = show_default
         self.show_choices = show_choices
 
@@ -85,6 +95,8 @@ class PromptBase(Generic[PromptType]):
         show_choices: bool = True,
         default: DefaultType,
         stream: Optional[TextIO] = None,
+        validate_error_message: Optional[str] = None,
+        illegal_choice_message: Optional[str] = None,
     ) -> Union[DefaultType, PromptType]:
         ...
 
@@ -100,6 +112,8 @@ class PromptBase(Generic[PromptType]):
         show_default: bool = True,
         show_choices: bool = True,
         stream: Optional[TextIO] = None,
+        validate_error_message: Optional[str] = None,
+        illegal_choice_message: Optional[str] = None,
     ) -> PromptType:
         ...
 
@@ -115,6 +129,8 @@ class PromptBase(Generic[PromptType]):
         show_choices: bool = True,
         default: Any = ...,
         stream: Optional[TextIO] = None,
+        validate_error_message: Optional[str] = None,
+        illegal_choice_message: Optional[str] = None,
     ) -> Any:
         """Shortcut to construct and run a prompt loop and return the result.
 
@@ -129,6 +145,10 @@ class PromptBase(Generic[PromptType]):
             show_default (bool, optional): Show default in prompt. Defaults to True.
             show_choices (bool, optional): Show choices in prompt. Defaults to True.
             stream (TextIO, optional): Optional text file open for reading to get input. Defaults to None.
+            validate_error_message (str, optional): Message to user upon an invalid input.
+                Defaults to "[prompt.invalid]Please enter a valid value".
+            illegal_choice_message (str, optional): Message to user upon them not selecting a valid choice.
+                Defaults to "[prompt.invalid.choice]Please select one of the available options".
         """
         _prompt = cls(
             prompt,
@@ -137,6 +157,8 @@ class PromptBase(Generic[PromptType]):
             choices=choices,
             show_default=show_default,
             show_choices=show_choices,
+            validate_error_message=validate_error_message,
+            illegal_choice_message=illegal_choice_message,
         )
         return _prompt(default=default, stream=stream)
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -93,3 +93,36 @@ def test_prompt_confirm_default():
     output = console.file.getvalue()
     print(repr(output))
     assert output == expected
+
+
+def test_prompt_illegal_choice_message():
+    INPUT = "egg\nfoo"
+    console = Console(file=io.StringIO())
+    name = Prompt.ask(
+        "what is your name",
+        console=console,
+        choices=["foo", "bar"],
+        stream=io.StringIO(INPUT),
+        illegal_choice_message="Only select `foo` or `bar`",
+    )
+    assert name == "foo"
+    expected = "what is your name [foo/bar]: Only select `foo` or `bar`\nwhat is your name [foo/bar]: "
+    output = console.file.getvalue()
+    print(repr(output))
+    assert output == expected
+
+
+def test_prompt_validate_error_message():
+    INPUT = "foo\ny"
+    console = Console(file=io.StringIO())
+    answer = Confirm.ask(
+        "continue",
+        console=console,
+        stream=io.StringIO(INPUT),
+        validate_error_message="Entered an invalid choice, try again",
+    )
+    assert answer is True
+    expected = "continue [y/n]: Entered an invalid choice, try again\ncontinue [y/n]: "
+    output = console.file.getvalue()
+    print(repr(output))
+    assert output == expected


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This adds the ability for users to easily modify the error messages (i.e. `validate_error_message` and `illegal_choice_message`) for a Prompt without creating a new class.
