### PR TITLE
fix invalid escapes

### DIFF
--- a/tests/render.py
+++ b/tests/render.py
@@ -4,7 +4,7 @@ import re
 from rich.console import Console, RenderableType
 
 
-re_link_ids = re.compile(r"id=[\d\.\-]*?;.*?\x1b")
+re_link_ids = re.compile(r"id=[\d.\-]*?;.*?\x1b")
 
 
 def replace_link_ids(render: str) -> str:

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -144,7 +144,7 @@ def test_markup_error():
 
 
 def test_markup_escape():
-    result = str(render("[dim white]\[url=[/]"))
+    result = str(render("[dim white][url=[/]"))
     assert result == "[url="
 
 

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -49,7 +49,7 @@ def test_handler():
                 "│" + (" " * 98) + "│",
             )
             for frame_start in re.finditer(
-                "^│ .+rich/tests/test_traceback\.py:",
+                "^│ .+rich/tests/test_traceback.py:",
                 rendered_exception,
                 flags=re.MULTILINE,
             ):


### PR DESCRIPTION
A couple of the escape sequences in strings are causing DeprecationWarning in the test suite

```
tests/test_markup.py:147
  /Users/wim/git/rich/tests/test_markup.py:147: DeprecationWarning: invalid escape sequence '\['
    result = str(render("[dim white]\[url=[/]"))

tests/test_traceback.py:52
  /Users/wim/git/rich/tests/test_traceback.py:52: DeprecationWarning: invalid escape sequence '\.'
    "^│ .+rich/tests/test_traceback\.py:",
```