### PR TITLE
docs: update `rich.reconfigure` docstring

### DIFF
--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -40,7 +40,8 @@ def reconfigure(*args: Any, **kwargs: Any) -> None:
     """Reconfigures the global console by replacing it with another.
 
     Args:
-        console (Console): Replacement console instance.
+        *args (Any): Positional arguments for the replacement :class:`~rich.console.Console`.
+        **kwargs (Any): Keyword arguments for the replacement :class:`~rich.console.Console`.
     """
     from rich.console import Console
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Update the docstring for `rich.reconfigure`. Previously, the docstring said it would accept an instance of `rich.console.Console`, but it expects positional and keyword arguments that are forward to the initializer for `rich.console.Console`.
