### PR TITLE
Handle 'no_color' Console on legacy Windows platforms

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -36,12 +36,12 @@ jobs:
           source $VENV
           make typecheck
       - name: Test with pytest (with coverage)
-        if: matrix.python-version != '3.11.0-beta.4'
+        if: matrix.python-version != '3.11.0-beta.5'
         run: |
           source $VENV
           pytest tests -v --cov=./rich --cov-report=xml:./coverage.xml --cov-report term-missing
       - name: Test with pytest (no coverage)
-        if: matrix.python-version == '3.11.0-beta.4'
+        if: matrix.python-version == '3.11.0-beta.5'
         run: |
           source $VENV
           pytest tests -v

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-beta.5"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     defaults:
       run:
         shell: bash
@@ -36,15 +36,9 @@ jobs:
           source $VENV
           make typecheck
       - name: Test with pytest (with coverage)
-        if: matrix.python-version != '3.11.0-beta.5'
         run: |
           source $VENV
           pytest tests -v --cov=./rich --cov-report=xml:./coverage.xml --cov-report term-missing
-      - name: Test with pytest (no coverage)
-        if: matrix.python-version == '3.11.0-beta.5'
-        run: |
-          source $VENV
-          pytest tests -v
       - name: Upload code coverage
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-beta.4"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-beta.5"]
     defaults:
       run:
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix NO_COLOR support on legacy Windows https://github.com/Textualize/rich/pull/2458
+
 ## [12.5.2] - 2022-07-18
 
 ### Added

--- a/rich/console.py
+++ b/rich/console.py
@@ -1996,9 +1996,11 @@ class Console:
                             from rich._win32_console import LegacyWindowsTerm
                             from rich._windows_renderer import legacy_windows_render
 
-                            legacy_windows_render(
-                                self._buffer[:], LegacyWindowsTerm(self.file)
-                            )
+                            buffer = self._buffer[:]
+                            if self.no_color and self._color_system:
+                                buffer = Segment.remove_color(buffer)
+
+                            legacy_windows_render(buffer, LegacyWindowsTerm(self.file))
                         else:
                             # Either a non-std stream on legacy Windows, or modern Windows.
                             text = self._render_buffer(self._buffer[:])

--- a/rich/console.py
+++ b/rich/console.py
@@ -1998,7 +1998,7 @@ class Console:
 
                             buffer = self._buffer[:]
                             if self.no_color and self._color_system:
-                                buffer = Segment.remove_color(buffer)
+                                buffer = list(Segment.remove_color(buffer))
 
                             legacy_windows_render(buffer, LegacyWindowsTerm(self.file))
                         else:


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The "no_color" parameter of Console was not being respected on legacy Windows mode.
This update strips colour from the Segment buffer if necessary, before passing them into the legacy Windows renderer.

Also updates to Python 3.11b5 (up from b4) in CI.