### PR TITLE
Add Console.build_svg() function to get SVG and its size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.5.3] - 2022-08-04
+
+### Added
+
+- New `Console.build_svg()` to get SVG code and its size, https://github.com/Textualize/rich/issues/2431
+
 ## [12.5.2] - 2022-07-18
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,7 @@ The following people have contributed to the development of Rich:
 - [Clément Robert](https://github.com/neutrinoceros)
 - [Brian Rutledge](https://github.com/bhrutledge)
 - [Tushar Sadhwani](https://github.com/tusharsadhwani)
+- [Jose Salvatierra](https://github.com/jslvtr)
 - [Paul Sanders](https://github.com/sanders41)
 - [Tim Savage](https://github.com/timsavage)
 - [Anthony Shaw](https://github.com/tonybaloney)

--- a/rich/console.py
+++ b/rich/console.py
@@ -2231,25 +2231,27 @@ class Console:
         with open(path, "wt", encoding="utf-8") as write_file:
             write_file.write(html)
 
-    def export_svg(
+    def build_svg(
         self,
         *,
         title: str = "Rich",
         theme: Optional[TerminalTheme] = None,
         clear: bool = True,
         code_format: str = CONSOLE_SVG_FORMAT,
-    ) -> str:
+    ) -> Tuple[str, int, int]:
         """
         Generate an SVG from the console contents (requires record=True in Console constructor).
 
         Args:
-            path (str): The path to write the SVG to.
             title (str): The title of the tab in the output image
             theme (TerminalTheme, optional): The ``TerminalTheme`` object to use to style the terminal
             clear (bool, optional): Clear record buffer after exporting. Defaults to ``True``
             code_format (str): Format string used to generate the SVG. Rich will inject a number of variables
                 into the string in order to form the final SVG output. The default template used and the variables
                 injected by Rich can be found by inspecting the ``console.CONSOLE_SVG_FORMAT`` variable.
+
+        Returns:
+            Tuple[str, int, int]: the SVG code, the width of the SVG, and the height of the SVG
         """
 
         from rich.cells import cell_len
@@ -2455,6 +2457,9 @@ class Console:
             </g>
         """
 
+        svg_width = terminal_width + margin_width
+        svg_height = terminal_height + margin_height
+
         svg = code_format.format(
             unique_id=unique_id,
             char_width=char_width,
@@ -2462,8 +2467,8 @@ class Console:
             line_height=line_height,
             terminal_width=char_width * width - 1,
             terminal_height=(y + 1) * line_height - 1,
-            width=terminal_width + margin_width,
-            height=terminal_height + margin_height,
+            width=svg_width,
+            height=svg_height,
             terminal_x=margin_left + padding_left,
             terminal_y=margin_top + padding_top,
             styles=styles,
@@ -2471,6 +2476,33 @@ class Console:
             backgrounds=backgrounds,
             matrix=matrix,
             lines=lines,
+        )
+        return svg, svg_width, svg_height
+
+    def export_svg(
+        self,
+        *,
+        title: str = "Rich",
+        theme: Optional[TerminalTheme] = None,
+        clear: bool = True,
+        code_format: str = CONSOLE_SVG_FORMAT,
+    ) -> str:
+        """
+        Generate an SVG from the console contents (requires record=True in Console constructor).
+
+        Args:
+            title (str): The title of the tab in the output image
+            theme (TerminalTheme, optional): The ``TerminalTheme`` object to use to style the terminal
+            clear (bool, optional): Clear record buffer after exporting. Defaults to ``True``
+            code_format (str): Format string used to generate the SVG. Rich will inject a number of variables
+                into the string in order to form the final SVG output. The default template used and the variables
+                injected by Rich can be found by inspecting the ``console.CONSOLE_SVG_FORMAT`` variable.
+
+        Returns:
+            str: The SVG code
+        """
+        svg, _, _ = self.build_svg(
+            title=title, theme=theme, clear=clear, code_format=code_format
         )
         return svg
 

--- a/rich/console.py
+++ b/rich/console.py
@@ -2236,7 +2236,7 @@ class Console:
         *,
         title: str = "Rich",
         theme: Optional[TerminalTheme] = None,
-        clear: bool = True,
+        clear: bool = False,
         code_format: str = CONSOLE_SVG_FORMAT,
     ) -> Tuple[str, int, int]:
         """
@@ -2245,7 +2245,7 @@ class Console:
         Args:
             title (str): The title of the tab in the output image
             theme (TerminalTheme, optional): The ``TerminalTheme`` object to use to style the terminal
-            clear (bool, optional): Clear record buffer after exporting. Defaults to ``True``
+            clear (bool, optional): Clear record buffer after exporting. Defaults to ``False``
             code_format (str): Format string used to generate the SVG. Rich will inject a number of variables
                 into the string in order to form the final SVG output. The default template used and the variables
                 injected by Rich can be found by inspecting the ``console.CONSOLE_SVG_FORMAT`` variable.

--- a/rich/console.py
+++ b/rich/console.py
@@ -2236,7 +2236,7 @@ class Console:
         *,
         title: str = "Rich",
         theme: Optional[TerminalTheme] = None,
-        clear: bool = False,
+        clear: bool = True,
         code_format: str = CONSOLE_SVG_FORMAT,
     ) -> Tuple[str, int, int]:
         """
@@ -2245,7 +2245,7 @@ class Console:
         Args:
             title (str): The title of the tab in the output image
             theme (TerminalTheme, optional): The ``TerminalTheme`` object to use to style the terminal
-            clear (bool, optional): Clear record buffer after exporting. Defaults to ``False``
+            clear (bool, optional): Clear record buffer after exporting. Defaults to ``True``
             code_format (str): Format string used to generate the SVG. Rich will inject a number of variables
                 into the string in order to form the final SVG output. The default template used and the variables
                 injected by Rich can be found by inspecting the ``console.CONSOLE_SVG_FORMAT`` variable.

--- a/rich/console.py
+++ b/rich/console.py
@@ -2238,7 +2238,7 @@ class Console:
         theme: Optional[TerminalTheme] = None,
         clear: bool = True,
         code_format: str = CONSOLE_SVG_FORMAT,
-    ) -> Tuple[str, int, int]:
+    ) -> Tuple[str, float, float]:
         """
         Generate an SVG from the console contents (requires record=True in Console constructor).
 
@@ -2251,7 +2251,7 @@ class Console:
                 injected by Rich can be found by inspecting the ``console.CONSOLE_SVG_FORMAT`` variable.
 
         Returns:
-            Tuple[str, int, int]: the SVG code, the width of the SVG, and the height of the SVG
+            Tuple[str, float, float]: the SVG code, the width of the SVG, and the height of the SVG
         """
 
         from rich.cells import cell_len

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -514,11 +514,36 @@ def test_export_html_inline():
 EXPECTED_SVG = '<svg class="rich-terminal" viewBox="0 0 1238 74.4" xmlns="http://www.w3.org/2000/svg">\n    <!-- Generated with Rich https://www.textualize.io -->\n    <style>\n\n    @font-face {\n        font-family: "Fira Code";\n        src: local("FiraCode-Regular"),\n                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),\n                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");\n        font-style: normal;\n        font-weight: 400;\n    }\n    @font-face {\n        font-family: "Fira Code";\n        src: local("FiraCode-Bold"),\n                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),\n                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");\n        font-style: bold;\n        font-weight: 700;\n    }\n\n    .terminal-614794459-matrix {\n        font-family: Fira Code, monospace;\n        font-size: 20px;\n        line-height: 24.4px;\n        font-variant-east-asian: full-width;\n    }\n\n    .terminal-614794459-title {\n        font-size: 18px;\n        font-weight: bold;\n        font-family: arial;\n    }\n\n    .terminal-614794459-r1 { fill: #608ab1;font-weight: bold }\n.terminal-614794459-r2 { fill: #c5c8c6 }\n    </style>\n\n    <defs>\n    <clipPath id="terminal-614794459-clip-terminal">\n      <rect x="0" y="0" width="1219.0" height="23.4" />\n    </clipPath>\n    \n    </defs>\n\n    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1236" height="72.4" rx="8"/><text class="terminal-614794459-title" fill="#c5c8c6" text-anchor="middle" x="618" y="27">Rich</text>\n            <g transform="translate(26,22)">\n            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>\n            <circle cx="22" cy="0" r="7" fill="#febc2e"/>\n            <circle cx="44" cy="0" r="7" fill="#28c840"/>\n            </g>\n        \n    <g transform="translate(9, 41)" clip-path="url(#terminal-614794459-clip-terminal)">\n    <rect fill="#cc555a" x="0" y="1.5" width="36.6" height="24.65" shape-rendering="crispEdges"/>\n    <g class="terminal-614794459-matrix">\n    <text class="terminal-614794459-r1" x="0" y="20" textLength="36.6" clip-path="url(#terminal-614794459-line-0)">foo</text><text class="terminal-614794459-r2" x="48.8" y="20" textLength="61" clip-path="url(#terminal-614794459-line-0)">Click</text><text class="terminal-614794459-r2" x="1220" y="20" textLength="12.2" clip-path="url(#terminal-614794459-line-0)">\n</text>\n    </g>\n    </g>\n</svg>\n'
 
 
+def test_build_svg():
+    console = Console(record=True, width=100)
+    console.print(
+        "[b red on blue reverse]foo[/] [blink][link=https://example.org]Click[/link]"
+    )
+    svg, width, height = console.build_svg()
+    print(repr(svg))
+
+    assert svg == EXPECTED_SVG
+    assert width == 1238
+    assert height == 74.4
+
+
 def test_export_svg():
     console = Console(record=True, width=100)
     console.print(
         "[b red on blue reverse]foo[/] [blink][link=https://example.org]Click[/link]"
     )
+    svg = console.export_svg()
+    print(repr(svg))
+
+    assert svg == EXPECTED_SVG
+
+
+def test_build_then_export():
+    console = Console(record=True, width=100)
+    console.print(
+        "[b red on blue reverse]foo[/] [blink][link=https://example.org]Click[/link]"
+    )
+    svg, _, _ = console.build_svg()
     svg = console.export_svg()
     print(repr(svg))
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -538,18 +538,6 @@ def test_export_svg():
     assert svg == EXPECTED_SVG
 
 
-def test_build_then_export():
-    console = Console(record=True, width=100)
-    console.print(
-        "[b red on blue reverse]foo[/] [blink][link=https://example.org]Click[/link]"
-    )
-    svg, _, _ = console.build_svg()
-    svg = console.export_svg()
-    print(repr(svg))
-
-    assert svg == EXPECTED_SVG
-
-
 def test_save_svg():
     console = Console(record=True, width=100)
     console.print(


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Add Console.build_svg() function to get SVG and its size.

Then changed the existing `export_svg()` to use the new `build_svg()` function, but only return the first value which is the SVG string. Power users could then use `build_svg()` to get the SVG code as well as the width and height.

This is related to issue #2431 
