### PR TITLE
Add option to suppress provided types in tracebacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parse ANSI escape sequences in pretty repr https://github.com/Textualize/rich/pull/2470
 - Add support for `FORCE_COLOR` env var https://github.com/Textualize/rich/pull/2449
 - Allow a `max_depth` argument to be passed to the `install()` hook https://github.com/Textualize/rich/issues/2486
+- Add a 'locals_suppress' argument to the Traceback handler https://github.com/Textualize/rich/issues/1810
 
 ### Fixed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,7 @@ The following people have contributed to the development of Rich:
 - [Alexander Mancevice](https://github.com/amancevice)
 - [Will McGugan](https://github.com/willmcgugan)
 - [Paul McGuire](https://github.com/ptmcg)
+- [Cameron Mckain](https://github.com/cmckain)
 - [Antony Milne](https://github.com/AntonyMilneQB)
 - [Michael Milton](https://github.com/multimeric)
 - [Nathan Page](https://github.com/nathanrpage97)

--- a/rich/console.py
+++ b/rich/console.py
@@ -1823,6 +1823,7 @@ class Console:
         show_locals: bool = False,
         suppress: Iterable[Union[str, ModuleType]] = (),
         max_frames: int = 100,
+        locals_suppress: Iterable[Any] = (),
     ) -> None:
         """Prints a rich render of the last exception and traceback.
 
@@ -1834,6 +1835,7 @@ class Console:
             show_locals (bool, optional): Enable display of local variables. Defaults to False.
             suppress (Iterable[Union[str, ModuleType]]): Optional sequence of modules or paths to exclude from traceback.
             max_frames (int): Maximum number of frames to show in a traceback, 0 for no maximum. Defaults to 100.
+            locals_suppress (Sequence[Any]): Optional sequence of types that should be suppressed in the list of local variables.
         """
         from .traceback import Traceback
 
@@ -1845,6 +1847,7 @@ class Console:
             show_locals=show_locals,
             suppress=suppress,
             max_frames=max_frames,
+            locals_suppress=locals_suppress,
         )
         self.print(traceback)
 

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -260,6 +260,8 @@ class Traceback:
             self.suppress.append(path)
         self.max_frames = max(4, max_frames) if max_frames > 0 else 0
 
+        self.locals_suppress = locals_suppress
+
     @classmethod
     def from_exception(
         cls,
@@ -301,7 +303,7 @@ class Traceback:
             Traceback: A Traceback instance that may be printed.
         """
         rich_traceback = cls.extract(
-            exc_type, exc_value, traceback, show_locals=show_locals, locals_suppress
+            exc_type, exc_value, traceback, show_locals=show_locals, locals_suppress=locals_suppress,
         )
         return cls(
             rich_traceback,

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -231,7 +231,11 @@ class Traceback:
                     "Value for 'trace' required if not called in except: block"
                 )
             trace = self.extract(
-                exc_type, exc_value, traceback, show_locals=show_locals, locals_suppress=locals_suppress
+                exc_type,
+                exc_value,
+                traceback,
+                show_locals=show_locals,
+                locals_suppress=locals_suppress,
             )
         self.trace = trace
         self.width = width
@@ -351,7 +355,7 @@ class Traceback:
                 return str(_object)
             except Exception:
                 return "<exception str() failed>"
-               
+
         def clean_values(_object: Any) -> Any:
             if isinstance(_object, tuple(locals_suppress)):
                 return type(_object)

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -301,7 +301,7 @@ class Traceback:
             Traceback: A Traceback instance that may be printed.
         """
         rich_traceback = cls.extract(
-            exc_type, exc_value, traceback, show_locals=show_locals
+            exc_type, exc_value, traceback, show_locals=show_locals, locals_suppress
         )
         return cls(
             rich_traceback,
@@ -315,6 +315,7 @@ class Traceback:
             locals_max_string=locals_max_string,
             suppress=suppress,
             max_frames=max_frames,
+            locals_suppress=locals_suppress,
         )
 
     @classmethod

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -308,6 +308,17 @@ def test_suppress():
         assert "foo" in traceback.suppress[1]
 
 
+def test_locals_suppress():
+    try:
+        a = [1, 2, 3]
+        1 / 0
+    except Exception:
+        traceback = Traceback(locals_suppress=[int, str])
+        assert traceback.locals_suppress == [int, str]
+        assert traceback.locals_suppress[0] is int
+        assert traceback.locals_suppress[1] is str
+
+
 @pytest.mark.parametrize(
     "rich_traceback_omit_for_level2,expected_frames_length,expected_frame_names",
     (


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

As described in #1810, this will allow for certain types to be excluded content-wise from Rich tracebacks, including if they are contained within certain hardcoded (list, tuple, and dict) arrays, where they will be replaced by their type (or array[type]). This argument may be used whenever tracebacks are initialized, including the general install() handler. It takes an array, instead of a callable as originally suggested[^1], because I think the problem this is intended to fix is more around the content of a variable, rather than the name of a variable (#2414 is probably a better mechanism for implementing that).

Although @willmcgugan had suggested a similar argument be included for limiting the length of local variables, I think that you would have to implement additional checks for the content of nested arrays (that's why the original locals_max_string and locals_max_length arguments didn't work for my purposes) and that should be for an additional PR.

[^1]: It could probably be rewritten to accept both arrays and functions if that would make this more useful.
