### PR TITLE
Update links to current repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: Needs triage
 assignees: ""
 ---
 
-You may find a solution to your problem in the [docs](https://rich.readthedocs.io/en/latest/introduction.html) or [issues](https://github.com/willmcgugan/rich/issues).
+You may find a solution to your problem in the [docs](https://rich.readthedocs.io/en/latest/introduction.html) or [issues](https://github.com/Textualize/rich/issues).
 
 **Describe the bug**
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Consider posting in https://github.com/willmcgugan/rich/discussions for feedback before raising a feature request.
+Consider posting in https://github.com/Textualize/rich/discussions for feedback before raising a feature request.
 
 Have you checked the issues for a similar suggestions?
 

--- a/.github/workflows/readmechanged.yml
+++ b/.github/workflows/readmechanged.yml
@@ -19,6 +19,6 @@ jobs:
       run: |
         COMMIT=$(git rev-parse --short "$GIT_SHA")
         AUTHORS='@willmcgugan @oleksis @Adilius'
-        BODY="🤓 $AUTHORS README.md changed 📝. Check the [commit $COMMIT](https://github.com/willmcgugan/rich/commit/$GIT_SHA) 👀"
+        BODY="🤓 $AUTHORS README.md changed 📝. Check the [commit $COMMIT](https://github.com/Textualize/rich/commit/$GIT_SHA) 👀"
         DISCUSSIONID='MDEwOkRpc2N1c3Npb24zMzI2NzM0'
         gh api graphql -H 'GraphQL-Features: discussions_api' -f body="$BODY" -F discussionId="$DISCUSSIONID" -f query='mutation($body: String!, $discussionId: ID!){addDiscussionComment(input:{body: $body , discussionId: $discussionId}){comment{id}}}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix NO_COLOR support on legacy Windows https://github.com/Textualize/rich/pull/2458
+- Update links to current repo https://github.com/Textualize/rich/pull/2509
 
 ## [12.5.2] - 2022-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Progress.open and Progress.wrap_file method to track the progress while reading from a file or file-like object https://github.com/willmcgugan/rich/pull/1759
+- Progress.open and Progress.wrap_file method to track the progress while reading from a file or file-like object https://github.com/Textualize/rich/pull/1759
 - SVG export functionality https://github.com/Textualize/rich/pull/2101
 - Adding Indonesian translation
 
@@ -252,23 +252,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed issues with overlapping tags https://github.com/willmcgugan/rich/issues/1755
+- Fixed issues with overlapping tags https://github.com/Textualize/rich/issues/1755
 
 ## [10.16.0] - 2021-12-12
 
 ### Fixed
 
-- Double print of progress bar in Jupyter https://github.com/willmcgugan/rich/issues/1737
+- Double print of progress bar in Jupyter https://github.com/Textualize/rich/issues/1737
 
 ### Added
 
-- Added Text.markup property https://github.com/willmcgugan/rich/issues/1751
+- Added Text.markup property https://github.com/Textualize/rich/issues/1751
 
 ## [10.15.2] - 2021-12-02
 
 ### Fixed
 
-- Deadlock issue https://github.com/willmcgugan/rich/issues/1734
+- Deadlock issue https://github.com/Textualize/rich/issues/1734
 
 ## [10.15.1] - 2021-11-29
 
@@ -290,51 +290,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed issue with progress bar not rendering markup https://github.com/willmcgugan/rich/issues/1721
-- Fixed race condition when exiting Live https://github.com/willmcgugan/rich/issues/1530
+- Fixed issue with progress bar not rendering markup https://github.com/Textualize/rich/issues/1721
+- Fixed race condition when exiting Live https://github.com/Textualize/rich/issues/1530
 
 ## [10.14.0] - 2021-11-16
 
 ### Fixed
 
 - Fixed progress speed not updating when total doesn't change
-- Fixed superfluous new line in Status https://github.com/willmcgugan/rich/issues/1662
+- Fixed superfluous new line in Status https://github.com/Textualize/rich/issues/1662
 - Fixed Windows legacy width again
-- Fixed infinite loop in set_cell_size https://github.com/willmcgugan/rich/issues/1682
+- Fixed infinite loop in set_cell_size https://github.com/Textualize/rich/issues/1682
 
 ### Added
 
-- Added file protocol to URL highlighter https://github.com/willmcgugan/rich/issues/1681
+- Added file protocol to URL highlighter https://github.com/Textualize/rich/issues/1681
 - Added rich.protocol.rich_cast
 
 ### Changed
 
 - Allowed `__rich__` to work recursively
-- Allowed Text classes to work with sep in print https://github.com/willmcgugan/rich/issues/1689
+- Allowed Text classes to work with sep in print https://github.com/Textualize/rich/issues/1689
 
 ### Added
 
-- Added a `rich.text.Text.from_ansi` helper method for handling pre-formatted input strings https://github.com/willmcgugan/rich/issues/1670
+- Added a `rich.text.Text.from_ansi` helper method for handling pre-formatted input strings https://github.com/Textualize/rich/issues/1670
 
 ## [10.13.0] - 2021-11-07
 
 ### Added
 
-- Added json.dumps parameters to print_json https://github.com/willmcgugan/rich/issues/1638
+- Added json.dumps parameters to print_json https://github.com/Textualize/rich/issues/1638
 
 ### Fixed
 
 - Fixed an edge case bug when console module try to detect if they are in a tty at the end of a pytest run
 - Fixed a bug where logging handler raises an exception when running with pythonw (related to https://bugs.python.org/issue13807)
-- Fixed issue with TERM env vars that have more than one hyphen https://github.com/willmcgugan/rich/issues/1640
-- Fixed missing new line after progress bar when terminal is not interactive https://github.com/willmcgugan/rich/issues/1606
-- Fixed exception in IPython when disabling pprint with %pprint https://github.com/willmcgugan/rich/issues/1646
-- Fixed issue where values longer than the console width produced invalid JSON https://github.com/willmcgugan/rich/issues/1653
-- Fixes trailing comma when pretty printing dataclass with last field repr=False https://github.com/willmcgugan/rich/issues/1599
+- Fixed issue with TERM env vars that have more than one hyphen https://github.com/Textualize/rich/issues/1640
+- Fixed missing new line after progress bar when terminal is not interactive https://github.com/Textualize/rich/issues/1606
+- Fixed exception in IPython when disabling pprint with %pprint https://github.com/Textualize/rich/issues/1646
+- Fixed issue where values longer than the console width produced invalid JSON https://github.com/Textualize/rich/issues/1653
+- Fixes trailing comma when pretty printing dataclass with last field repr=False https://github.com/Textualize/rich/issues/1599
 
 ## Changed
 
-- Markdown codeblocks now word-wrap https://github.com/willmcgugan/rich/issues/1515
+- Markdown codeblocks now word-wrap https://github.com/Textualize/rich/issues/1515
 
 ## [10.12.0] - 2021-10-06
 
@@ -361,7 +361,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed pretty printing of objects with fo magic with **getattr** https://github.com/willmcgugan/rich/issues/1492
+- Fixed pretty printing of objects with fo magic with **getattr** https://github.com/Textualize/rich/issues/1492
 
 ## [10.9.0] - 2021-08-29
 
@@ -387,7 +387,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug where calling `rich.reconfigure` within a `pytest_configure` hook would lead to a crash
-- Fixed highlight not being passed through options https://github.com/willmcgugan/rich/issues/1404
+- Fixed highlight not being passed through options https://github.com/Textualize/rich/issues/1404
 
 ## [10.7.0] - 2021-08-05
 
@@ -421,7 +421,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed issue with adjoining color tags https://github.com/willmcgugan/rich/issues/1334
+- Fixed issue with adjoining color tags https://github.com/Textualize/rich/issues/1334
 
 ### Changed
 
@@ -431,10 +431,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed Pandas objects not pretty printing https://github.com/willmcgugan/rich/issues/1305
-- Fixed https://github.com/willmcgugan/rich/issues/1256
+- Fixed Pandas objects not pretty printing https://github.com/Textualize/rich/issues/1305
+- Fixed https://github.com/Textualize/rich/issues/1256
 - Fixed typing with rich.repr.auto decorator
-- Fixed repr error formatting https://github.com/willmcgugan/rich/issues/1326
+- Fixed repr error formatting https://github.com/Textualize/rich/issues/1326
 
 ### Added
 
@@ -472,13 +472,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed status not rendering console markup https://github.com/willmcgugan/rich/issues/1244
+- Fixed status not rendering console markup https://github.com/Textualize/rich/issues/1244
 
 ## [10.2.1] - 2021-05-17
 
 ### Fixed
 
-- Fixed panel in Markdown exploding https://github.com/willmcgugan/rich/issues/1234
+- Fixed panel in Markdown exploding https://github.com/Textualize/rich/issues/1234
 
 ## [10.2.0] - 2021-05-12
 
@@ -497,7 +497,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed initial blank lines removed from Syntax https://github.com/willmcgugan/rich/issues/1214
+- Fixed initial blank lines removed from Syntax https://github.com/Textualize/rich/issues/1214
 
 ## [10.1.0] - 2021-04-03
 
@@ -509,13 +509,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed race condition that duplicated lines in progress https://github.com/willmcgugan/rich/issues/1144
+- Fixed race condition that duplicated lines in progress https://github.com/Textualize/rich/issues/1144
 
 ## [10.0.0] - 2021-03-27
 
 ### Changed
 
-- Made pydoc import lazy as at least one use found it slow to import https://github.com/willmcgugan/rich/issues/1104
+- Made pydoc import lazy as at least one use found it slow to import https://github.com/Textualize/rich/issues/1104
 - Modified string highlighting to not match in the middle of a word, so that apostrophes are not considered strings
 - New way of encoding control codes in Segment
 - New signature for Control class
@@ -539,10 +539,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed table style taking precedence over row style https://github.com/willmcgugan/rich/issues/1129
-- Fixed incorrect measurement of Text with new lines and whitespace https://github.com/willmcgugan/rich/issues/1133
+- Fixed table style taking precedence over row style https://github.com/Textualize/rich/issues/1129
+- Fixed incorrect measurement of Text with new lines and whitespace https://github.com/Textualize/rich/issues/1133
 - Made type annotations consistent for various `total` keyword arguments in `rich.progress` and rich.`progress_bar`
-- Disabled Progress no longer displays itself when starting https://github.com/willmcgugan/rich/pull/1125
+- Disabled Progress no longer displays itself when starting https://github.com/Textualize/rich/pull/1125
 - Animations no longer reset when updating rich.status.Status
 
 ## [9.13.0] - 2021-03-06
@@ -553,8 +553,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed Syntax background https://github.com/willmcgugan/rich/issues/1088
-- Fix for double tracebacks when no formatter https://github.com/willmcgugan/rich/issues/1079
+- Fixed Syntax background https://github.com/Textualize/rich/issues/1088
+- Fix for double tracebacks when no formatter https://github.com/Textualize/rich/issues/1079
 
 ### Changed
 
@@ -564,7 +564,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed custom formatters with rich tracebacks in RichHandler https://github.com/willmcgugan/rich/issues/1079
+- Fixed custom formatters with rich tracebacks in RichHandler https://github.com/Textualize/rich/issues/1079
 
 ### Changed
 
@@ -591,7 +591,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed deadlock in Progress https://github.com/willmcgugan/rich/issues/1061
+- Fixed deadlock in Progress https://github.com/Textualize/rich/issues/1061
 
 ### Added
 
@@ -607,14 +607,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed issue with Syntax and missing lines in Layout https://github.com/willmcgugan/rich/issues/1050
-- Fixed issue with nested markdown elements https://github.com/willmcgugan/rich/issues/1036
-- Fixed new lines not invoking render hooks https://github.com/willmcgugan/rich/issues/1052
-- Fixed Align setting height to child https://github.com/willmcgugan/rich/issues/1057
+- Fixed issue with Syntax and missing lines in Layout https://github.com/Textualize/rich/issues/1050
+- Fixed issue with nested markdown elements https://github.com/Textualize/rich/issues/1036
+- Fixed new lines not invoking render hooks https://github.com/Textualize/rich/issues/1052
+- Fixed Align setting height to child https://github.com/Textualize/rich/issues/1057
 
 ### Changed
 
-- Printing a table with no columns now result in a blank line https://github.com/willmcgugan/rich/issues/1044
+- Printing a table with no columns now result in a blank line https://github.com/Textualize/rich/issues/1044
 
 ### Added
 
@@ -626,9 +626,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed table with expand=False not expanding when justify="center"
 - Fixed single renderable in Layout not respecting height
-- Fixed COLUMNS and LINES env var https://github.com/willmcgugan/rich/issues/1019
+- Fixed COLUMNS and LINES env var https://github.com/Textualize/rich/issues/1019
 - Layout now respects minimum_size when fixes sizes are greater than available space
-- HTML export now changes link underline score to match terminal https://github.com/willmcgugan/rich/issues/1009
+- HTML export now changes link underline score to match terminal https://github.com/Textualize/rich/issues/1009
 
 ### Changed
 
@@ -643,8 +643,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed error message for tracebacks with broken `__str__` https://github.com/willmcgugan/rich/issues/980
-- Fixed markup edge case https://github.com/willmcgugan/rich/issues/987
+- Fixed error message for tracebacks with broken `__str__` https://github.com/Textualize/rich/issues/980
+- Fixed markup edge case https://github.com/Textualize/rich/issues/987
 
 ### Added
 
@@ -685,7 +685,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix double line tree guides on Windows
 - Fixed Tracebacks ignoring initial blank lines
 - Partial fix for tracebacks not finding source after chdir
-- Fixed error message when code in tracebacks doesn't have an extension https://github.com/willmcgugan/rich/issues/996
+- Fixed error message when code in tracebacks doesn't have an extension https://github.com/Textualize/rich/issues/996
 
 ### Added
 
@@ -695,13 +695,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed deadlock in live https://github.com/willmcgugan/rich/issues/927
+- Fixed deadlock in live https://github.com/Textualize/rich/issues/927
 
 ## [9.8.1] - 2021-01-13
 
 ### Fixed
 
-- Fixed rich.inspect failing with attributes that claim to be callable but aren't https://github.com/willmcgugan/rich/issues/916
+- Fixed rich.inspect failing with attributes that claim to be callable but aren't https://github.com/Textualize/rich/issues/916
 
 ## [9.8.0] - 2021-01-11
 
@@ -720,7 +720,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed panel cropping when shrunk too bar
 - Allow passing markdown over STDIN when using `python -m rich.markdown`
-- Fix printing MagicMock.mock_calls https://github.com/willmcgugan/rich/issues/903
+- Fix printing MagicMock.mock_calls https://github.com/Textualize/rich/issues/903
 
 ## [9.7.0] - 2021-01-09
 
@@ -733,9 +733,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed markup escaping edge case https://github.com/willmcgugan/rich/issues/878
+- Fixed markup escaping edge case https://github.com/Textualize/rich/issues/878
 - Double tag escape, i.e. `"\\[foo]"` results in a backslash plus `[foo]` tag
-- Fixed header_style not applying to headers in positional args https://github.com/willmcgugan/rich/issues/953
+- Fixed header_style not applying to headers in positional args https://github.com/Textualize/rich/issues/953
 
 ## [9.6.1] - 2020-12-31
 
@@ -764,7 +764,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed terminal size detection on Windows https://github.com/willmcgugan/rich/issues/836
+- Fixed terminal size detection on Windows https://github.com/Textualize/rich/issues/836
 - Fixed hex number highlighting
 
 ## [9.5.0] - 2020-12-18
@@ -788,15 +788,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed double output in rich.live https://github.com/willmcgugan/rich/issues/485
-- Fixed Console.out highlighting not reflecting defaults https://github.com/willmcgugan/rich/issues/827
-- FileProxy now raises TypeError for empty non-str arguments https://github.com/willmcgugan/rich/issues/828
+- Fixed double output in rich.live https://github.com/Textualize/rich/issues/485
+- Fixed Console.out highlighting not reflecting defaults https://github.com/Textualize/rich/issues/827
+- FileProxy now raises TypeError for empty non-str arguments https://github.com/Textualize/rich/issues/828
 
 ## [9.4.0] - 2020-12-12
 
 ### Added
 
-- Added rich.live https://github.com/willmcgugan/rich/pull/382
+- Added rich.live https://github.com/Textualize/rich/pull/382
 - Added algin parameter to Rule and Console.rule
 - Added rich.Status class and Console.status
 - Added getitem to Text
@@ -810,7 +810,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-- Fixed suppressed traceback context https://github.com/willmcgugan/rich/issues/468
+- Fixed suppressed traceback context https://github.com/Textualize/rich/issues/468
 
 ## [9.3.0] - 2020-12-1
 
@@ -831,9 +831,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed redirecting of stderr in Progress
-- Fixed broken expanded tuple of one https://github.com/willmcgugan/rich/issues/445
+- Fixed broken expanded tuple of one https://github.com/Textualize/rich/issues/445
 - Fixed traceback message with `from` exceptions
-- Fixed justify argument not working in console.log https://github.com/willmcgugan/rich/issues/460
+- Fixed justify argument not working in console.log https://github.com/Textualize/rich/issues/460
 
 ## [9.2.0] - 2020-11-08
 
@@ -870,13 +870,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed negative time remaining in Progress bars https://github.com/willmcgugan/rich/issues/378
+- Fixed negative time remaining in Progress bars https://github.com/Textualize/rich/issues/378
 
 ## [9.0.1] - 2020-10-19
 
 ### Fixed
 
-- Fixed broken ANSI codes in input on windows legacy https://github.com/willmcgugan/rich/issues/393
+- Fixed broken ANSI codes in input on windows legacy https://github.com/Textualize/rich/issues/393
 
 ## [9.0.0] - 2020-10-18
 
@@ -896,15 +896,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added binary_units in progress download column
 - Added Progress.reset
 - Added Style.background_style property
-- Added Bar renderable https://github.com/willmcgugan/rich/pull/361
+- Added Bar renderable https://github.com/Textualize/rich/pull/361
 - Added Table.min_width
 - Added table.Column.min_width and table.Column.max_width, and same to Table.add_column
 
 ### Changed
 
 - Dropped box.get_safe_box function in favor of Box.substitute
-- Changed default padding in Panel from 0 to (0, 1) https://github.com/willmcgugan/rich/issues/385
-- Table with row_styles will extend background color between cells if the box has no vertical dividerhttps://github.com/willmcgugan/rich/issues/383
+- Changed default padding in Panel from 0 to (0, 1) https://github.com/Textualize/rich/issues/385
+- Table with row_styles will extend background color between cells if the box has no vertical dividerhttps://github.com/Textualize/rich/issues/383
 - Changed default of fit kwarg in render_group() from False to True
 - Renamed rich.bar to rich.progress_bar, and Bar class to ProgressBar, rich.bar is now the new solid bar class
 
@@ -937,7 +937,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added Console.begin_capture, Console.end_capture and Console.capture
-- Added Table.title_justify and Table.caption_justify https://github.com/willmcgugan/rich/issues/301
+- Added Table.title_justify and Table.caption_justify https://github.com/Textualize/rich/issues/301
 
 ### Changed
 
@@ -1028,7 +1028,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed underscore with display hook https://github.com/willmcgugan/rich/issues/235
+- Fixed underscore with display hook https://github.com/Textualize/rich/issues/235
 
 ## [5.2.0] - 2020-08-14
 
@@ -1036,7 +1036,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added crop argument to Console.print
 - Added "ignore" overflow method
-- Added multiple characters per rule @hedythedev https://github.com/willmcgugan/rich/pull/207
+- Added multiple characters per rule @hedythedev https://github.com/Textualize/rich/pull/207
 
 ## [5.1.2] - 2020-08-10
 
@@ -1055,12 +1055,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added Text.cell_len
-- Added helpful message regarding unicode decoding errors https://github.com/willmcgugan/rich/issues/212
+- Added helpful message regarding unicode decoding errors https://github.com/Textualize/rich/issues/212
 - Added display hook with pretty.install()
 
 ### Fixed
 
-- Fixed deprecation warnings re backslash https://github.com/willmcgugan/rich/issues/210
+- Fixed deprecation warnings re backslash https://github.com/Textualize/rich/issues/210
 - Fixed repr highlighting of scientific notation, e.g. 1e100
 
 ### Changed
@@ -1087,24 +1087,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added show_time and show_level parameters to RichHandler https://github.com/willmcgugan/rich/pull/182
+- Added show_time and show_level parameters to RichHandler https://github.com/Textualize/rich/pull/182
 
 ### Fixed
 
-- Fixed progress.track iterator exiting early https://github.com/willmcgugan/rich/issues/189
-- Added workaround for Python bug https://bugs.python.org/issue37871, fixing https://github.com/willmcgugan/rich/issues/186
+- Fixed progress.track iterator exiting early https://github.com/Textualize/rich/issues/189
+- Added workaround for Python bug https://bugs.python.org/issue37871, fixing https://github.com/Textualize/rich/issues/186
 
 ### Changed
 
-- Set overflow=fold for log messages https://github.com/willmcgugan/rich/issues/190
+- Set overflow=fold for log messages https://github.com/Textualize/rich/issues/190
 
 ## [4.2.0] - 2020-07-27
 
 ### Fixed
 
-- Fixed missing new lines https://github.com/willmcgugan/rich/issues/178
-- Fixed Progress.track https://github.com/willmcgugan/rich/issues/184
-- Remove control codes from exported text https://github.com/willmcgugan/rich/issues/181
+- Fixed missing new lines https://github.com/Textualize/rich/issues/178
+- Fixed Progress.track https://github.com/Textualize/rich/issues/184
+- Remove control codes from exported text https://github.com/Textualize/rich/issues/181
 - Implemented auto-detection and color rendition of 16-color mode
 
 ## [4.1.0] - 2020-07-26
@@ -1120,7 +1120,7 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 
 ### Added
 
-- Added markup switch to RichHandler https://github.com/willmcgugan/rich/issues/171
+- Added markup switch to RichHandler https://github.com/Textualize/rich/issues/171
 
 ### Changed
 
@@ -1129,7 +1129,7 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 
 ### Fixed
 
-- Fixed rendering of Confirm prompt https://github.com/willmcgugan/rich/issues/170
+- Fixed rendering of Confirm prompt https://github.com/Textualize/rich/issues/170
 
 ## [3.4.1] - 2020-07-22
 
@@ -1224,7 +1224,7 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 
 ### Changed
 
-- More precise detection of Windows console https://github.com/willmcgugan/rich/issues/140
+- More precise detection of Windows console https://github.com/Textualize/rich/issues/140
 
 ## [3.0.3] - 2020-07-03
 
@@ -1281,7 +1281,7 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 
 ### Fixed
 
-- Disabled legacy_windows if jupyter is detected https://github.com/willmcgugan/rich/issues/125
+- Disabled legacy_windows if jupyter is detected https://github.com/Textualize/rich/issues/125
 
 ## [2.3.0] - 2020-06-26
 
@@ -1302,13 +1302,13 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 
 ### Changed
 
-- Store a "link id" on Style instance, so links containing different styles are highlighted together. (https://github.com/willmcgugan/rich/pull/123)
+- Store a "link id" on Style instance, so links containing different styles are highlighted together. (https://github.com/Textualize/rich/pull/123)
 
 ## [2.2.5] - 2020-06-23
 
 ### Fixed
 
-- Fixed justify of tables (https://github.com/willmcgugan/rich/issues/117)
+- Fixed justify of tables (https://github.com/Textualize/rich/issues/117)
 
 ## [2.2.4] - 2020-06-21
 
@@ -1436,7 +1436,7 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 
 ### Fixed
 
-- Fixed Progress deadlock https://github.com/willmcgugan/rich/issues/90
+- Fixed Progress deadlock https://github.com/Textualize/rich/issues/90
 
 ### Changed
 
@@ -1567,7 +1567,7 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 
 ### Fixed
 
-- Issue with Windows legacy support https://github.com/willmcgugan/rich/issues/59
+- Issue with Windows legacy support https://github.com/Textualize/rich/issues/59
 
 ## [1.0.1] - 2020-05-08
 
@@ -1589,7 +1589,7 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 
 ### Fixed
 
-- Fixed Text.assemble not working with strings https://github.com/willmcgugan/rich/issues/57
+- Fixed Text.assemble not working with strings https://github.com/Textualize/rich/issues/57
 - Fixed table when column widths must be compressed to fit
 
 ## [1.0.0] - 2020-05-03
@@ -1799,7 +1799,7 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 ### Fixed
 
 - Fixed Windows color support
-- Fixed line width on windows issue (https://github.com/willmcgugan/rich/issues/7)
+- Fixed line width on windows issue (https://github.com/Textualize/rich/issues/7)
 - Fixed Pretty print on Windows
 
 ## [0.3.2] - 2020-01-26
@@ -1820,158 +1820,158 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 
 - First official release, API still to be stabilized
 
-[unreleased]: https://github.com/willmcgugan/rich/compare/v12.5.2...HEAD
-[12.5.2]: https://github.com/willmcgugan/rich/compare/v12.5.1...v12.5.2
-[12.5.1]: https://github.com/willmcgugan/rich/compare/v12.5.0...v12.5.1
-[12.5.0]: https://github.com/willmcgugan/rich/compare/v12.4.4...v12.5.0
-[12.4.4]: https://github.com/willmcgugan/rich/compare/v12.4.3...v12.4.4
-[12.4.3]: https://github.com/willmcgugan/rich/compare/v12.4.2...v12.4.3
-[12.4.2]: https://github.com/willmcgugan/rich/compare/v12.4.1...v12.4.2
-[12.4.1]: https://github.com/willmcgugan/rich/compare/v12.4.0...v12.4.1
-[12.4.0]: https://github.com/willmcgugan/rich/compare/v12.3.0...v12.4.0
-[12.3.0]: https://github.com/willmcgugan/rich/compare/v12.2.0...v12.3.0
-[12.2.0]: https://github.com/willmcgugan/rich/compare/v12.1.0...v12.2.0
-[12.1.0]: https://github.com/willmcgugan/rich/compare/v12.0.1...v12.1.0
-[12.0.1]: https://github.com/willmcgugan/rich/compare/v12.0.0...v12.0.1
-[12.0.0]: https://github.com/willmcgugan/rich/compare/v11.2.0...v12.0.0
-[11.2.0]: https://github.com/willmcgugan/rich/compare/v11.1.0...v11.2.0
-[11.1.0]: https://github.com/willmcgugan/rich/compare/v11.0.0...v11.1.0
-[11.0.0]: https://github.com/willmcgugan/rich/compare/v10.16.1...v11.0.0
-[10.16.2]: https://github.com/willmcgugan/rich/compare/v10.16.1...v10.16.2
-[10.16.1]: https://github.com/willmcgugan/rich/compare/v10.16.0...v10.16.1
-[10.16.0]: https://github.com/willmcgugan/rich/compare/v10.15.2...v10.16.0
-[10.15.2]: https://github.com/willmcgugan/rich/compare/v10.15.1...v10.15.2
-[10.15.1]: https://github.com/willmcgugan/rich/compare/v10.15.0...v10.15.1
-[10.15.0]: https://github.com/willmcgugan/rich/compare/v10.14.0...v10.15.0
-[10.14.0]: https://github.com/willmcgugan/rich/compare/v10.13.0...v10.14.0
-[10.13.0]: https://github.com/willmcgugan/rich/compare/v10.12.0...v10.13.0
-[10.12.0]: https://github.com/willmcgugan/rich/compare/v10.11.0...v10.12.0
-[10.11.0]: https://github.com/willmcgugan/rich/compare/v10.10.0...v10.11.0
-[10.10.0]: https://github.com/willmcgugan/rich/compare/v10.9.0...v10.10.0
-[10.9.0]: https://github.com/willmcgugan/rich/compare/v10.8.0...v10.9.0
-[10.8.0]: https://github.com/willmcgugan/rich/compare/v10.7.0...v10.8.0
-[10.7.0]: https://github.com/willmcgugan/rich/compare/v10.6.0...v10.7.0
-[10.6.0]: https://github.com/willmcgugan/rich/compare/v10.5.0...v10.6.0
-[10.5.0]: https://github.com/willmcgugan/rich/compare/v10.4.0...v10.5.0
-[10.4.0]: https://github.com/willmcgugan/rich/compare/v10.3.0...v10.4.0
-[10.3.0]: https://github.com/willmcgugan/rich/compare/v10.2.2...v10.3.0
-[10.2.2]: https://github.com/willmcgugan/rich/compare/v10.2.1...v10.2.2
-[10.2.1]: https://github.com/willmcgugan/rich/compare/v10.2.0...v10.2.1
-[10.2.0]: https://github.com/willmcgugan/rich/compare/v10.1.0...v10.2.0
-[10.1.0]: https://github.com/willmcgugan/rich/compare/v10.0.1...v10.1.0
-[10.0.1]: https://github.com/willmcgugan/rich/compare/v10.0.0...v10.0.1
-[10.0.0]: https://github.com/willmcgugan/rich/compare/v9.13.0...v10.0.0
-[9.13.0]: https://github.com/willmcgugan/rich/compare/v9.12.4...v9.13.0
-[9.12.4]: https://github.com/willmcgugan/rich/compare/v9.12.3...v9.12.4
-[9.12.3]: https://github.com/willmcgugan/rich/compare/v9.12.2...v9.12.3
-[9.12.2]: https://github.com/willmcgugan/rich/compare/v9.12.1...v9.12.2
-[9.12.1]: https://github.com/willmcgugan/rich/compare/v9.12.0...v9.12.1
-[9.12.0]: https://github.com/willmcgugan/rich/compare/v9.11.1...v9.12.0
-[9.11.1]: https://github.com/willmcgugan/rich/compare/v9.11.0...v9.11.1
-[9.11.0]: https://github.com/willmcgugan/rich/compare/v9.10.0...v9.11.0
-[9.10.0]: https://github.com/willmcgugan/rich/compare/v9.9.0...v9.10.0
-[9.9.0]: https://github.com/willmcgugan/rich/compare/v9.8.2...v9.9.0
-[9.8.2]: https://github.com/willmcgugan/rich/compare/v9.8.1...v9.8.2
-[9.8.1]: https://github.com/willmcgugan/rich/compare/v9.8.0...v9.8.1
-[9.8.0]: https://github.com/willmcgugan/rich/compare/v9.7.0...v9.8.0
-[9.7.0]: https://github.com/willmcgugan/rich/compare/v9.6.2...v9.7.0
-[9.6.2]: https://github.com/willmcgugan/rich/compare/v9.6.1...v9.6.2
-[9.6.1]: https://github.com/willmcgugan/rich/compare/v9.6.0...v9.6.1
-[9.6.0]: https://github.com/willmcgugan/rich/compare/v9.5.1...v9.6.0
-[9.5.1]: https://github.com/willmcgugan/rich/compare/v9.5.0...v9.5.1
-[9.5.0]: https://github.com/willmcgugan/rich/compare/v9.4.0...v9.5.0
-[9.4.0]: https://github.com/willmcgugan/rich/compare/v9.3.0...v9.4.0
-[9.3.0]: https://github.com/willmcgugan/rich/compare/v9.2.0...v9.3.0
-[9.2.0]: https://github.com/willmcgugan/rich/compare/v9.1.0...v9.2.0
-[9.1.0]: https://github.com/willmcgugan/rich/compare/v9.0.1...v9.1.0
-[9.0.1]: https://github.com/willmcgugan/rich/compare/v9.0.0...v9.0.1
-[9.0.0]: https://github.com/willmcgugan/rich/compare/v8.0.0...v9.0.0
-[8.0.0]: https://github.com/willmcgugan/rich/compare/v7.1.0...v8.0.0
-[7.1.0]: https://github.com/willmcgugan/rich/compare/v7.0.0...v7.1.0
-[7.0.0]: https://github.com/willmcgugan/rich/compare/v6.2.0...v7.0.0
-[6.2.0]: https://github.com/willmcgugan/rich/compare/v6.1.2...v6.2.0
-[6.1.2]: https://github.com/willmcgugan/rich/compare/v6.1.1...v6.1.2
-[6.1.1]: https://github.com/willmcgugan/rich/compare/v6.1.0...v6.1.1
-[6.1.0]: https://github.com/willmcgugan/rich/compare/v6.0.0...v6.1.0
-[6.0.0]: https://github.com/willmcgugan/rich/compare/v5.2.1...v6.0.0
-[5.2.1]: https://github.com/willmcgugan/rich/compare/v5.2.0...v5.2.1
-[5.2.0]: https://github.com/willmcgugan/rich/compare/v5.1.2...v5.2.0
-[5.1.2]: https://github.com/willmcgugan/rich/compare/v5.1.1...v5.1.2
-[5.1.1]: https://github.com/willmcgugan/rich/compare/v5.1.0...v5.1.1
-[5.1.0]: https://github.com/willmcgugan/rich/compare/v5.0.0...v5.1.0
-[5.0.0]: https://github.com/willmcgugan/rich/compare/v4.2.2...v5.0.0
-[4.2.2]: https://github.com/willmcgugan/rich/compare/v4.2.1...v4.2.2
-[4.2.1]: https://github.com/willmcgugan/rich/compare/v4.2.0...v4.2.1
-[4.2.0]: https://github.com/willmcgugan/rich/compare/v4.1.0...v4.2.0
-[4.1.0]: https://github.com/willmcgugan/rich/compare/v4.0.0...v4.1.0
-[4.0.0]: https://github.com/willmcgugan/rich/compare/v3.4.1...v4.0.0
-[3.4.1]: https://github.com/willmcgugan/rich/compare/v3.4.0...v3.4.1
-[3.4.0]: https://github.com/willmcgugan/rich/compare/v3.3.2...v3.4.0
-[3.3.2]: https://github.com/willmcgugan/rich/compare/v3.3.1...v3.3.2
-[3.3.1]: https://github.com/willmcgugan/rich/compare/v3.3.0...v3.3.1
-[3.3.0]: https://github.com/willmcgugan/rich/compare/v3.2.0...v3.3.0
-[3.2.0]: https://github.com/willmcgugan/rich/compare/v3.1.0...v3.2.0
-[3.1.0]: https://github.com/willmcgugan/rich/compare/v3.0.5...v3.1.0
-[3.0.5]: https://github.com/willmcgugan/rich/compare/v3.0.4...v3.0.5
-[3.0.4]: https://github.com/willmcgugan/rich/compare/v3.0.3...v3.0.4
-[3.0.3]: https://github.com/willmcgugan/rich/compare/v3.0.2...v3.0.3
-[3.0.2]: https://github.com/willmcgugan/rich/compare/v3.0.1...v3.0.2
-[3.0.1]: https://github.com/willmcgugan/rich/compare/v3.0.0...v3.0.1
-[3.0.0]: https://github.com/willmcgugan/rich/compare/v2.3.1...v3.0.0
-[2.3.1]: https://github.com/willmcgugan/rich/compare/v2.3.0...v2.3.1
-[2.3.0]: https://github.com/willmcgugan/rich/compare/v2.2.6...v2.3.0
-[2.2.6]: https://github.com/willmcgugan/rich/compare/v2.2.5...v2.2.6
-[2.2.5]: https://github.com/willmcgugan/rich/compare/v2.2.4...v2.2.5
-[2.2.4]: https://github.com/willmcgugan/rich/compare/v2.2.3...v2.2.4
-[2.2.3]: https://github.com/willmcgugan/rich/compare/v2.2.2...v2.2.3
-[2.2.2]: https://github.com/willmcgugan/rich/compare/v2.2.1...v2.2.2
-[2.2.1]: https://github.com/willmcgugan/rich/compare/v2.2.0...v2.2.1
-[2.2.0]: https://github.com/willmcgugan/rich/compare/v2.1.0...v2.2.0
-[2.1.0]: https://github.com/willmcgugan/rich/compare/v2.0.1...v2.1.0
-[2.0.1]: https://github.com/willmcgugan/rich/compare/v2.0.0...v2.0.1
-[2.0.0]: https://github.com/willmcgugan/rich/compare/v1.3.1...v2.0.0
-[1.3.1]: https://github.com/willmcgugan/rich/compare/v1.3.0...v1.3.1
-[1.3.0]: https://github.com/willmcgugan/rich/compare/v1.2.3...v1.3.0
-[1.2.3]: https://github.com/willmcgugan/rich/compare/v1.2.2...v1.2.3
-[1.2.2]: https://github.com/willmcgugan/rich/compare/v1.2.1...v1.2.2
-[1.2.1]: https://github.com/willmcgugan/rich/compare/v1.2.0...v1.2.1
-[1.2.0]: https://github.com/willmcgugan/rich/compare/v1.1.9...v1.2.0
-[1.1.9]: https://github.com/willmcgugan/rich/compare/v1.1.8...v1.1.9
-[1.1.8]: https://github.com/willmcgugan/rich/compare/v1.1.7...v1.1.8
-[1.1.7]: https://github.com/willmcgugan/rich/compare/v1.1.6...v1.1.7
-[1.1.6]: https://github.com/willmcgugan/rich/compare/v1.1.5...v1.1.6
-[1.1.5]: https://github.com/willmcgugan/rich/compare/v1.1.4...v1.1.5
-[1.1.4]: https://github.com/willmcgugan/rich/compare/v1.1.3...v1.1.4
-[1.1.3]: https://github.com/willmcgugan/rich/compare/v1.1.2...v1.1.3
-[1.1.2]: https://github.com/willmcgugan/rich/compare/v1.1.1...v1.1.2
-[1.1.1]: https://github.com/willmcgugan/rich/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/willmcgugan/rich/compare/v1.0.3...v1.1.0
-[1.0.3]: https://github.com/willmcgugan/rich/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/willmcgugan/rich/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/willmcgugan/rich/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/willmcgugan/rich/compare/v0.8.13...v1.0.0
-[0.8.13]: https://github.com/willmcgugan/rich/compare/v0.8.12...v0.8.13
-[0.8.12]: https://github.com/willmcgugan/rich/compare/v0.8.11...v0.8.12
-[0.8.11]: https://github.com/willmcgugan/rich/compare/v0.8.10...v0.8.11
-[0.8.10]: https://github.com/willmcgugan/rich/compare/v0.8.9...v0.8.10
-[0.8.9]: https://github.com/willmcgugan/rich/compare/v0.8.8...v0.8.9
-[0.8.8]: https://github.com/willmcgugan/rich/compare/v0.8.7...v0.8.8
-[0.8.7]: https://github.com/willmcgugan/rich/compare/v0.8.6...v0.8.7
-[0.8.6]: https://github.com/willmcgugan/rich/compare/v0.8.5...v0.8.6
-[0.8.5]: https://github.com/willmcgugan/rich/compare/v0.8.4...v0.8.5
-[0.8.4]: https://github.com/willmcgugan/rich/compare/v0.8.3...v0.8.4
-[0.8.3]: https://github.com/willmcgugan/rich/compare/v0.8.2...v0.8.3
-[0.8.2]: https://github.com/willmcgugan/rich/compare/v0.8.1...v0.8.2
-[0.8.1]: https://github.com/willmcgugan/rich/compare/v0.8.0...v0.8.1
-[0.8.0]: https://github.com/willmcgugan/rich/compare/v0.7.2...v0.8.0
-[0.7.2]: https://github.com/willmcgugan/rich/compare/v0.7.1...v0.7.2
-[0.7.1]: https://github.com/willmcgugan/rich/compare/v0.7.0...v0.7.1
-[0.7.0]: https://github.com/willmcgugan/rich/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/willmcgugan/rich/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/willmcgugan/rich/compare/v0.4.1...v0.5.0
-[0.4.1]: https://github.com/willmcgugan/rich/compare/v0.4.0...v0.4.1
-[0.4.0]: https://github.com/willmcgugan/rich/compare/v0.3.3...v0.4.0
-[0.3.3]: https://github.com/willmcgugan/rich/compare/v0.3.2...v0.3.3
-[0.3.2]: https://github.com/willmcgugan/rich/compare/v0.3.1...v0.3.2
-[0.3.1]: https://github.com/willmcgugan/rich/compare/v0.3.0...v0.3.1
-[0.3.0]: https://github.com/willmcgugan/rich/compare/v0.2.0...v0.3.0
+[unreleased]: https://github.com/Textualize/rich/compare/v12.5.2...HEAD
+[12.5.2]: https://github.com/Textualize/rich/compare/v12.5.1...v12.5.2
+[12.5.1]: https://github.com/Textualize/rich/compare/v12.5.0...v12.5.1
+[12.5.0]: https://github.com/Textualize/rich/compare/v12.4.4...v12.5.0
+[12.4.4]: https://github.com/Textualize/rich/compare/v12.4.3...v12.4.4
+[12.4.3]: https://github.com/Textualize/rich/compare/v12.4.2...v12.4.3
+[12.4.2]: https://github.com/Textualize/rich/compare/v12.4.1...v12.4.2
+[12.4.1]: https://github.com/Textualize/rich/compare/v12.4.0...v12.4.1
+[12.4.0]: https://github.com/Textualize/rich/compare/v12.3.0...v12.4.0
+[12.3.0]: https://github.com/Textualize/rich/compare/v12.2.0...v12.3.0
+[12.2.0]: https://github.com/Textualize/rich/compare/v12.1.0...v12.2.0
+[12.1.0]: https://github.com/Textualize/rich/compare/v12.0.1...v12.1.0
+[12.0.1]: https://github.com/Textualize/rich/compare/v12.0.0...v12.0.1
+[12.0.0]: https://github.com/Textualize/rich/compare/v11.2.0...v12.0.0
+[11.2.0]: https://github.com/Textualize/rich/compare/v11.1.0...v11.2.0
+[11.1.0]: https://github.com/Textualize/rich/compare/v11.0.0...v11.1.0
+[11.0.0]: https://github.com/Textualize/rich/compare/v10.16.1...v11.0.0
+[10.16.2]: https://github.com/Textualize/rich/compare/v10.16.1...v10.16.2
+[10.16.1]: https://github.com/Textualize/rich/compare/v10.16.0...v10.16.1
+[10.16.0]: https://github.com/Textualize/rich/compare/v10.15.2...v10.16.0
+[10.15.2]: https://github.com/Textualize/rich/compare/v10.15.1...v10.15.2
+[10.15.1]: https://github.com/Textualize/rich/compare/v10.15.0...v10.15.1
+[10.15.0]: https://github.com/Textualize/rich/compare/v10.14.0...v10.15.0
+[10.14.0]: https://github.com/Textualize/rich/compare/v10.13.0...v10.14.0
+[10.13.0]: https://github.com/Textualize/rich/compare/v10.12.0...v10.13.0
+[10.12.0]: https://github.com/Textualize/rich/compare/v10.11.0...v10.12.0
+[10.11.0]: https://github.com/Textualize/rich/compare/v10.10.0...v10.11.0
+[10.10.0]: https://github.com/Textualize/rich/compare/v10.9.0...v10.10.0
+[10.9.0]: https://github.com/Textualize/rich/compare/v10.8.0...v10.9.0
+[10.8.0]: https://github.com/Textualize/rich/compare/v10.7.0...v10.8.0
+[10.7.0]: https://github.com/Textualize/rich/compare/v10.6.0...v10.7.0
+[10.6.0]: https://github.com/Textualize/rich/compare/v10.5.0...v10.6.0
+[10.5.0]: https://github.com/Textualize/rich/compare/v10.4.0...v10.5.0
+[10.4.0]: https://github.com/Textualize/rich/compare/v10.3.0...v10.4.0
+[10.3.0]: https://github.com/Textualize/rich/compare/v10.2.2...v10.3.0
+[10.2.2]: https://github.com/Textualize/rich/compare/v10.2.1...v10.2.2
+[10.2.1]: https://github.com/Textualize/rich/compare/v10.2.0...v10.2.1
+[10.2.0]: https://github.com/Textualize/rich/compare/v10.1.0...v10.2.0
+[10.1.0]: https://github.com/Textualize/rich/compare/v10.0.1...v10.1.0
+[10.0.1]: https://github.com/Textualize/rich/compare/v10.0.0...v10.0.1
+[10.0.0]: https://github.com/Textualize/rich/compare/v9.13.0...v10.0.0
+[9.13.0]: https://github.com/Textualize/rich/compare/v9.12.4...v9.13.0
+[9.12.4]: https://github.com/Textualize/rich/compare/v9.12.3...v9.12.4
+[9.12.3]: https://github.com/Textualize/rich/compare/v9.12.2...v9.12.3
+[9.12.2]: https://github.com/Textualize/rich/compare/v9.12.1...v9.12.2
+[9.12.1]: https://github.com/Textualize/rich/compare/v9.12.0...v9.12.1
+[9.12.0]: https://github.com/Textualize/rich/compare/v9.11.1...v9.12.0
+[9.11.1]: https://github.com/Textualize/rich/compare/v9.11.0...v9.11.1
+[9.11.0]: https://github.com/Textualize/rich/compare/v9.10.0...v9.11.0
+[9.10.0]: https://github.com/Textualize/rich/compare/v9.9.0...v9.10.0
+[9.9.0]: https://github.com/Textualize/rich/compare/v9.8.2...v9.9.0
+[9.8.2]: https://github.com/Textualize/rich/compare/v9.8.1...v9.8.2
+[9.8.1]: https://github.com/Textualize/rich/compare/v9.8.0...v9.8.1
+[9.8.0]: https://github.com/Textualize/rich/compare/v9.7.0...v9.8.0
+[9.7.0]: https://github.com/Textualize/rich/compare/v9.6.2...v9.7.0
+[9.6.2]: https://github.com/Textualize/rich/compare/v9.6.1...v9.6.2
+[9.6.1]: https://github.com/Textualize/rich/compare/v9.6.0...v9.6.1
+[9.6.0]: https://github.com/Textualize/rich/compare/v9.5.1...v9.6.0
+[9.5.1]: https://github.com/Textualize/rich/compare/v9.5.0...v9.5.1
+[9.5.0]: https://github.com/Textualize/rich/compare/v9.4.0...v9.5.0
+[9.4.0]: https://github.com/Textualize/rich/compare/v9.3.0...v9.4.0
+[9.3.0]: https://github.com/Textualize/rich/compare/v9.2.0...v9.3.0
+[9.2.0]: https://github.com/Textualize/rich/compare/v9.1.0...v9.2.0
+[9.1.0]: https://github.com/Textualize/rich/compare/v9.0.1...v9.1.0
+[9.0.1]: https://github.com/Textualize/rich/compare/v9.0.0...v9.0.1
+[9.0.0]: https://github.com/Textualize/rich/compare/v8.0.0...v9.0.0
+[8.0.0]: https://github.com/Textualize/rich/compare/v7.1.0...v8.0.0
+[7.1.0]: https://github.com/Textualize/rich/compare/v7.0.0...v7.1.0
+[7.0.0]: https://github.com/Textualize/rich/compare/v6.2.0...v7.0.0
+[6.2.0]: https://github.com/Textualize/rich/compare/v6.1.2...v6.2.0
+[6.1.2]: https://github.com/Textualize/rich/compare/v6.1.1...v6.1.2
+[6.1.1]: https://github.com/Textualize/rich/compare/v6.1.0...v6.1.1
+[6.1.0]: https://github.com/Textualize/rich/compare/v6.0.0...v6.1.0
+[6.0.0]: https://github.com/Textualize/rich/compare/v5.2.1...v6.0.0
+[5.2.1]: https://github.com/Textualize/rich/compare/v5.2.0...v5.2.1
+[5.2.0]: https://github.com/Textualize/rich/compare/v5.1.2...v5.2.0
+[5.1.2]: https://github.com/Textualize/rich/compare/v5.1.1...v5.1.2
+[5.1.1]: https://github.com/Textualize/rich/compare/v5.1.0...v5.1.1
+[5.1.0]: https://github.com/Textualize/rich/compare/v5.0.0...v5.1.0
+[5.0.0]: https://github.com/Textualize/rich/compare/v4.2.2...v5.0.0
+[4.2.2]: https://github.com/Textualize/rich/compare/v4.2.1...v4.2.2
+[4.2.1]: https://github.com/Textualize/rich/compare/v4.2.0...v4.2.1
+[4.2.0]: https://github.com/Textualize/rich/compare/v4.1.0...v4.2.0
+[4.1.0]: https://github.com/Textualize/rich/compare/v4.0.0...v4.1.0
+[4.0.0]: https://github.com/Textualize/rich/compare/v3.4.1...v4.0.0
+[3.4.1]: https://github.com/Textualize/rich/compare/v3.4.0...v3.4.1
+[3.4.0]: https://github.com/Textualize/rich/compare/v3.3.2...v3.4.0
+[3.3.2]: https://github.com/Textualize/rich/compare/v3.3.1...v3.3.2
+[3.3.1]: https://github.com/Textualize/rich/compare/v3.3.0...v3.3.1
+[3.3.0]: https://github.com/Textualize/rich/compare/v3.2.0...v3.3.0
+[3.2.0]: https://github.com/Textualize/rich/compare/v3.1.0...v3.2.0
+[3.1.0]: https://github.com/Textualize/rich/compare/v3.0.5...v3.1.0
+[3.0.5]: https://github.com/Textualize/rich/compare/v3.0.4...v3.0.5
+[3.0.4]: https://github.com/Textualize/rich/compare/v3.0.3...v3.0.4
+[3.0.3]: https://github.com/Textualize/rich/compare/v3.0.2...v3.0.3
+[3.0.2]: https://github.com/Textualize/rich/compare/v3.0.1...v3.0.2
+[3.0.1]: https://github.com/Textualize/rich/compare/v3.0.0...v3.0.1
+[3.0.0]: https://github.com/Textualize/rich/compare/v2.3.1...v3.0.0
+[2.3.1]: https://github.com/Textualize/rich/compare/v2.3.0...v2.3.1
+[2.3.0]: https://github.com/Textualize/rich/compare/v2.2.6...v2.3.0
+[2.2.6]: https://github.com/Textualize/rich/compare/v2.2.5...v2.2.6
+[2.2.5]: https://github.com/Textualize/rich/compare/v2.2.4...v2.2.5
+[2.2.4]: https://github.com/Textualize/rich/compare/v2.2.3...v2.2.4
+[2.2.3]: https://github.com/Textualize/rich/compare/v2.2.2...v2.2.3
+[2.2.2]: https://github.com/Textualize/rich/compare/v2.2.1...v2.2.2
+[2.2.1]: https://github.com/Textualize/rich/compare/v2.2.0...v2.2.1
+[2.2.0]: https://github.com/Textualize/rich/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/Textualize/rich/compare/v2.0.1...v2.1.0
+[2.0.1]: https://github.com/Textualize/rich/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/Textualize/rich/compare/v1.3.1...v2.0.0
+[1.3.1]: https://github.com/Textualize/rich/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/Textualize/rich/compare/v1.2.3...v1.3.0
+[1.2.3]: https://github.com/Textualize/rich/compare/v1.2.2...v1.2.3
+[1.2.2]: https://github.com/Textualize/rich/compare/v1.2.1...v1.2.2
+[1.2.1]: https://github.com/Textualize/rich/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/Textualize/rich/compare/v1.1.9...v1.2.0
+[1.1.9]: https://github.com/Textualize/rich/compare/v1.1.8...v1.1.9
+[1.1.8]: https://github.com/Textualize/rich/compare/v1.1.7...v1.1.8
+[1.1.7]: https://github.com/Textualize/rich/compare/v1.1.6...v1.1.7
+[1.1.6]: https://github.com/Textualize/rich/compare/v1.1.5...v1.1.6
+[1.1.5]: https://github.com/Textualize/rich/compare/v1.1.4...v1.1.5
+[1.1.4]: https://github.com/Textualize/rich/compare/v1.1.3...v1.1.4
+[1.1.3]: https://github.com/Textualize/rich/compare/v1.1.2...v1.1.3
+[1.1.2]: https://github.com/Textualize/rich/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/Textualize/rich/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/Textualize/rich/compare/v1.0.3...v1.1.0
+[1.0.3]: https://github.com/Textualize/rich/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/Textualize/rich/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/Textualize/rich/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/Textualize/rich/compare/v0.8.13...v1.0.0
+[0.8.13]: https://github.com/Textualize/rich/compare/v0.8.12...v0.8.13
+[0.8.12]: https://github.com/Textualize/rich/compare/v0.8.11...v0.8.12
+[0.8.11]: https://github.com/Textualize/rich/compare/v0.8.10...v0.8.11
+[0.8.10]: https://github.com/Textualize/rich/compare/v0.8.9...v0.8.10
+[0.8.9]: https://github.com/Textualize/rich/compare/v0.8.8...v0.8.9
+[0.8.8]: https://github.com/Textualize/rich/compare/v0.8.7...v0.8.8
+[0.8.7]: https://github.com/Textualize/rich/compare/v0.8.6...v0.8.7
+[0.8.6]: https://github.com/Textualize/rich/compare/v0.8.5...v0.8.6
+[0.8.5]: https://github.com/Textualize/rich/compare/v0.8.4...v0.8.5
+[0.8.4]: https://github.com/Textualize/rich/compare/v0.8.3...v0.8.4
+[0.8.3]: https://github.com/Textualize/rich/compare/v0.8.2...v0.8.3
+[0.8.2]: https://github.com/Textualize/rich/compare/v0.8.1...v0.8.2
+[0.8.1]: https://github.com/Textualize/rich/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/Textualize/rich/compare/v0.7.2...v0.8.0
+[0.7.2]: https://github.com/Textualize/rich/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/Textualize/rich/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/Textualize/rich/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/Textualize/rich/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/Textualize/rich/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/Textualize/rich/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/Textualize/rich/compare/v0.3.3...v0.4.0
+[0.3.3]: https://github.com/Textualize/rich/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/Textualize/rich/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/Textualize/rich/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/Textualize/rich/compare/v0.2.0...v0.3.0

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,3 +51,4 @@ The following people have contributed to the development of Rich:
 - [Motahhar Mokfi](https://github.com/motahhar)
 - [Tomer Shalev](https://github.com/tomers)
 - [Serkan UYSAL](https://github.com/uysalserkan)
+- [Calum Young](https://github.com/calumy)

--- a/README.cn.md
+++ b/README.cn.md
@@ -4,30 +4,30 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich 是一个 Python 库，可以为您在终端中提供富文本和精美格式。
 
 [Rich 的 API](https://rich.readthedocs.io/en/latest/) 让在终端输出颜色和样式变得很简单。此外，Rich 还可以绘制漂亮的表格、进度条、markdown、语法高亮的源代码以及栈回溯信息（tracebacks）等——开箱即用。
 
-![功能纵览](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![功能纵览](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 有关 Rich 的视频介绍，请参见
 [@fishnets88](https://twitter.com/fishnets88) 录制的
@@ -57,7 +57,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## 在交互式命令行（REPL）中使用 Rich
 
@@ -68,7 +68,7 @@ Rich 可以被安装到 Python 交互式命令行中，那样做以后，任何�
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## 使用控制台
 
@@ -96,7 +96,7 @@ console.print("Hello", "World!", style="bold red")
 
 输出如下图：
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 这个范例一次只设置了一行文字的样式。如果想获得更细腻更复杂的样式，Rich 可以渲染一个特殊的标记，其语法类似于[bbcode](https://en.wikipedia.org/wiki/BBCode)。示例如下：
 
@@ -104,7 +104,7 @@ console.print("Hello", "World!", style="bold red")
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![控制台标记](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![控制台标记](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 使用`Console`对象，你可以花最少的工夫生成复杂的输出。更详细的内容可查阅 [Console API](https://rich.readthedocs.io/en/latest/console.html) 文档。
 
@@ -118,9 +118,9 @@ Rich 提供一个 [inspect](https://rich.readthedocs.io/en/latest/reference/init
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
-查看  [inspect 文档](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect)详细了解。
+查看 [inspect 文档](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect)详细了解。
 
 # Rich 库内容
 
@@ -158,7 +158,7 @@ test_log()
 
 以上范例的输出如下：
 
-![日志](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![日志](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 注意其中的`log_locals`参数会输出一个表格，该表格包含调用 log 方法的局部变量。
 
@@ -170,7 +170,7 @@ log 方法既可用于将常驻进程（例如服务器进程）的日志打印�
 
 您还可以使用内置的[处理器类](https://rich.readthedocs.io/en/latest/logging.html)来对 Python 的 logging 模块的输出进行格式化和着色。下面是输出示例：
 
-![记录](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![记录](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -225,13 +225,13 @@ console.print(table)
 
 该示例的输出如下：
 
-![表格](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![表格](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 请注意，控制台标记的呈现方式与`print()`和`log()`相同。实际上，由 Rich 渲染的任何内容都可以添加到标题/行（甚至其他表格）中。
 
 `Table`类很聪明，可以调整列的大小以适合终端的可用宽度，并能根据需要对文字折行。下面是相同的示例，输出与比上表小的终端上：
 
-![表格 2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![表格 2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -251,13 +251,13 @@ for step in track(range(100)):
 
 添加多个进度条并不难。以下是从文档中获取的示例：
 
-![进度](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![进度](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 这些列可以配置为显示您所需的任何详细信息。内置列包括完成百分比，文件大小，文件速度和剩余时间。下面是显示正在进行的下载的示例：
 
-![进度](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![进度](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-要自己尝试一下，请参阅[examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py)，它可以在显示进度的同时下载多个 URL。
+要自己尝试一下，请参阅[examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py)，它可以在显示进度的同时下载多个 URL。
 
 </details>
 
@@ -282,7 +282,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 这会往终端生成以下输出：
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 这个旋转动画借鉴自 [cli-spinners](https://www.npmjs.com/package/cli-spinners) 项目。你可以通过`spinner`参数指定一种动画效果。执行以下命令来查看所有可选值：
 
@@ -292,7 +292,7 @@ python -m rich.spinner
 
 这会往终端输出以下内容：
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -309,9 +309,9 @@ python -m rich.tree
 
 这会产生以下输出：
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-[tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) 是一个展示任意目录的文件树视图的样例文件，类似于 Linux 中的 `tree` 命令。
+[tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) 是一个展示任意目录的文件树视图的样例文件，类似于 Linux 中的 `tree` 命令。
 
 </details>
 
@@ -331,9 +331,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-以下屏幕截图是[列示例](https://github.com/willmcgugan/rich/blob/master/examples/columns.py)的输出，该列显示了从 API 提取的数据：
+以下屏幕截图是[列示例](https://github.com/Textualize/rich/blob/master/examples/columns.py)的输出，该列显示了从 API 提取的数据：
 
-![列](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![列](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -356,7 +356,7 @@ console.print(markdown)
 
 该例子的输出如下图：
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -391,7 +391,7 @@ console.print(syntax)
 
 输出如下：
 
-![语法](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![语法](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -402,7 +402,7 @@ Rich 可以渲染出漂亮的[栈回溯信息](https://rich.readthedocs.io/en/la
 
 下面是在 OSX（在 Linux 上也类似）系统的效果：
 
-![回溯](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![回溯](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -421,7 +421,7 @@ Rich 可以渲染出漂亮的[栈回溯信息](https://rich.readthedocs.io/en/la
 - [hedythedev/StarCli](https://github.com/hedythedev/starcli)
   通过命令行浏览 GitHub 热门项目
 - [intel/cve-bin-tool](https://github.com/intel/cve-bin-tool)
-  这个工具可以扫描一些常见的、有漏洞的组件（openssl、libpng、libxml2、expat和其他一些组件），让你知道你的系统是否包含有已知漏洞的常用库。
+  这个工具可以扫描一些常见的、有漏洞的组件（openssl、libpng、libxml2、expat 和其他一些组件），让你知道你的系统是否包含有已知漏洞的常用库。
 - [nf-core/tools](https://github.com/nf)
   包含 nf-core 社区帮助工具的 Python 包
 - [cansarigol/pdbr](https://github.com/cansarigol/pdbr)
@@ -429,9 +429,9 @@ Rich 可以渲染出漂亮的[栈回溯信息](https://rich.readthedocs.io/en/la
 - [plant99/felicette](https://github.com/plant99/felicette)
   傻瓜式卫星图像
 - [seleniumbase/SeleniumBase](https://github.com/seleniumbase/SeleniumBase)
-  使用 Selenium 和 pytest 使自动化和测试速度提高10倍，包括电池
+  使用 Selenium 和 pytest 使自动化和测试速度提高 10 倍，包括电池
 - [smacke/ffsubsync](https://github.com/smacke/ffsubsync)
   自动将字幕与视频同步
 - [tryolabs/norfair](https://github.com/tryolabs/norfair)
   轻量级 Python 库，用于向任何检测器添加实时 2D 对象跟踪
-- +[还有很多](https://github.com/willmcgugan/rich/network/dependents)!
+- +[还有很多](https://github.com/Textualize/rich/network/dependents)!

--- a/README.de-ch.md
+++ b/README.de-ch.md
@@ -4,30 +4,30 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich isch ä Python Library för _rich_ Text ond ganz schöni formatiärig im Törminäl
 
 D [Rich API](https://rich.readthedocs.io/en/latest/) machts ganz eifach zom Farbä ond Stiil zu de Törminälusgob hinzu z füäge. Rich cha au schöni Tabelle, Progressbare, Markdown, Syntax hervorhebe, Tracebäcks und meh darstelle — fix fertig usem Böxli.
 
-![Features](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Features](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 E Video Iifüärig öber Rich geds onder [calmcode.io](https://calmcode.io/rich/introduction.html) vo [@fishnets88](https://twitter.com/fishnets88).
 
@@ -63,7 +63,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -74,7 +74,7 @@ Rich cha i de Python REPL installiert werde so dass irgend e Datestruktuur hübs
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Console bruchä
 
@@ -102,7 +102,7 @@ console.print("Hello", "World!", style="bold red")
 
 D Usgob gsiät öppe ä so us:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 Da isch guät für d Gstalltig vom Text pro Liniä. Vör ä granularäri Gstalltig hed Rich e spezielli Markup mitäre ähnloche Befehlsufbau wiä [bbcode](https://en.wikipedia.org/wiki/BBCode). Do es Bispiil:
 
@@ -110,7 +110,7 @@ Da isch guät für d Gstalltig vom Text pro Liniä. Vör ä granularäri Gstallt
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 Du chasch mitmäne Console Objekt mit wenig Ufwand aasprechendi Usgob erziile. Lueg do d [Console API](https://rich.readthedocs.io/en/latest/console.html) Dokumentation für d Details a.
 
@@ -124,7 +124,7 @@ Rich hät e [inspect](https://rich.readthedocs.io/en/latest/reference/init.html?
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 Lueg do d [inspect Dokumentation](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) für d Details a.
 
@@ -164,7 +164,7 @@ test_log()
 
 Das do obe gid di folgend Usgob:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 Beachte s Argument `log_locals` wo innere Tabelle di lokalä Variable us gid zur Zitt wo d Methodä ufgruäfä worde isch.
 
@@ -176,7 +176,7 @@ D log Methodä cha zum is Törminäl inne z Logge für langläbige Applikationä
 
 Du chasch au d Builtin [Handler Class](https://rich.readthedocs.io/en/latest/logging.html) verwende zum d Usgob vom Python logging Module z formatiäre und iifärbe. Do es Bispiil vo de Usgob:
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -199,9 +199,9 @@ Bitte verwend diä Funktion gschiid.
 
 Rich cha flexiibäl [Tabelle](https://rich.readthedocs.io/en/latest/tables.html) mit Boxä us Unicodezeiche generiäre. Es gid e Viilzahl vo Formatiärigsoptionä für Ränder, Stiil, Zelleusrichtig ond so witter.
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-D Animation obe isch mit [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) us em Bispiil-Ordner erstellt worde.
+D Animation obe isch mit [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) us em Bispiil-Ordner erstellt worde.
 
 Do es eifachs Tabelle-Bispiil:
 
@@ -237,13 +237,13 @@ console.print(table)
 
 Das gid di folgend Usgob:
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 Beacht das d Konsole Markup glich wie bi `print()` ond `log()` generiärt wird. Ond zwor cha alles wo vo Rich generiert werde cha au im Chopf / Zille iigfüägt werde (sogar anderi Tabellene).
 
 D Klass `Table` isch gschiid gnuäg yum d Spaltebreite am verfüägbare Platz im Törminäl aazpasse und de Text gegäbenefalls umzbreche. Do isch s gliche Bispiil mit em Törminäl chlinner als d Tabelle vo obe:
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -263,13 +263,13 @@ for step in track(range(100)):
 
 Es isch nöd vill schwiriger zum mehräri Progress Bars hinzuä zfüäge. Do es Bispiil us de Doku:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 D Spaltä cha so konfiguriärt werde das alli gwünschte Details aazeigt werded. D Built-in Spalte beinhaltät Prozentsatz, Dateigrössi, Dateigschwindikeit ond öbrigi Zitt. Do isch e andos Bispiil wo en laufände Download zeigt:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-Zums selber usprobiäre lueg [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) a, wo cha glichzittig mehräri URLs abelade und de Fortschritt aazeige.
+Zums selber usprobiäre lueg [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) a, wo cha glichzittig mehräri URLs abelade und de Fortschritt aazeige.
 
 </details>
 
@@ -294,7 +294,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 Das gid di folgendi Usgob im Törminäl.
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 D Spinner Animatione sind vo [cli-spinners](https://www.npmjs.com/package/cli-spinners) usglehnt. Du chasch en speziifischä Spinner mit em `spinner` Parameter uswähle. Start de folgend Befehl zom die verfüägbare Wert z gsiä:
 
@@ -304,7 +304,7 @@ python -m rich.spinner
 
 De Befehl obe generiärt di folgändi Usgob im Törminäl:
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -321,9 +321,9 @@ python -m rich.tree
 
 Das generiärt di folgend Usgob:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-Lueg s Bispiil Script [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) für e Darstellig vo irgend eim Ordner als Tree, glich wie de Linux Befehl `tree`.
+Lueg s Bispiil Script [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) für e Darstellig vo irgend eim Ordner als Tree, glich wie de Linux Befehl `tree`.
 
 </details>
 
@@ -343,9 +343,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-De folgend Screenshot isch d Usgob vom [Spalte-Bispiil](https://github.com/willmcgugan/rich/blob/master/examples/columns.py), wo Date vonnere API hollt ond in Spaltene darstellt:
+De folgend Screenshot isch d Usgob vom [Spalte-Bispiil](https://github.com/Textualize/rich/blob/master/examples/columns.py), wo Date vonnere API hollt ond in Spaltene darstellt:
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -368,7 +368,7 @@ console.print(markdown)
 
 Das wird d Usgob ungefär wie s Folgende geh:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -403,7 +403,7 @@ console.print(syntax)
 
 Das wird d Usgob ungefär wie s Folgende geh:
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -414,7 +414,7 @@ Rich cha [wunderschöni Tracebacks](https://rich.readthedocs.io/en/latest/traceb
 
 So gsiets ungefär ufemen OSX (ähnloch uf Linux) us:
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -454,6 +454,6 @@ Do es paar Projekt wo Rich verwended:
   Lightweight Python library for adding real-time 2D object tracking to any detector.
 - [ansible/ansible-lint](https://github.com/ansible/ansible-lint) Ansible-lint checks playbooks for practices and behaviour that could potentially be improved
 - [ansible-community/molecule](https://github.com/ansible-community/molecule) Ansible Molecule testing framework
-- +[Vieli meh](https://github.com/willmcgugan/rich/network/dependents)!
+- +[Vieli meh](https://github.com/Textualize/rich/network/dependents)!
 
 <!-- This is a test, no need to translate -->

--- a/README.de.md
+++ b/README.de.md
@@ -4,30 +4,30 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich ist eine Python-Bibliothek für _rich_ Text und schöne Formatierung im Terminal.
 
 Die [Rich API](https://rich.readthedocs.io/en/latest/) erleichtert das Hinzufügen von Farbe und Stil zur Terminalausgabe. Rich kann auch schöne Tabellen, Fortschrittsbalken, Markdowns, durch Syntax hervorgehobenen Quellcode, Tracebacks und mehr sofort rendern.
 
-![Features](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Features](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 Eine Video-Einführung in Rich findest du unter [quietcode.io](https://calmcode.io/rich/introduction.html) von [@ fishnets88](https://twitter.com/fishnets88).
 
@@ -63,7 +63,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -74,7 +74,7 @@ Rich kann in Python REPL installiert werden, so dass alle Datenstrukturen schön
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Verwenden der Konsole
 
@@ -102,7 +102,7 @@ console.print("Hello", "World!", style="bold red")
 
 Die Ausgabe wird in etwa wie folgt aussehen:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 Das ist gut, um jeweils eine Textzeile zu stylen. Für eine detailliertere Gestaltung bietet Rich ein spezielles Markup an, das in der Syntax ähnlich [bbcode](https://en.wikipedia.org/wiki/BBCode) ist. Hier ein Beispiel:
 
@@ -110,7 +110,7 @@ Das ist gut, um jeweils eine Textzeile zu stylen. Für eine detailliertere Gesta
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 Du kannst ein Console-Objekt verwenden, um mit minimalem Aufwand anspruchsvolle Ausgaben zu erzeugen. Siehe [Konsolen-API](https://rich.readthedocs.io/en/latest/console.html) für Details.
 
@@ -124,7 +124,7 @@ Rich hat eine Funktion [inspect](https://rich.readthedocs.io/en/latest/reference
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 Siehe [Doks Inspektor](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) für Details.
 
@@ -164,7 +164,7 @@ test_log()
 
 Die obige Funktion erzeugt die folgende Ausgabe:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 Beachte das Argument `log_locals`, das eine Tabelle mit den lokalen Variablen ausgibt, in der die log-Methode aufgerufen wurde.
 
@@ -176,7 +176,7 @@ Die log-Methode kann für die Protokollierung auf dem Terminal für langlaufende
 
 Du kannst auch die eingebaute [Handler-Klasse](https://rich.readthedocs.io/en/latest/logging.html) verwenden, um die Ausgabe von Pythons Logging-Modul zu formatieren und einzufärben. Hier ein Beispiel für die Ausgabe:
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -199,9 +199,9 @@ Bitte verwenden Sie diese Funktion mit Bedacht.
 
 Rich kann flexible [Tabellen](https://rich.readthedocs.io/en/latest/tables.html) mit Unicode-Box-Characters darstellen. Es gibt eine Vielzahl von Formatierungsmöglichkeiten für Rahmen, Stile, Zellausrichtung usw.
 
-![Film-Tabelle](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![Film-Tabelle](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-Die obige Animation wurde mit [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) im Verzeichnis `examples` erzeugt.
+Die obige Animation wurde mit [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) im Verzeichnis `examples` erzeugt.
 
 Hier ist ein einfacheres Tabellenbeispiel:
 
@@ -237,13 +237,13 @@ console.print(table)
 
 Dies erzeugt diese Ausgabe:
 
-![Tabelle](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![Tabelle](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 Beachte, dass das Konsolen-Markup auf die gleiche Weise gerendert wird wie `print()` und `log()`. Tatsächlich kann alles, was von Rich gerendert werden kann, in den Kopfzeilen/Zeilen enthalten sein (sogar andere Tabellen).
 
 Die Klasse `Table` ist intelligent genug, um die Größe der Spalten an die verfügbare Breite des Terminals anzupassen und den Text wie erforderlich umzubrechen. Hier ist das gleiche Beispiel, wobei das Terminal kleiner als bei der obigen Tabelle ist:
 
-![Tabelle2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![Tabelle2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -252,7 +252,7 @@ Die Klasse `Table` ist intelligent genug, um die Größe der Spalten an die verf
 
 Rich kann mehrere flackerfreie [Fortschrittsbalken](https://rich.readthedocs.io/en/latest/progress.html) darstellen, um langlaufende Aufgaben zu verfolgen.
 
-Einfachste Anwendung ist, eine beliebige Sequenz in die Funktion `track` einzupacken und  über das Ergebnis zu iterieren. Hier ein Beispiel:
+Einfachste Anwendung ist, eine beliebige Sequenz in die Funktion `track` einzupacken und über das Ergebnis zu iterieren. Hier ein Beispiel:
 
 ```python
 from rich.progress import track
@@ -263,13 +263,13 @@ for step in track(range(100)):
 
 Es ist nicht viel schwieriger, mehrere Fortschrittsbalken hinzuzufügen. Hier ein Beispiel aus der Doku:
 
-![Fortschritt](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![Fortschritt](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 Die Spalten können so konfiguriert werden, dass sie alle gewünschten Details anzeigen. Zu den eingebauten Spalten gehören Prozentsatz der Fertigstellung, Dateigröße, Downloadgeschwindigkeit und verbleibende Zeit. Hier ist ein weiteres Beispiel, das einen laufenden Download anzeigt:
 
-![Fortschritt](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![Fortschritt](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-Um dies selbst auszuprobieren, sieh dir [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) an, das mehrere URLs gleichzeitig herunterladen kann und dabei den Fortschritt anzeigt.
+Um dies selbst auszuprobieren, sieh dir [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) an, das mehrere URLs gleichzeitig herunterladen kann und dabei den Fortschritt anzeigt.
 
 </details>
 
@@ -294,7 +294,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 Dies erzeugt diese Ausgabe im Terminal.
 
-![Status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![Status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 Die Spinner-Animationen wurden von [cli-spinners](https://www.npmjs.com/package/cli-spinners) geliehen. Du kannst einen Spinner auswählen, indem du den Parameter `spinner` angibst. Führe den folgenden Befehl aus, um die verfügbaren Werte zu sehen:
 
@@ -304,7 +304,7 @@ python -m rich.spinner
 
 Der obige Befehl erzeugt die folgende Ausgabe im Terminal:
 
-![Spinner](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![Spinner](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -321,9 +321,9 @@ python -m rich.tree
 
 Dies erzeugt diese Ausgabe:
 
-![Markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![Markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-Siehe das Beispiel [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) für ein Skript, das eine Baumansicht eines beliebigen Verzeichnisses anzeigt, ähnlich dem Linux-Befehl `tree`.
+Siehe das Beispiel [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) für ein Skript, das eine Baumansicht eines beliebigen Verzeichnisses anzeigt, ähnlich dem Linux-Befehl `tree`.
 
 </details>
 
@@ -343,9 +343,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-Der folgende Screenshot ist die Ausgabe von [Spalten-Beispiel](https://github.com/willmcgugan/rich/blob/master/examples/columns.py), das Daten, die aus einer API kommen, in Spalten anzeigt:
+Der folgende Screenshot ist die Ausgabe von [Spalten-Beispiel](https://github.com/Textualize/rich/blob/master/examples/columns.py), das Daten, die aus einer API kommen, in Spalten anzeigt:
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -368,7 +368,7 @@ console.print(markdown)
 
 Dies erzeugt diese Ausgabe:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -403,7 +403,7 @@ console.print(syntax)
 
 Dies erzeugt die folgende Ausgabe:
 
-![Syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![Syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -414,7 +414,7 @@ Rich kann [schöne Tracebacks](https://rich.readthedocs.io/en/latest/traceback.h
 
 So sieht es unter OSX aus (ähnlich unter Linux):
 
-![Traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![Traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -454,4 +454,4 @@ Hier sind ein paar Projekte, die Rich verwenden:
   Leichtgewichtige Python-Bibliothek zum Hinzufügen von 2D-Objektverfolgung in Echtzeit zu jedem Detektor.
 - [ansible/ansible-lint](https://github.com/ansible/ansible-lint) Ansible-lint prüft Playbooks auf Praktiken und Verhalten, die möglicherweise verbessert werden könnten
 - [ansible-community/molecule](https://github.com/ansible-community/molecule) Ansible Molecule-Testing-Framework
-- +[Viele weitere](https://github.com/willmcgugan/rich/network/dependents)!
+- +[Viele weitere](https://github.com/Textualize/rich/network/dependents)!

--- a/README.es.md
+++ b/README.es.md
@@ -4,30 +4,30 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich es un paquete de Python para texto _enriquecido_ y un hermoso formato en la terminal.
 
 La [API Rich](https://rich.readthedocs.io/en/latest/) facilita la adición de color y estilo a la salida del terminal. Rich también puede representar tablas bonitas, barras de progreso, markdown, código fuente resaltado por sintaxis, trazas y más — listo para usar.
 
-![Funciones](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Funciones](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 Para ver un vídeo de introducción a Rich, consulte [calmcode.io](https://calmcode.io/rich/introduction.html) de [@fishnets88](https://twitter.com/fishnets88).
 
@@ -63,7 +63,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -74,7 +74,7 @@ Rich se puede instalar en Python REPL, por lo que cualquier estructura de datos 
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Usando la consola
 
@@ -102,7 +102,7 @@ console.print("Hello", "World!", style="bold red")
 
 La salida será similar a la siguiente:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 Eso está bien para diseñar una línea de texto a la vez. Para un estilo más fino, Rich presenta un marcado especial que es similar en sintaxis a [bbcode](https://en.wikipedia.org/wiki/BBCode). He aquí un ejemplo:
 
@@ -110,7 +110,7 @@ Eso está bien para diseñar una línea de texto a la vez. Para un estilo más f
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 Usted puede usar el objeto Console para generar salida sofisticada con mínimo esfuerzo. Ver la [API Console](https://rich.readthedocs.io/en/latest/console.html) docs para detalles.
 
@@ -124,7 +124,7 @@ Rich tiene ua función [inspeccionar](https://rich.readthedocs.io/en/latest/refe
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 Ver la [docs inspector](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) para detalles.
 
@@ -164,7 +164,7 @@ test_log()
 
 Lo anterior produce el siguiente resultado:
 
-![Registro](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Registro](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 Tenga en cuenta el argumento `log_locals`, que genera una tabla que contiene las variables locales donde se llamó al método log.
 
@@ -174,9 +174,10 @@ El método de registro podría usarse para iniciar sesión en el terminal para a
 <details>
 <summary>Controlador de registro</summary>
 
-También puede usar la [Handler class](https://rich.readthedocs.io/en/latest/logging.html) incorporada  para formatear y colorear la salida del módulo de registro de Python. Aquí hay un ejemplo de la salida:
+También puede usar la [Handler class](https://rich.readthedocs.io/en/latest/logging.html) incorporada para formatear y colorear la salida del módulo de registro de Python. Aquí hay un ejemplo de la salida:
 
-![Registro](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Registro](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
+
 </details>
 
 <details>
@@ -190,6 +191,7 @@ Para insertar un emoji en la salida de la consola, coloque el nombre entre dos p
 ```
 
 Utilice esta función con prudencia.
+
 </details>
 
 <details>
@@ -197,9 +199,9 @@ Utilice esta función con prudencia.
 
 Rich puede renderizar [tablas](https://rich.readthedocs.io/en/latest/tables.html) flexibles con caracteres de cuadro Unicode. Existe una gran variedad de opciones de formato para bordes, estilos, alineación de celdas, etc.
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-La animación anterior se generó con [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) en el directorio de ejemplos.
+La animación anterior se generó con [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) en el directorio de ejemplos.
 
 Aquí hay un ejemplo de tabla más simple:
 
@@ -235,13 +237,13 @@ console.print(table)
 
 Esto produce la siguiente salida:
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 Tenga en cuenta que el marcado de la consola se representa de la misma manera que `print()` y `log()`. De hecho, cualquier cosa que Rich pueda representar se puede incluir en los encabezados / filas (incluso en otras tablas).
 
 La clase `Table` es lo suficientemente inteligente como para cambiar el tamaño de las columnas para que se ajusten al ancho disponible de la terminal, ajustando el texto según sea necesario. Este es el mismo ejemplo, con la terminal más pequeña que la tabla anterior:
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -261,13 +263,13 @@ for step in track(range(100)):
 
 No es mucho más difícil agregar varias barras de progreso. Aquí hay un ejemplo tomado de la documentación:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 Las columnas pueden configurarse para mostrar los detalles que desee. Las columnas integradas incluyen porcentaje completado, tamaño de archivo, velocidad de archivo y tiempo restante. Aquí hay otro ejemplo que muestra una descarga en progreso:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-Para probar esto usted mismo, consulte [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) que puede descargar varias URL simultáneamente mientras muestra el progreso.
+Para probar esto usted mismo, consulte [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) que puede descargar varias URL simultáneamente mientras muestra el progreso.
 
 </details>
 
@@ -292,7 +294,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 Esto genera la siguiente salida en el terminal.
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 Las animaciones de spinner fueron tomadas de [cli-spinners](https://www.npmjs.com/package/cli-spinners). Puede seleccionar un spinner especificando el `spinner` parameter. Ejecute el siguiente comando para ver los valores disponibles:
 
@@ -302,7 +304,7 @@ python -m rich.spinner
 
 El comando anterior genera la siguiente salida en la terminal:
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -319,9 +321,9 @@ python -m rich.tree
 
 Esto genera la siguiente salida:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-Ver el ejemplo [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) para un script que muestra una vista de  árbol de cualquier directorio, similar a el comando de linux `tree`.
+Ver el ejemplo [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) para un script que muestra una vista de árbol de cualquier directorio, similar a el comando de linux `tree`.
 
 </details>
 
@@ -341,9 +343,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-La siguiente captura de pantalla es el resultado del [ejemplo de columnas](https://github.com/willmcgugan/rich/blob/master/examples/columns.py) que muestra los datos extraídos de una API en columnas:
+La siguiente captura de pantalla es el resultado del [ejemplo de columnas](https://github.com/Textualize/rich/blob/master/examples/columns.py) que muestra los datos extraídos de una API en columnas:
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -366,7 +368,7 @@ console.print(markdown)
 
 Esto producirá una salida similar a la siguiente:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -401,7 +403,7 @@ console.print(syntax)
 
 Esto producirá el siguiente resultado:
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -412,7 +414,7 @@ Rich puede representar [tracebacks hermosos](https://rich.readthedocs.io/en/late
 
 Así es como se ve en OSX (similar en Linux):
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -452,4 +454,4 @@ Aquí hay algunos proyectos que usan Rich:
   Libreria de Python para agregar tracking a cualquier detector.
 - [ansible/ansible-lint](https://github.com/ansible/ansible-lint) Ansible-lint comprueba los playbooks en busca de prácticas y comportamientos que podrían mejorarse
 - [ansible-community/molecule](https://github.com/ansible-community/molecule) Marco de prueba de Ansible Molecule
-- +¡[Muchos más](https://github.com/willmcgugan/rich/network/dependents)!
+- +¡[Muchos más](https://github.com/Textualize/rich/network/dependents)!

--- a/README.fa.md
+++ b/README.fa.md
@@ -5,24 +5,24 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
- • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 ریچ یک کتاب خانه پایتون برای متن های _باشکوه_ و قالب بندی زیبا در ترمینال است.
 
@@ -36,8 +36,7 @@
 (Tracebacks),
 و غیره را به صورت خودکار در ترمینال نمایش دهد.
 
-
-![قابلیت ها](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![قابلیت ها](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 برای معرفی ویدئویی ریچ این ویدئو را ببینید [calmcode.io](https://calmcode.io/rich/introduction.html) توسط [@fishnets88](https://twitter.com/fishnets88).
 
@@ -51,7 +50,7 @@
 3.6.3
 یا جدیدتر نیاز دارد.
 
-ریچ با  [ژوپیتر نوت بوک (Jupyter notebooks)](https://jupyter.org/)
+ریچ با [ژوپیتر نوت بوک (Jupyter notebooks)](https://jupyter.org/)
 بدون نیازمندی اضافه ای کار می کند.
 
 ## نصب کردن
@@ -72,11 +71,11 @@ python -m rich
 
 ## Rich Print
 
-برای اضافه کردن راحت خروجی ریچ به برنامه خودتان، شما می توانید 
+برای اضافه کردن راحت خروجی ریچ به برنامه خودتان، شما می توانید
 [rich print](https://rich.readthedocs.io/en/latest/introduction.html#quick-start)
 را به پروژه خودتان اضافه
 (Import)
-کنید که اثر یکسانی مشابه تابع داخلی پایتون دارد. 
+کنید که اثر یکسانی مشابه تابع داخلی پایتون دارد.
 این قطعه کد را امتحان کنید:
 
 ```python
@@ -85,7 +84,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -98,7 +97,7 @@ print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## استفاده از Console
 
@@ -148,7 +147,7 @@ console.print("Hello", "World!", style="bold red")
 
 خروجی چیزی شبیه به این است:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 تا اینجا برای سبک و استایل دادن به یک خط خوب است. برای سبکی با دانه بندی (Finely Grained Styling)، ریچ یک نشانه گذاری خاص ارائه می دهند که چیزی شبیه به [bbcode](https://en.wikipedia.org/wiki/BBCode) است. مثال آن به صورت زیر است:
 
@@ -156,9 +155,9 @@ console.print("Hello", "World!", style="bold red")
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
-شما می توانید از یک شیء Console برای تولید خروجی پیچیده، با کمترین تلاش استفاده کنید. برای جزئیات بیشتر به  [Console API](https://rich.readthedocs.io/en/latest/console.html)  مراجعه کنید.
+شما می توانید از یک شیء Console برای تولید خروجی پیچیده، با کمترین تلاش استفاده کنید. برای جزئیات بیشتر به [Console API](https://rich.readthedocs.io/en/latest/console.html) مراجعه کنید.
 
 ## Rich Inspect
 
@@ -170,7 +169,7 @@ console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 برای جزئیات بیشتر به [inspect docs](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) مراجعه کنید.
 
@@ -185,7 +184,6 @@ console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i
 
 شیء Console دارای یک تابع `()log` است که رفتاری مشابه `()print` دارد، اما همچنین یک ستون برای نمایش زمان، فایل مربوطه و شماره خطِ کدِ اجرا شده در نظر می گیرد. به صورت پیشفرض، ریچ علائم (syntax) را برای ساختار های پایتون و برای رشته (String)
 های repr برجسته می کند. اگر شما یک مجموعه (دیکشنری یا لیست) را چاپ کنید، ریچ به زیبایی آن را در فضای موجود چاپ می کند. مثال زیر نمایش برخی ویژگی های آن است:
-
 
 ```python
 from rich.console import Console
@@ -212,7 +210,7 @@ test_log()
 
 قطعه کد بالا، خروجی زیر را تولد می کند:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 به متغیر های `log_locals` توجه کنید، جایی که تابع log صدا زده می شود، یک جدول که شامل متغیر های محلی است در خروجی نمایش داده می شود.
 
@@ -224,7 +222,7 @@ test_log()
 
 همچنین شما می توانید از [Handler class](https://rich.readthedocs.io/en/latest/logging.html) های داخلی برای فرمت دادن و رنگی کردن خروجی از ماژول گزارش پایتون (Python's logging module) استفاده کنید. کد زیر یک مثال از خروجی را نشان می دهد:
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -247,9 +245,9 @@ test_log()
 
 ریچ توانایی آن را دارد که [جداول](https://rich.readthedocs.io/en/latest/tables.html) انعطاف پذیری را با کارکتر های یونیکد (unicode) بسازد.
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-انیمشن بالا با استفاده از [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) در دایرکتوری (پوشه) تست ساخته شده است.
+انیمشن بالا با استفاده از [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) در دایرکتوری (پوشه) تست ساخته شده است.
 
 این یک مثال ساده از جدول است:
 
@@ -285,13 +283,13 @@ console.print(table)
 
 این کد خروجی زیر را تولید می کند:
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
-توجه داشته باشید که نشانه گذاری کنسول به همان روش  `print()` و `log()` پردازش می شود. در واقع، هر چیزی که توسط Rich قابل رندر است در هدرها / ردیف ها (حتی جداول دیگر) ممکن است گنجانده شود.
+توجه داشته باشید که نشانه گذاری کنسول به همان روش `print()` و `log()` پردازش می شود. در واقع، هر چیزی که توسط Rich قابل رندر است در هدرها / ردیف ها (حتی جداول دیگر) ممکن است گنجانده شود.
 
 کلاس `Table` به اندازه کافی هوشمند است که اندازه ستون ها را متناسب با عرض موجود ترمینال تغییر دهد و متن را در صورت لزوم بسته بندی کند. این همان مثال با ترمینال کوچکتر از جدول بالاست:
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -311,13 +309,13 @@ for step in track(range(100)):
 
 اضافه کردن چندین نوار پیشرفت خیلی سخت نیست. مثال آن که برگرفته از اسناد و داکیومنت میباشد به صورت زیر است:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 ستون ها ممکن است به گونه ای پیکربندی شوند که جزئیاتی را که می خواهید نشان دهند. ستون های از پیش تعیین شده شامل درصد کامل شده، اندازه فایل، سرعت فایل و زمان باقی مانده است. در زیر مثال دیگری وجود دارد که دانلود در حال انجام را نشان می دهد:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-برای اینکه خودتان این را امتحان کنید، فایل [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) را ببینید که می‌تواند چندین لینک URL را به طور همزمان بارگیری کند و پیشرفت را نشان دهد.
+برای اینکه خودتان این را امتحان کنید، فایل [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) را ببینید که می‌تواند چندین لینک URL را به طور همزمان بارگیری کند و پیشرفت را نشان دهد.
 
 </details>
 
@@ -342,7 +340,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 این کد خروجی زیر را در ترمینال ایجاد می کند.
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 در انیمیشن های چرخنده از [cli-spinners](https://www.npmjs.com/package/cli-spinners) استفاده شده است. شما می توانید با تعیین پارامتر `spinner` یک چرخنده را انتخاب کنید. برای مشاهده موارد موجود، دستور زیر را اجرا کنید:
 
@@ -352,7 +350,7 @@ python -m rich.spinner
 
 دستور بالا خروجی زیر را در ترمینال ایجاد می کند:
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -369,9 +367,9 @@ python -m rich.tree
 
 این کد خروجی زیر را ایجاد می کند:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-مثال [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) را برای اسکریپتی ببینید که نمایش درختی از هر دایرکتوری را نمایش می دهد، شبیه به فرمان `tree` در لینوکس است.
+مثال [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) را برای اسکریپتی ببینید که نمایش درختی از هر دایرکتوری را نمایش می دهد، شبیه به فرمان `tree` در لینوکس است.
 
 </details>
 
@@ -379,7 +377,6 @@ python -m rich.tree
 <summary>Columns</summary>
 
 ریچ می تواند محتوا را به صورت [columns](https://rich.readthedocs.io/en/latest/columns.html) مرتب با عرض مساوی یا بهینه ارائه دهد. مثال زیر یک شبیه سازی بسیار ابتدایی از دستور `ls` در (مک او اس / لینوکس) است که فهرست دایرکتوری را در ستون ها نمایش می دهد:
-
 
 ```python
 import os
@@ -392,9 +389,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-تصویر زیر خروجی [columns example](https://github.com/willmcgugan/rich/blob/master/examples/columns.py) است که داده های استخراج شده از یک API را در ستون ها نمایش می دهد:
+تصویر زیر خروجی [columns example](https://github.com/Textualize/rich/blob/master/examples/columns.py) است که داده های استخراج شده از یک API را در ستون ها نمایش می دهد:
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -403,8 +400,7 @@ print(Columns(directory))
 
 ریچ میتواند [markdown](https://rich.readthedocs.io/en/latest/markdown.html) را پردازش کند و کار مناسبی را برای فرمت بندی آن در ترمینال انجام میدهد.
 
-برای پردازش markdown کافی است تا کلاس `Markdown` آنرا فرا خوانی کرده و یک شی از آن را بسازید و متن حاوی markdown  را به آن بدهید. در نهایت آنرا در کنسول و ترمینال چاپ کنید. مثال آن به صورت زیر است:
-
+برای پردازش markdown کافی است تا کلاس `Markdown` آنرا فرا خوانی کرده و یک شی از آن را بسازید و متن حاوی markdown را به آن بدهید. در نهایت آنرا در کنسول و ترمینال چاپ کنید. مثال آن به صورت زیر است:
 
 ```python
 from rich.console import Console
@@ -418,7 +414,7 @@ console.print(markdown)
 
 خروجی کد بالا چیزی شبیه به تصویر زیر را تولید می کند:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -453,7 +449,7 @@ console.print(syntax)
 
 این کد خروجی زیر را ایجاد می کند:
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -464,7 +460,7 @@ console.print(syntax)
 
 در مک او اس به صورت زیر نمایش داده می شود (در لینوکس نیز مشابه این است):
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -476,8 +472,6 @@ console.print(syntax)
 # Rich CLI
 
 همچنین [Rich CLI](https://github.com/textualize/rich-cli) را که برای برنامه های دستوری (command line)، توسط Rich ساخته شده است ببینید. برجسته سازی کد (Syntax highlight code)، پردازش کردن مارک دون، نمایش فایل های CSV در جدول ها و موارد بیشتر، به صورت مستقیم از خط فرمان و ترمینال.
-
-
 
 ![Rich CLI](https://raw.githubusercontent.com/Textualize/rich-cli/main/imgs/rich-cli-splash.jpg)
 

--- a/README.fa.md
+++ b/README.fa.md
@@ -1,7 +1,7 @@
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/rich/10.11.0)](https://pypi.org/project/rich/) [![PyPI version](https://badge.fury.io/py/rich.svg)](https://badge.fury.io/py/rich)
 
 [![Downloads](https://pepy.tech/badge/rich/month)](https://pepy.tech/project/rich)
-[![codecov](https://img.shields.io/codecov/c/github/Textualize/rich?label=codecov&logo=codecov)](https://codecov.io/gh/willmcgugan/rich)
+[![codecov](https://img.shields.io/codecov/c/github/Textualize/rich?label=codecov&logo=codecov)](https://codecov.io/gh/Textualize/rich)
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -4,30 +4,30 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich est une bibliothèque Python pour le _rich_ texte et la mise en forme dans le terminal.
 
 L'[API Rich](https://rich.readthedocs.io/en/latest/) permet d'ajouter facilement de la couleur et du style sur la sortie du terminal. Rich peut également rendre de jolis tableaux, des barres de progression, du markdown, du code source avec de la coloration syntaxique, des traçeurs d'erreurs et bien d'autres choses encore, et ce dès le départ.
 
-![Features](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Features](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 Pour une introduction vidéo à Rich, voir [camelcode.io](https://calmcode.io/rich/introduction.html) par [@ fishnets88](https://twitter.com/fishnets88)
 
@@ -63,7 +63,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -74,7 +74,7 @@ Rich peut être installé dans le REPL de Python, de sorte que toutes les struct
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Utilisation de Console
 
@@ -102,7 +102,7 @@ console.print("Hello", "World!", style="bold red")
 
 La sortie sera quelque chose comme ce qui suit :
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 C'est très bien pour styliser une ligne de texte à la fois. Pour un style plus fin, Rich rend un balisage spécial dont la syntaxe est similaire à celle du [bbcode](https://en.wikipedia.org/wiki/BBCode). Voici un exemple :
 
@@ -110,7 +110,7 @@ C'est très bien pour styliser une ligne de texte à la fois. Pour un style plus
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 Vous pouvez utiliser un objet Console pour générer une sortie sophistiquée avec un effort minimal. Consultez la documentation de l'[API Console](https://rich.readthedocs.io/en/latest/console.html) pour plus de détails.
 
@@ -124,11 +124,12 @@ Rich possède une fonction [inspect](https://rich.readthedocs.io/en/latest/refer
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 Consultez la [documentation d'inspect](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) pour plus de détails.
 
 ## Bibliothèque Rich
+
 Rich contient un certain nombre _d'éléments de rendu_ intégrés que vous pouvez utiliser pour créer une sortie élégante dans votre CLI et vous aider à déboguer votre code.
 
 Cliquez sur les rubriques suivantes pour plus de détails :
@@ -163,11 +164,12 @@ test_log()
 
 L'opération ci-dessus produit le résultat suivant :
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 Notez l'argument `log_locals`, qui produit un tableau contenant les variables locales où la méthode log a été appelée.
 
 La méthode log peut être utilisée pour la journalisation vers le terminal pour les applications qui tournent longtemps, comme les serveurs, mais c'est aussi une très bonne aide au débogage.
+
 </details>
 
 <details>
@@ -175,7 +177,8 @@ La méthode log peut être utilisée pour la journalisation vers le terminal pou
 
 Vous pouvez également utiliser la classe intégrée [Handler](https://rich.readthedocs.io/en/latest/logging.html) pour formater et coloriser les sorties du module de journalisation de Python. Voici un exemple de sortie :
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
+
 </details>
 
 <details>
@@ -189,6 +192,7 @@ Pour insérer un emoji dans la sortie de la console, placez le nom entre deux po
 ```
 
 Veuillez utiliser cette fonction à bon escient.
+
 </details>
 
 <details>
@@ -196,9 +200,9 @@ Veuillez utiliser cette fonction à bon escient.
 
 Rich peut rendre des [tableaux](https://rich.readthedocs.io/en/latest/tables.html) flexibles avec des caractères de boîte unicode. Il existe une grande variété d'options de formatage pour les bordures, les styles, l'alignement des cellules, etc.
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-L'animation ci-dessus a été générée avec [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) dans le répertoire des exemples.
+L'animation ci-dessus a été générée avec [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) dans le répertoire des exemples.
 
 Voici un exemple de tableau plus simple :
 
@@ -234,13 +238,14 @@ console.print(table)
 
 Cela produit le résultat suivant :
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 Notez que les balises de la console sont rendues de la même manière que `print()` et `log()`. En fait, tout ce qui peut être rendu par Rich peut être inclus dans les en-têtes / lignes (même d'autres tables).
 
 La classe `Table` est suffisamment intelligente pour redimensionner les colonnes en fonction de la largeur disponible du terminal, en enveloppant le texte si nécessaire. Voici le même exemple, avec un terminal plus petit que le tableau ci-dessus :
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
+
 </details>
 
 <details>
@@ -259,13 +264,13 @@ for step in track(range(100)):
 
 Il n'est pas beaucoup plus difficile d'ajouter plusieurs barres de progression. Voici un exemple tiré de la documentation :
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 Les colonnes peuvent être configurées pour afficher tous les détails que vous souhaitez. Les colonnes intégrées comprennent le pourcentage d'achèvement, la taille du fichier, la vitesse du fichier et le temps restant. Voici un autre exemple montrant un téléchargement en cours :
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-Pour l'essayer vous-même, voyez [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) qui peut télécharger plusieurs URL simultanément tout en affichant la progression.
+Pour l'essayer vous-même, voyez [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) qui peut télécharger plusieurs URL simultanément tout en affichant la progression.
 
 </details>
 
@@ -290,7 +295,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 Cela génère la sortie suivante dans le terminal.
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 Les animations des toupies ont été empruntées à [cli-spinners](https://www.npmjs.com/package/cli-spinners). Vous pouvez sélectionner un spinner en spécifiant le paramètre `spinner`. Exécutez la commande suivante pour voir les valeurs disponibles :
 
@@ -300,7 +305,8 @@ python -m rich.spinner
 
 La commande ci-dessus génère la sortie suivante dans le terminal :
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
+
 </details>
 
 <details>
@@ -316,9 +322,9 @@ python -m rich.tree
 
 La commande ci-dessus génère la sortie suivante dans le terminal :
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-Voir l'exemple [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) pour un script qui affiche une vue arborescente de n'importe quel répertoire, similaire à la commande linux `tree`.
+Voir l'exemple [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) pour un script qui affiche une vue arborescente de n'importe quel répertoire, similaire à la commande linux `tree`.
 
 </details>
 
@@ -338,9 +344,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-La capture d'écran suivante est le résultat de [columns example](https://github.com/willmcgugan/rich/blob/master/examples/columns.py) qui affiche les données extraites d'une API en colonnes :
+La capture d'écran suivante est le résultat de [columns example](https://github.com/Textualize/rich/blob/master/examples/columns.py) qui affiche les données extraites d'une API en colonnes :
 
-![colonne](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![colonne](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -363,7 +369,7 @@ console.print(markdown)
 
 Cela produira un résultat semblable à ce qui suit :
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -398,7 +404,8 @@ console.print(syntax)
 
 Cela produira le résultat suivant :
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
+
 </details>
 
 <details>
@@ -408,7 +415,7 @@ Rich peut rendre des [traçages d'erreurs](https://rich.readthedocs.io/en/latest
 
 Voici à quoi cela ressemble sous OSX (similaire sous Linux) :
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -446,4 +453,4 @@ Les mainteneurs de Rich et de milliers d'autres paquets collaborent avec Tidelif
   Bibliothèque Python légère pour ajouter le suivi d'objets 2D en temps réel à n'importe quel détecteur.
 - [ansible/ansible-lint](https://github.com/ansible/ansible-lint) Ansible-lint vérifie dans les playbooks les pratiques et comportements qui pourraient être améliorés.
 - [ansible-community/molecule](https://github.com/ansible-community/molecule) Cadre de test Ansible Molecule.
-- [Beaucoup d'autres](https://github.com/willmcgugan/rich/network/dependents) !
+- [Beaucoup d'autres](https://github.com/Textualize/rich/network/dependents) !

--- a/README.hi.md
+++ b/README.hi.md
@@ -4,34 +4,32 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich टर्मिनल में _समृद्ध_ पाठ और सुंदर स्वरूपण के लिए एक Python संग्रह है।
 
-
 [Rich API](https://rich.readthedocs.io/en/latest/) टर्मिनल उत्पादन में रंग और शैली डालना आसान बनाता है। Rich सुंदर सारणियाँ, प्रगति सूचक डंडे, markdown, रचनाक्रम चिन्हांकित स्त्रोत कोड, ट्रेसबैक आदि प्रस्तुत कर सकता है - बिना कुछ बदले।
 
-![Features](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Features](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 Rich के वीडियो परिचय के लिए देखें [@fishnets88](https://twitter.com/fishnets88) द्वारा बनाई गई [calmcode.io](https://calmcode.io/rich/introduction.html)।
-
 
 देखें [लोग रिच के बारे में क्या कह रहे हैं](https://www.willmcgugan.com/blog/pages/post/rich-tweets/)।
 
@@ -50,6 +48,7 @@ python -m pip install rich
 ```
 
 आपके टर्मिनल पर Rich उत्पादन का परीक्षण करने के लिए यह चलाएं:
+
 ```sh
 python -m rich
 ```
@@ -64,17 +63,18 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
 Rich को Python REPL में स्थापित किया जा सकता है, ताकि कोई भी डेटा संरचनाएं सुंदरता से छपे तथा चिह्नांकित हों।
+
 ```python
 >>> from rich import pretty
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## कॉनसोल (Console) का इस्तेमाल करना
 
@@ -87,21 +87,21 @@ console = Console()
 ```
 
 Console वस्तु के पास एक `print` क्रिया है जिसका अंतरापृष्ठ जानबूझ कर अंतर्निहित `print` क्रिया के सामान है। इसके इस्तेमाल का एक उदाहरण :
+
 ```python
 console.print("Hello", "World!")
 ```
 
-
 जैसा आप उम्मीद कर रहे होंगे, यह टर्मिनल पर `"Hello World!"` छाप देगा। ध्यान दें की अंतर्निहित `print` क्रिया के भिन्न, Rich आपके पाठ को "वर्ड-रैप" कर देगा ताकि वह टर्मिनल की चौड़ाई में फस सके।
 
 अपने उत्पादन में रंग और शैली डालने के लिए एक से अधिक तरीके हैं। `style` कीवर्ड तर्क जोड़कर आप सम्पूर्ण उत्पादन के लिए शैली निर्धारित कर सकते हैं। इसका एक उदाहरण:
+
 ```python
 console.print("Hello", "World!", style="bold red")
 ```
 
 उत्पादन कुछ इस प्रकार का होगा:
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
-
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 ये एक बारी में एक पंक्ति का शैलीकरण करने के लिए तो ठीक है। अधिक बारीकी से शैलीकरण करने के लिए, Rich एक विशेष मार्कअप को प्रदर्शित करता है जो रचनाक्रम में [bbcode](https://en.wikipedia.org/wiki/BBCode) से मिलता-जुलता है। इसका एक उदाहरण:
 
@@ -109,27 +109,27 @@ console.print("Hello", "World!", style="bold red")
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 कम-से-कम मेहनत में परिष्कृत उत्पादन उत्पन्न करने के लिए आप एक Console वस्तु का उपयोग कर सकते हैं। अधिक जानकारी के लिए आप [Console API](https://rich.readthedocs.io/en/latest/console.html) का प्रलेख पढ़ सकते हैं।
 
 ## Rich Inspect
 
 Rich में एक [inspect](https://rich.readthedocs.io/en/latest/reference/init.html?highlight=inspect#rich.inspect) फलन उपलब्ध है जो किसी भी Python वस्तु, जैसे की क्लास, इन्स्टैन्स या अंतर्निहित पर प्रतिवेदन उत्पादित कर सकता है।
+
 ```python
 >>> my_list = ["foo", "bar"]
 >>> from rich import inspect
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 अधिक जानकारी के लिए [inspect का प्रलेखन](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) पढ़ें।
 
 # Rich संग्रह
 
 Rich में कई अंतर्निहित _प्रतिपाद्य_ मौजूद हैं जिनका इस्तेमाल करके आप अपने CLI में सुंदर उत्पादन उत्पन्न कर सकते हैं तथा अपने कोड का दोषमार्जन (डीबग) करने में सहायता प सकते हैं।
-
 
 जानकारी के लिए निम्न शीर्षकों पर क्लिक करें:
 
@@ -163,7 +163,7 @@ test_log()
 
 उपर्युक्त कोड से निम्न उत्पादन उत्पन्न होता है:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 ध्यान दें `log_levels` तर्क की तरफ, जो एक सारणी उत्पादित करता है जिसमे लॉग फलन के आवाहन के स्थान के स्थानिये चर युक्त हैं।
 
@@ -175,7 +175,7 @@ test_log()
 
 Python के `logging` मापांक से आए हुए उत्पादन का संरूपण एवं रंगीकरण करने के लिए आप अंतर्निहित [Handler वर्ग](https://rich.readthedocs.io/en/latest/logging.html) का भी इस्तेमाल कर सकते हैं। उत्पादन का एक उपहरण प्रस्तुत है:
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -183,12 +183,14 @@ Python के `logging` मापांक से आए हुए उत्प�
 <summary>इमोजी</summary>
 
 Console उत्पादन में इमोजी डालने के लिए नाम को दो अपूर्ण विरामों (:) के बीच रखें। इसका एक उदाहरण:
+
 ```python
 >>> console.print(":smiley: :vampire: :pile_of_poo: :thumbs_up: :raccoon:")
 😃 🧛 💩 👍 🦝
 ```
 
 कृपया इसका इस्तेमाल समझदारी से करें।
+
 </details>
 
 <details>
@@ -196,11 +198,12 @@ Console उत्पादन में इमोजी डालने के �
 
 Rich यूनिकोड डिब्बा अक्षरों की सहायता से लचीली [सारणियाँ](https://rich.readthedocs.io/en/latest/tables.html) प्रदर्शित कर सकता है। सीमाएँ, शैलियाँ, कक्ष संरेखण आदि के लिए कई सारे स्वरूपण विकल्प उपलब्ध हैं।
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-उपर्युक्त अनुप्राणन examples डायरेक्टरी के [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) से बनाया गया है।
+उपर्युक्त अनुप्राणन examples डायरेक्टरी के [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) से बनाया गया है।
 
 इससे सरल संचिका का उदाहरण:
+
 ```python
 from rich.console import Console
 from rich.table import Table
@@ -233,13 +236,13 @@ console.print(table)
 
 इससे निम्नलिखित उत्पादन उत्पन्न होता है:
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 ध्यान दें की कॉनसोल मार्कअप `print()` और `log()` की तरह ही प्रदर्शित होते हैं। वास्तव में, कोई भी वस्तु जो Rich के द्वारा प्रदर्शनीय है वह शीर्षकों / पंक्तियों (दूसरी संचिकाओं में भी) में युक्त किया जा सकता है।
 
 `Table` वर्ग इतनी बुद्धिमान है की वह टर्मिनल की उपलब्ध चौड़ाई में फ़साने के लिए स्तंभों का आकार बदल सकता है, आवश्यकता के अनुसार पाठ को लपेटते हुए। यह वही उदाहरण है, टर्मिनल को उपर्युक्त संचिका से छोटा रखते हुए:
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -249,6 +252,7 @@ console.print(table)
 लंबे समय तक चलने वाले कार्यों पर नज़र रखने के लिए Rich अनेक झिलमिलाहट-मुक्त [प्रगति सूचक](https://rich.readthedocs.io/en/latest/progress.html) डंडे प्रदर्शित कर सकता है।
 
 बुनियादी उपयोग के लिए, किसी भी क्रम को `track` फलन में लपेटें और परिणाम पर पुनरावर्तन करें। इसका एक उदाहरण:
+
 ```python
 from rich.progress import track
 
@@ -257,18 +261,20 @@ for step in track(range(100)):
 ```
 
 अनेक प्रगति सूचक डंडे जोड़ने इससे अधिक कठिन नहीं है। ये रहा एक उदाहरण जो प्रलेखन से उठाया गया है:
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 स्तंभों का विन्यास इस प्रकार किया जा सकता है की आपकी इच्छानुसार विवरण दिखाए जाएँ। अंतर्निहित स्तंभ में प्रतिशत पूरा, संचिका आकार, संचिका गति तथा शेष समय युक्त होते हैं। ये रहा एक और उदाहरण एक चालू डाउनलोड को दर्शाते हुए।
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-इसे स्वयं आजमाने के लिए, देखें [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) जो अनेक URL एक साथ डाउनलोड करते हुए प्रगति दर्शाता है।
+इसे स्वयं आजमाने के लिए, देखें [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) जो अनेक URL एक साथ डाउनलोड करते हुए प्रगति दर्शाता है।
+
 </details>
 
 <details>
 <summary>स्थिति</summary>
 
 ऐसी परिस्थितियों में जहां प्रगति की गणना करना कठिन हों, आप [status](https://rich.readthedocs.io/en/latest/reference/console.html#rich.console.Console.status) (स्थिति) फलन का उपयोग कर सकते हैं जो एक 'स्पिनर' अनुप्राणन और संदेश दर्शाएगा। अनुप्राणन आपको सामान्य तरीके से कॉनसोल को इस्तेमाल करने से नहीं रोकेगा। ये एक उदाहरण:
+
 ```python
 from time import sleep
 from rich.console import Console
@@ -284,15 +290,16 @@ with console.status("[bold green]Working on tasks...") as status:
 ```
 
 इससे टर्मिनल में निम्नलिखित उत्पादन उत्पन्न होता है:
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 स्पिनर अनुप्राणन [cli-spinners](https://www.npmjs.com/package/cli-spinners) से उधारे गए थे। आप `spinner` प्राचल को उल्लिखित करके स्पिनर चुन सकते हैं। उपलब्ध विकल्प देखने के लिए निम्नलिखित आदेश चलकर देखें:
+
 ```
 python -m rich.spinner
 ```
 
 उपर्युक्त आदेश टर्मिनल में निम्नलिखित उत्पादन उतपन्न करता है:
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -302,21 +309,21 @@ python -m rich.spinner
 Rich मरकदर्शक रेखाओं से [tree](https://rich.readthedocs.io/en/latest/tree.html) (वृक्ष) प्रदर्शित कर सकता है। संचिता संरचना, अथवा कोई भी और पदानुक्रमित डेटा दर्शाने के लिए वृक्ष एक आदर्श विकल्प है।
 
 वृक्ष के नाम सरल पाठ्यांश या कुछ भी और जो Rich प्रदर्शित कर सके। इसके एक प्रदर्शन के लिए निम्नलिखित को चलाएं:
+
 ```
 python -m rich.tree
 ```
 
 इससे निम्न उत्पादन उत्पन्न होता है:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-देखें उदाहरण [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) एक क्रमादेश के लिए जो किसी भी डायरेक्टरी का वृक्ष दृश्य (ट्री व्यू) दर्शाएगा, लिनक्स के `tree` आदेश के समान।
+देखें उदाहरण [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) एक क्रमादेश के लिए जो किसी भी डायरेक्टरी का वृक्ष दृश्य (ट्री व्यू) दर्शाएगा, लिनक्स के `tree` आदेश के समान।
 
 </details>
 
 <details>
 <summary>स्तंभ</summary>
-
 
 Rich सामग्री को समान अथवा श्रेष्ट चौड़ाई के साथ स्पष्ट [स्तंभ](https://rich.readthedocs.io/en/latest/columns.html) प्रदर्शित कार सकता है। यही (MacOS / Linux) `ls` आदेश का बहुत बुनियादी प्रतिरूप प्रस्तुत किया गया है जो स्तंभों में डायरेक्टरी सूची को दर्शाता है।
 
@@ -331,8 +338,8 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-निम्न स्क्रीनशॉट [स्तंभों के उदाहरण](https://github.com/willmcgugan/rich/blob/master/examples/columns.py) का उत्पादन है जो एक API से खींचे गए डेटा को स्तंभों में प्रदर्शित करता है:
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+निम्न स्क्रीनशॉट [स्तंभों के उदाहरण](https://github.com/Textualize/rich/blob/master/examples/columns.py) का उत्पादन है जो एक API से खींचे गए डेटा को स्तंभों में प्रदर्शित करता है:
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -341,8 +348,8 @@ print(Columns(directory))
 
 Rich [markdown](https://rich.readthedocs.io/en/latest/markdown.html) को प्रदर्शित कार सकता है और स्वरूपण का अनुवाद टर्मिनल पर करने में उचित कार्य करता है।
 
-
 Markdown प्रदर्शित करने के लिए आप `Markdown` वर्ग को आयात कार सकते हैं और उसे markdown कोड युक्त अक्षरमाला के साथ निर्मित कर सकते हैं। फिर उसे कॉनसोल पर छापें। एक उदाहरण प्रस्तुत है:
+
 ```python
 from rich.console import Console
 from rich.markdown import Markdown
@@ -355,7 +362,7 @@ console.print(markdown)
 
 इससे कुछ इस प्रकार का उत्पादन उत्पन्न होगा:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -363,6 +370,7 @@ console.print(markdown)
 <summary>रचनाक्रम चिह्नांकन</summary>
 
 Rich [रचनाक्रम चिह्नांकन](https://rich.readthedocs.io/en/latest/syntax.html) के लिए [pygments](https://pygments.org/) संग्रह का उपयोग करता है। उपयोग markdown को प्रदर्शित करने से मिलता-जुलता है; एक `Syntax` वस्तु निर्मित करें और उसे कॉनसोल पर छापें। एक उदाहरण:
+
 ```python
 from rich.console import Console
 from rich.syntax import Syntax
@@ -390,7 +398,7 @@ console.print(syntax)
 This will produce the following output:
 इससे निम्न उत्पादन उत्पन्न होता है:
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -400,7 +408,7 @@ This will produce the following output:
 Rich [खूबसूरत ट्रेसबैक](https://rich.readthedocs.io/en/latest/traceback.html) दर्शा सकता है जो पढ़ने में आसान तथा मानक Python ट्रेसबैकों से अधिक कोड दिखाता है। आप Rich को व्यक्तीक्रम ट्रेसबैक संचालक भी निर्धारित कार सकते हैं ताकि सभी बेपकड़ अपवाद Rich के द्वारा प्रदर्शित हों।
 
 OSX (Linux पर समान) पर यह कुछ इस प्रकार दिखता है:
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -415,6 +423,7 @@ Rich एवं सहस्त्रों और संग्रहों क�
 # Rich का उपयोग करने वाली परियोजनाएँ
 
 ये रहे कुछ परियोजनाएँ जो Rich इस्तेमाल करते हैं।
+
 - [BrancoLab/BrainRender](https://github.com/BrancoLab/BrainRender)
   त्रिविम न्यूरो-संरचनात्मक डेटा का चित्रण करने के लिए एक Python संग्रह
 - [Ciphey/Ciphey](https://github.com/Ciphey/Ciphey)
@@ -441,6 +450,6 @@ Rich एवं सहस्त्रों और संग्रहों क�
   Ansible-lint उन आचरणों और व्यवहारों के लिए प्लेबुकों में जाँच करता है जिन्हे संभावित रूप से सुधारा जा सकता है
 - [ansible-community/molecule](https://github.com/ansible-community/molecule) Ansible Molecule testing framework
   Ansible Molecule परीक्षण ढांचा
-- +[कई और](https://github.com/willmcgugan/rich/network/dependents)!
+- +[कई और](https://github.com/Textualize/rich/network/dependents)!
 
 <!-- This is a test, no need to translate -->

--- a/README.id.md
+++ b/README.id.md
@@ -1,7 +1,7 @@
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/rich/10.11.0)](https://pypi.org/project/rich/) [![PyPI version](https://badge.fury.io/py/rich.svg)](https://badge.fury.io/py/rich)
 
 [![Downloads](https://pepy.tech/badge/rich/month)](https://pepy.tech/project/rich)
-[![codecov](https://img.shields.io/codecov/c/github/Textualize/rich?label=codecov&logo=codecov)](https://codecov.io/gh/willmcgugan/rich)
+[![codecov](https://img.shields.io/codecov/c/github/Textualize/rich?label=codecov&logo=codecov)](https://codecov.io/gh/Textualize/rich)
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 

--- a/README.id.md
+++ b/README.id.md
@@ -5,31 +5,31 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
- • [Indonesian readme](https://github.com/willmcgugan/rich/blob/master/README.id.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [Indonesian readme](https://github.com/Textualize/rich/blob/master/README.id.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich adalah library Python yang membantu _memperindah_ tampilan output suatu program di terminal.
 
 [Rich API](https://rich.readthedocs.io/en/latest/) dapat digunakan untuk mempermudah dalam penambahan gaya dan pewarnaan output di terminal. Rich juga mendukung fitur lain seperti pembuatan tabel, bar progress, penulisan markdown, penghighitan syntax source code, tracebacks, dan masih banyak lagi.
 
-![Features](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Features](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 Sebagai pengenalan Rich saksikan video berikut [calmcode.io](https://calmcode.io/rich/introduction.html) oleh [@fishnets88](https://twitter.com/fishnets88).
 
@@ -65,7 +65,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -76,7 +76,7 @@ Rich dapat diinstal ke dalam Python REPL sehingga setiap struktur data akan dita
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Penggunaan Console
 
@@ -104,7 +104,7 @@ console.print("Hello", "World!", style="bold red")
 
 Output dari perintah tersebut akan tampak sebagai berikut:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 Melakukan perubahan tampilan teks output dalam satu waktu mungkin sudah baik. Tetapi untuk membuat tampilan lebih rapi, Rich mendukung fitur rendering menggunakan pemformatan spesial dimana syntaxnya serupa dengan [bbcode](https://en.wikipedia.org/wiki/BBCode). Berikut adalah contoh penerapannya:
 
@@ -112,7 +112,7 @@ Melakukan perubahan tampilan teks output dalam satu waktu mungkin sudah baik. Te
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 Anda dapat menggunakan console object untuk menciptakan keluaran yang indah dengan usaha yang sedikit. Kunjungi [Console API](https://rich.readthedocs.io/en/latest/console.html) untuk informasi lebih lengkap.
 
@@ -126,7 +126,7 @@ Rich memiliki fungsi [inspect](https://rich.readthedocs.io/en/latest/reference/i
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 Kunjungi [dokumentasi inspect](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) untuk detail lebih lanjut.
 
@@ -166,7 +166,7 @@ test_log()
 
 Perintah di atas akan menampilkan output sebagai berikut:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 Sebagai catatan, argumen `log_locals` berupa tabel yang berisikan variabel lokal yang menunjukkan lokasi dimana log tersebut dipanggil.
 
@@ -178,7 +178,7 @@ Method log ini dapat digunakan untuk mencatat aktivitas terminal yang berjalan l
 
 Anda dapat juga menggunakan builtin [Handler class](https://rich.readthedocs.io/en/latest/logging.html) untuk memformat dan mewarnai output dari module logging Python. Berikut adalah contoh penerapannya:
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -201,9 +201,9 @@ Mohon gunakan fitur ini dengan bijak.
 
 Rich mendukung perenderan [tabel](https://rich.readthedocs.io/en/latest/tables.html) secara fleksibel dengan karakter unicode. Terdapat variasi sangat besar untuk opsi pemformatan seperti pengaturan border, gaya tabel, perataan teks di dalam cell, dan lain sebagainya.
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-Animasi di atas dibuat dengan program [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) pada direktori examples.
+Animasi di atas dibuat dengan program [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) pada direktori examples.
 
 Berikut adalah contoh tabel sederhana:
 
@@ -239,13 +239,13 @@ console.print(table)
 
 Program di atas akan menghasilkan output sebagai berikut:
 
-![tabel](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![tabel](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 Sebagai catatan console markup dirender sama seperti `print()` dan `log()`. Faktanya, untuk segala bentuk hal yang dapat dirender menggunakan Rich dapat disisipkan ke dalam header / baris (bahkan tabel lain).
 
 Class `Table` memiliki kemampuan yang baik untuk mengatur ukuran kolom supaya sesuai dengan lebar yang disediakan oleh terminal. Berikut adalah contoh penerapannya, dengan terminal memiliki ukuran yang lebih kecil dibandingkan tabel di atas:
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -254,7 +254,7 @@ Class `Table` memiliki kemampuan yang baik untuk mengatur ukuran kolom supaya se
 
 Rich dapat merender beragam bar [progress](https://rich.readthedocs.io/en/latest/progress.html) interaktif untuk memantau kemajuan yang telah dicapai oleh program yang berjalan lama.
 
-Untuk penggunaan dasar, masukan setiap urutan yang hendak dijadikan ke dalam bentuk progress ke dalam fungsi 'track' dan  iterasikan urutan tersebut di atas outputnya. Berikut adalah contoh penerapannya:
+Untuk penggunaan dasar, masukan setiap urutan yang hendak dijadikan ke dalam bentuk progress ke dalam fungsi 'track' dan iterasikan urutan tersebut di atas outputnya. Berikut adalah contoh penerapannya:
 
 ```python
 from rich.progress import track
@@ -265,13 +265,13 @@ for step in track(range(100)):
 
 Tidaklah sulit untuk menambahkan beberapa bar progress sekaligus. Berikut adalah contoh implementasi yang diambil dari file dokumentasi:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 Bagian kolom dapat dikonfigurasikan sesuai dengan kebutuhan. Built-in kolom juga memiliki fitur presentasi seleasi, ukuran file, kecepatan file, dan waktu sisa. Berikut adalah contoh menampilkan bar progress ketika mengunduh suatu file:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-Untuk bereksperimen, periksa [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) yang dapat menampilkan beberapa progress bar  pengunduhan dari beberapa alamat URL sekaligus.
+Untuk bereksperimen, periksa [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) yang dapat menampilkan beberapa progress bar pengunduhan dari beberapa alamat URL sekaligus.
 
 </details>
 
@@ -296,7 +296,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 Program di atas akan menghasilkan output sebagai berikut.
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 Animasi spinner tersebut diambil dari [cli-spinners](https://www.npmjs.com/package/cli-spinners). Anda dapat menentukan spinner yang hendak digunakan dengan menspesifikannya di parameter `spinner`. Jalankan perintah berikut untuk melihat parameter yang tersedia:
 
@@ -306,7 +306,7 @@ python -m rich.spinner
 
 Perintah di atas akan menghasilkan output sebagai berikut:
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -323,9 +323,9 @@ python -m rich.tree
 
 Program di atas akan menghasilkan output sebagai berikut:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-Periksa contoh program [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) untuk menampilkan tampilan tree view dari direktori apapun, perintah ini serupa dengan `tree` pada linux.
+Periksa contoh program [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) untuk menampilkan tampilan tree view dari direktori apapun, perintah ini serupa dengan `tree` pada linux.
 
 </details>
 
@@ -345,9 +345,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-Screenshot berikut merupakan output dari [contoh kolom](https://github.com/willmcgugan/rich/blob/master/examples/columns.py) yang menampilkan data yang diambil melalui API ke dalam bentuk kolom:
+Screenshot berikut merupakan output dari [contoh kolom](https://github.com/Textualize/rich/blob/master/examples/columns.py) yang menampilkan data yang diambil melalui API ke dalam bentuk kolom:
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -370,7 +370,7 @@ console.print(markdown)
 
 Program di atas akan menghasilkan output seperti berikut:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -405,7 +405,7 @@ console.print(syntax)
 
 Program di atas akan menghasilkan output sebagai berikut:
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -416,7 +416,7 @@ Rich dapat merender [tracebacks dengan indah](https://rich.readthedocs.io/en/lat
 
 Berikut adalah tampilannya pada OSX (serupa dengan Linux):
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -424,12 +424,9 @@ Semua perenderan Rich menggunakan [Console Protocol](https://rich.readthedocs.io
 
 # Rich CLI
 
-
 Baca juga [Rich CLI](https://github.com/textualize/rich-cli) sebuah program command line yang dibuat menggunakan Rich. Penghilightan syntax, perenderan markdown, menampilkan CSVs ke dalam tabel, dan masih banyak lagi, secara langsung melalui command prompt.
 
-
 ![Rich CLI](https://raw.githubusercontent.com/Textualize/rich-cli/main/imgs/rich-cli-splash.jpg)
-
 
 # Projek yang telah menggunakan Rich
 
@@ -444,7 +441,7 @@ Berikut adalah beberpa projek yang menggunakan Rich:
 - [hedythedev/StarCli](https://github.com/hedythedev/starcli)
   Melakukan penelusuran projek terkenal GitHub melalui command line.
 - [intel/cve-bin-tool](https://github.com/intel/cve-bin-tool)
-  Tools ini dapat digunakan untuk melakukan scanning pada komponen yang rentan  (openssl, libpng, libxml2, expat and a few others) untuk membuat anda mengetahui sistem anda mempunyai library yang telah diketahui kerentanannya.
+  Tools ini dapat digunakan untuk melakukan scanning pada komponen yang rentan (openssl, libpng, libxml2, expat and a few others) untuk membuat anda mengetahui sistem anda mempunyai library yang telah diketahui kerentanannya.
 - [nf-core/tools](https://github.com/nf-core/tools)
   package Python dengan tools bantuan untuk komunitas nf-core.
 - [cansarigol/pdbr](https://github.com/cansarigol/pdbr)
@@ -459,6 +456,6 @@ Berikut adalah beberpa projek yang menggunakan Rich:
   Library Python ringan untuk menambahkan deteksi objek secara real-time pada objek 2D pada suatu detektor.
 - [ansible/ansible-lint](https://github.com/ansible/ansible-lint) Sebuah ansible-lint untuk memeriksa playbooks yang digunakan sebagai practices and behaviour yang secara potensial dapat ditingkatkan.
 - [ansible-community/molecule](https://github.com/ansible-community/molecule) Ansible Molecule untuk framework testing
-- +[Lebih banyak lagi](https://github.com/willmcgugan/rich/network/dependents)!
+- +[Lebih banyak lagi](https://github.com/Textualize/rich/network/dependents)!
 
 <!-- This is a test, no need to translate -->

--- a/README.it.md
+++ b/README.it.md
@@ -3,31 +3,30 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
-
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich è una libreria Python per un testo _rich_ e con una piacevole formattazione nel terminale.
 
 Le [Rich API](https://rich.readthedocs.io/en/latest/) permettono di aggiungere facilmente colore e stile all'output del terminale. Rich permette di visualizzare tabelle, barre di avanzamento, markdown, evidenziazione della sintassi, tracebacks, e molto altro ancora — tutto già pronto all'uso.
 
-![Features](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Features](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 Per una video-introduzione di Rich puoi vedere [calmcode.io](https://calmcode.io/rich/introduction.html) by [@fishnets88](https://twitter.com/fishnets88).
 
@@ -63,7 +62,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -74,7 +73,7 @@ Rich può essere installo in Python REPL, in questo modo ogni struttura dati sar
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Utilizzo di Console
 
@@ -102,7 +101,7 @@ console.print("Hello", "World!", style="bold red")
 
 L'output sarà qualcosa tipo:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 Questo va bene per applicare uno stile ad una linea di testo alla volta. Per uno stile più ricercato, puoi utilizzare uno speciale linguaggio di markup che è simile nella sintassi a [bbcode](https://en.wikipedia.org/wiki/BBCode). Ad esempio:
 
@@ -110,7 +109,7 @@ Questo va bene per applicare uno stile ad una linea di testo alla volta. Per uno
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 Puoi utilizzare l'oggetto Console per generare output sofisticati con il minimo sforzo. Vedi la docs di [Console API](https://rich.readthedocs.io/en/latest/console.html) per ulteriori dettagli.
 
@@ -124,7 +123,7 @@ Rich ha una funzione [inspect](https://rich.readthedocs.io/en/latest/reference/i
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 Vedi [inspect docs](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) per ulteriori dettagli.
 
@@ -164,7 +163,7 @@ test_log()
 
 Il codice appena mostrato produce il seguente output:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 Nota l'argomento `log_locals`, che visualizza una tabella contenente le variabili locali dove il metodo log è stato chiamato.
 
@@ -176,7 +175,7 @@ Il metodo log può essere usato per il logging su terminale di applicazioni che 
 
 Puoi anche utilizzare la classe builtin [Handler](https://rich.readthedocs.io/en/latest/logging.html) per formattare e colorare l'output dal modulo logging di Python. Ecco un esempio dell'output:
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -199,9 +198,9 @@ Usa questa feature saggiamente.
 
 Rich può visualizzare [tabelle](https://rich.readthedocs.io/en/latest/tables.html) flessibili con caratteri unicode. C'è una vasta gamma di opzioni per la formattazione di bordi, stili, allineamenti di celle etc.
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-Questa animazione è stata realizzata con [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) presente nella directory examples.
+Questa animazione è stata realizzata con [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) presente nella directory examples.
 
 Ecco qui un semplice esempio di tabella:
 
@@ -237,13 +236,13 @@ console.print(table)
 
 Questo produce il seguente output:
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 Nota che il console markup è visualizzato nello stesso modo di `print()` e `log()`. Infatti, tutto ciò che è visualizzabile da Rich può essere incluso nelle intestazioni / righe (anche altre tabelle).
 
 La classe `Table` è abbastanza smart da ridimensionare le colonne per entrare nello spazio residuo del terminale, wrappando il testo come richiesto. Ad esempio, con il terminale reso più piccolo della tabella sopra:
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -263,13 +262,13 @@ for step in track(range(100)):
 
 Non è difficile aggiungere barre di avanzamento multiple. Ecco un esempio dalla documentazione:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 Le colonne possono essere configurate per visualizzare qualsiasi dettaglio tu voglia. Le colonne built-in includono percentuale di completamente, dimensione del file, velocità, e tempo rimasto. Ecco un altro esempio che mostra un download in corso:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-Per testare tu stesso, vedi [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) che può scaricare multipli URL simultaneamente mentre mostra lo stato di avanzamento.
+Per testare tu stesso, vedi [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) che può scaricare multipli URL simultaneamente mentre mostra lo stato di avanzamento.
 
 </details>
 
@@ -294,7 +293,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 Questo produrrà il seguente output nel terminale.
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 L'animazione dello spinner è ispirata da [cli-spinners](https://www.npmjs.com/package/cli-spinners). Puoi selezionarne uno specificando `spinner` tra i parametri. Esegui il seguente comando per visualizzare le possibili opzioni:
 
@@ -304,7 +303,7 @@ python -m rich.spinner
 
 Questo produrrà il seguente output nel terminale.
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -321,9 +320,9 @@ python -m rich.tree
 
 Questo produrrà il seguente output:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-Vedi l'esempio [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) per uno script che mostra una vista ad albero di ogni directory, simile a quella del comando linux `tree`.
+Vedi l'esempio [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) per uno script che mostra una vista ad albero di ogni directory, simile a quella del comando linux `tree`.
 
 </details>
 
@@ -343,9 +342,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-Il seguente screenshot è l'output dell'[esempio di columns](https://github.com/willmcgugan/rich/blob/master/examples/columns.py) che visualizza i dati ottenuti da un API in colonna:
+Il seguente screenshot è l'output dell'[esempio di columns](https://github.com/Textualize/rich/blob/master/examples/columns.py) che visualizza i dati ottenuti da un API in colonna:
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -368,7 +367,7 @@ console.print(markdown)
 
 Questo produrrà un output simile al seguente:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -403,7 +402,7 @@ console.print(syntax)
 
 Questo produrrà il seguente output:
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -414,7 +413,7 @@ Rich può visualizzare [gradevoli tracebacks](https://rich.readthedocs.io/en/lat
 
 Ecco come appare su OSX (simile a Linux):
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -454,6 +453,6 @@ Ecco alcuni progetti che utilizzano Rich:
   Lightweight Python library for adding real-time 2D object tracking to any detector.
 - [ansible/ansible-lint](https://github.com/ansible/ansible-lint) Ansible-lint checks playbooks for practices and behaviour that could potentially be improved
 - [ansible-community/molecule](https://github.com/ansible-community/molecule) Ansible Molecule testing framework
-- +[Many more](https://github.com/willmcgugan/rich/network/dependents)!
+- +[Many more](https://github.com/Textualize/rich/network/dependents)!
 
 <!-- This is a test, no need to translate -->

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,44 +4,44 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
-Richは、 _リッチ_ なテキストや美しい書式設定をターミナルで行うためのPythonライブラリです。
+Rich は、 _リッチ_ なテキストや美しい書式設定をターミナルで行うための Python ライブラリです。
 
-[Rich API](https://rich.readthedocs.io/en/latest/)を使用すると、ターミナルの出力に色やスタイルを簡単に追加することができます。 Richはきれいなテーブル、プログレスバー、マークダウン、シンタックスハイライトされたソースコード、トレースバックなどをすぐに生成・表示することもできます。
+[Rich API](https://rich.readthedocs.io/en/latest/)を使用すると、ターミナルの出力に色やスタイルを簡単に追加することができます。 Rich はきれいなテーブル、プログレスバー、マークダウン、シンタックスハイライトされたソースコード、トレースバックなどをすぐに生成・表示することもできます。
 
-![機能](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![機能](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
-Richの紹介動画はこちらをご覧ください。 [calmcode.io](https://calmcode.io/rich/introduction.html) by [@fishnets88](https://twitter.com/fishnets88).
+Rich の紹介動画はこちらをご覧ください。 [calmcode.io](https://calmcode.io/rich/introduction.html) by [@fishnets88](https://twitter.com/fishnets88).
 
-[Richについての人々の感想を見る。](https://www.willmcgugan.com/blog/pages/post/rich-tweets/)
+[Rich についての人々の感想を見る。](https://www.willmcgugan.com/blog/pages/post/rich-tweets/)
 
 ## 互換性
 
-RichはLinux、OSX、Windowsに対応しています。True colorと絵文字は新しい Windows ターミナルで動作しますが、古いターミナルでは8色に制限されています。Richを使用するにはPythonのバージョンは3.6.3以降が必要です。
+Rich は Linux、OSX、Windows に対応しています。True color と絵文字は新しい Windows ターミナルで動作しますが、古いターミナルでは 8 色に制限されています。Rich を使用するには Python のバージョンは 3.6.3 以降が必要です。
 
-Richは追加の設定を行わずとも、[Jupyter notebooks](https://jupyter.org/)で動作します。
+Rich は追加の設定を行わずとも、[Jupyter notebooks](https://jupyter.org/)で動作します。
 
 ## インストール
 
-`pip` や、あなたのお気に入りのPyPIパッケージマネージャを使ってインストールしてください。
+`pip` や、あなたのお気に入りの PyPI パッケージマネージャを使ってインストールしてください。
 
 ```sh
 python -m pip install rich
@@ -53,9 +53,9 @@ python -m pip install rich
 python -m rich
 ```
 
-## Richのprint関数
+## Rich の print 関数
 
-簡単にリッチな出力をアプリケーションに追加するには、Pythonの組み込み関数と同じ名前を持つ [rich print](https://rich.readthedocs.io/en/latest/introduction.html#quick-start) メソッドをインポートすることで実現できます。こちらを試してみてください:
+簡単にリッチな出力をアプリケーションに追加するには、Python の組み込み関数と同じ名前を持つ [rich print](https://rich.readthedocs.io/en/latest/introduction.html#quick-start) メソッドをインポートすることで実現できます。こちらを試してみてください:
 
 ```python
 from rich import print
@@ -63,32 +63,31 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
-RichはPythonのREPLでインストールすることができ、データ構造がきれいに表示され、ハイライトされます。
+Rich は Python の REPL でインストールすることができ、データ構造がきれいに表示され、ハイライトされます。
 
 ```python
 >>> from rich import pretty
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Rich Inspect
 
-RichにはPythonオブジェクトやクラス、インスタンス、組み込み関数などに関するレポートを作成することができる、[inspect関数](https://rich.readthedocs.io/en/latest/reference/init.html?highlight=inspect#rich.inspect)があります。
+Rich には Python オブジェクトやクラス、インスタンス、組み込み関数などに関するレポートを作成することができる、[inspect 関数](https://rich.readthedocs.io/en/latest/reference/init.html?highlight=inspect#rich.inspect)があります。
 
 ```python
 >>> from rich import inspect
 >>> inspect(str, methods=True)
 ```
 
-## Consoleの使い方
+## Console の使い方
 
 リッチなターミナルコンテンツをより制御していくには、[Console](https://rich.readthedocs.io/en/latest/reference/console.html#rich.console.Console) オブジェクトをインポートして構築していきます。
-
 
 ```python
 from rich.console import Console
@@ -113,21 +112,21 @@ console.print("Hello", "World!", style="bold red")
 
 以下のように出力されます:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 この方法は一行のテキストを一度にスタイリングするのに適しています。
-より細かくスタイリングを行うために、Richは[bbcode](https://en.wikipedia.org/wiki/BBCode)に似た構文の特別なマークアップを表示することができます。
+より細かくスタイリングを行うために、Rich は[bbcode](https://en.wikipedia.org/wiki/BBCode)に似た構文の特別なマークアップを表示することができます。
 これはその例です:
 
 ```python
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 ### Console logging
 
-Consoleオブジェクトには `log()` メソッドがあり、これは `print()` と同じインターフェイスを持ちますが、現在の時刻と呼び出しを行ったファイルと行数についてもカラムに表示します。デフォルトでは、RichはPythonの構造体とrepr文字列のシンタックスハイライトを行います。もしコレクション(例: dictやlist)をログに記録した場合、Richはそれを利用可能なスペースに収まるようにきれいに表示します。以下に、これらの機能のいくつかの例を示します。
+Console オブジェクトには `log()` メソッドがあり、これは `print()` と同じインターフェイスを持ちますが、現在の時刻と呼び出しを行ったファイルと行数についてもカラムに表示します。デフォルトでは、Rich は Python の構造体と repr 文字列のシンタックスハイライトを行います。もしコレクション(例: dict や list)をログに記録した場合、Rich はそれを利用可能なスペースに収まるようにきれいに表示します。以下に、これらの機能のいくつかの例を示します。
 
 ```python
 from rich.console import Console
@@ -154,21 +153,21 @@ test_log()
 
 上の例では以下のような出力が得られます:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
-`log_locals`という引数についてですが、これは、logメソッドが呼び出されたローカル変数を含むテーブルを出力します。
+`log_locals`という引数についてですが、これは、log メソッドが呼び出されたローカル変数を含むテーブルを出力します。
 
-logメソッドはサーバのような長時間稼働しているアプリケーションのターミナルへのloggingとして使用できますが、デバッグ時に非常に役に立つ手段でもあります。
+log メソッドはサーバのような長時間稼働しているアプリケーションのターミナルへの logging として使用できますが、デバッグ時に非常に役に立つ手段でもあります。
 
 ### Logging Handler
 
-また、内蔵されている[Handler class](https://rich.readthedocs.io/en/latest/logging.html)を用いて、Pythonのloggingモジュールからの出力をフォーマットしたり、色付けしたりすることもできます。以下に出力の例を示します。
+また、内蔵されている[Handler class](https://rich.readthedocs.io/en/latest/logging.html)を用いて、Python の logging モジュールからの出力をフォーマットしたり、色付けしたりすることもできます。以下に出力の例を示します。
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 ## 絵文字(Emoji)
 
-コンソールの出力に絵文字を挿入するには、2つのコロンの間に名前を入れます。例を示します:
+コンソールの出力に絵文字を挿入するには、2 つのコロンの間に名前を入れます。例を示します:
 
 ```python
 >>> console.print(":smiley: :vampire: :pile_of_poo: :thumbs_up: :raccoon:")
@@ -179,11 +178,11 @@ logメソッドはサーバのような長時間稼働しているアプリケ�
 
 ## テーブル
 
-Richはユニコードの枠を用いて柔軟に[テーブル](https://rich.readthedocs.io/en/latest/tables.html)を表示することができます。 罫線、スタイル、セルの配置などの書式設定のためのオプションが豊富にあります。
+Rich はユニコードの枠を用いて柔軟に[テーブル](https://rich.readthedocs.io/en/latest/tables.html)を表示することができます。 罫線、スタイル、セルの配置などの書式設定のためのオプションが豊富にあります。
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-上のアニメーションは、examplesディレクトリの[table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py)で生成したものです。
+上のアニメーションは、examples ディレクトリの[table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py)で生成したものです。
 
 もう少し簡単な表の例を示します:
 
@@ -219,18 +218,18 @@ console.print(table)
 
 これにより、以下のような出力が得られます:
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 コンソール上でのマークアップは`print()` や `log()` と同じように表示されることに注意してください。実際には、Rich が表示可能なものはすべてヘッダや行に含めることができます (それが他のテーブルであっても、です)。
 
 `Table`クラスは、ターミナルの利用可能な幅に合わせてカラムのサイズを変更したり、必要に応じてテキストを折り返したりするのに十分なスマートさを持っています。
 これは先ほどと同じ例で、ターミナルを上のテーブルよりも小さくしたものです。
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 ## プログレスバー
 
-Richでは複数のちらつきのないの[プログレスバー](https://rich.readthedocs.io/en/latest/progress.html)を表示して、長時間のタスクを追跡することができます。
+Rich では複数のちらつきのないの[プログレスバー](https://rich.readthedocs.io/en/latest/progress.html)を表示して、長時間のタスクを追跡することができます。
 
 基本的な使い方としては、任意のシーケンスを `track` 関数でラップし、その結果を繰り返し処理します。以下に例を示します:
 
@@ -243,13 +242,13 @@ for step in track(range(100)):
 
 複数のプログレスバーを追加するのはそれほど大変ではありません。以下はドキュメントから抜粋した例です:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 カラムには任意の詳細を表示するように設定することができます。組み込まれているカラムには、完了率、ファイルサイズ、ファイル速度、残り時間が含まれています。ここでは、進行中のダウンロードを表示する別の例を示します:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-こちらを自分で試して見るには、進捗状況を表示しながら複数のURLを同時にダウンロードできる [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) を参照してみてください。
+こちらを自分で試して見るには、進捗状況を表示しながら複数の URL を同時にダウンロードできる [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) を参照してみてください。
 
 ## ステータス
 
@@ -271,7 +270,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 これにより、ターミナルには以下のような出力が生成されます。
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 スピナーのアニメーションは [cli-spinners](https://www.npmjs.com/package/cli-spinners) から拝借しました。`spinner`パラメータを指定することでスピナーを選択することができます。以下のコマンドを実行して、利用可能な値を確認してください:
 
@@ -281,13 +280,13 @@ python -m rich.spinner
 
 上記コマンドは、ターミナルで以下のような出力を生成します:
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 ## ツリー
 
-Richはガイドライン付きの[ツリー](https://rich.readthedocs.io/en/latest/tree.html)を表示することができます。ツリーはファイル構造などの階層データを表示するのに適しています。
+Rich はガイドライン付きの[ツリー](https://rich.readthedocs.io/en/latest/tree.html)を表示することができます。ツリーはファイル構造などの階層データを表示するのに適しています。
 
-ツリーのラベルは、シンプルなテキストや、Richが表示できるものであれば何でも表示することができます。以下を実行してデモを行います:
+ツリーのラベルは、シンプルなテキストや、Rich が表示できるものであれば何でも表示することができます。以下を実行してデモを行います:
 
 ```
 python -m rich.tree
@@ -295,9 +294,9 @@ python -m rich.tree
 
 これにより、次のような出力が生成されます:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-linuxの `tree` コマンドと同様に、任意のディレクトリのツリー表示を行うスクリプトについては、[tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py)の例を参照してください。
+linux の `tree` コマンドと同様に、任意のディレクトリのツリー表示を行うスクリプトについては、[tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py)の例を参照してください。
 
 ## カラム
 
@@ -314,13 +313,13 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-以下のスクリーンショットは、APIから引っ張ってきたデータをカラムで表示する[columns example](https://github.com/willmcgugan/rich/blob/master/examples/columns.py)による出力です:
+以下のスクリーンショットは、API から引っ張ってきたデータをカラムで表示する[columns example](https://github.com/Textualize/rich/blob/master/examples/columns.py)による出力です:
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 ## マークダウン
 
-Richは[マークダウン](https://rich.readthedocs.io/en/latest/markdown.html)を使用することができ、フォーマットをターミナル向けに変換するための良い仕事をしてくれます。
+Rich は[マークダウン](https://rich.readthedocs.io/en/latest/markdown.html)を使用することができ、フォーマットをターミナル向けに変換するための良い仕事をしてくれます。
 
 マークダウンを使用するには、`Markdown`クラスをインポートし、マークダウンコードを含む文字列で構成します。そしてそれをコンソールに表示します。これは例です:
 
@@ -336,11 +335,11 @@ console.print(markdown)
 
 これにより、以下のような出力が得られます:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 ## シンタックスハイライト
 
-Richは [シンタックスハイライト](https://rich.readthedocs.io/en/latest/syntax.html) を実装するために [pygments](https://pygments.org/) ライブラリを使用しています。使い方はマークダウンを使用するのと似ています。 `Syntax` オブジェクトを構築してコンソールに表示します。以下にその例を示します:
+Rich は [シンタックスハイライト](https://rich.readthedocs.io/en/latest/syntax.html) を実装するために [pygments](https://pygments.org/) ライブラリを使用しています。使い方はマークダウンを使用するのと似ています。 `Syntax` オブジェクトを構築してコンソールに表示します。以下にその例を示します:
 
 ```python
 from rich.console import Console
@@ -368,26 +367,26 @@ console.print(syntax)
 
 これにより、以下のような出力が得られます:
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 ## トレースバック
 
-Rich は [美しいトレースバック](https://rich.readthedocs.io/en/latest/traceback.html) を表示することができ、通常のPythonのトレースバックよりも読みやすく、より多くのコードを表示することができます。Richをデフォルトのトレースバックハンドラとして設定することで、捕捉されなかった例外はすべてRichによって表示されるようになります。
+Rich は [美しいトレースバック](https://rich.readthedocs.io/en/latest/traceback.html) を表示することができ、通常の Python のトレースバックよりも読みやすく、より多くのコードを表示することができます。Rich をデフォルトのトレースバックハンドラとして設定することで、捕捉されなかった例外はすべて Rich によって表示されるようになります。
 
-OSXではこのような表示となります（Linuxでも似たような表示になります）:
+OSX ではこのような表示となります（Linux でも似たような表示になります）:
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
-## Richを使用したプロジェクト
+## Rich を使用したプロジェクト
 
-ここでは、Richを使用したいくつかのプロジェクトを紹介します:
+ここでは、Rich を使用したいくつかのプロジェクトを紹介します:
 
 - [BrancoLab/BrainRender](https://github.com/BrancoLab/BrainRender)
-  3次元の神経解剖学的データを可視化するpythonパッケージ
+  3 次元の神経解剖学的データを可視化する python パッケージ
 - [Ciphey/Ciphey](https://github.com/Ciphey/Ciphey)
   自動化された復号化ツール
 - [emeryberger/scalene](https://github.com/emeryberger/scalene)
-  Python用の高性能・高精度 CPU/メモリプロファイラ
+  Python 用の高性能・高精度 CPU/メモリプロファイラ
 - [hedythedev/StarCli](https://github.com/hedythedev/starcli)
   コマンドラインから GitHub のトレンドプロジェクトを閲覧できます
 - [intel/cve-bin-tool](https://github.com/intel/cve-bin-tool)
@@ -395,17 +394,17 @@ OSXではこのような表示となります（Linuxでも似たような表示
 - [nf-core/tools](https://github.com/nf-core/tools)
   nf-core コミュニティのためのヘルパーツールを含む Python パッケージ。
 - [cansarigol/pdbr](https://github.com/cansarigol/pdbr)
-  pdb + Richライブラリによる、強化されたデバッグツール。
+  pdb + Rich ライブラリによる、強化されたデバッグツール。
 - [plant99/felicette](https://github.com/plant99/felicette)
   ダミーのための衛星画像。
 - [seleniumbase/SeleniumBase](https://github.com/seleniumbase/SeleniumBase)
-  Seleniumとpytestで10倍速の自動化とテスト。バッテリーも含まれています。
+  Selenium と pytest で 10 倍速の自動化とテスト。バッテリーも含まれています。
 - [smacke/ffsubsync](https://github.com/smacke/ffsubsync)
   字幕を自動的にビデオと同期させます。
 - [tryolabs/norfair](https://github.com/tryolabs/norfair)
-  あらゆる検出器にリアルタイムの2Dオブジェクトトラッキングを追加するための軽量なPythonライブラリ。
+  あらゆる検出器にリアルタイムの 2D オブジェクトトラッキングを追加するための軽量な Python ライブラリ。
 - [ansible/ansible-lint](https://github.com/ansible/ansible-lint)
-  Ansible-lint がplaybooksをチェックして、改善できる可能性のあるプラクティスや動作を確認します。
+  Ansible-lint が playbooks をチェックして、改善できる可能性のあるプラクティスや動作を確認します。
 - [ansible-community/molecule](https://github.com/ansible-community/molecule)
-  Ansible Moleculeのテストフレームワーク
-- +[Many more](https://github.com/willmcgugan/rich/network/dependents)!
+  Ansible Molecule のテストフレームワーク
+- +[Many more](https://github.com/Textualize/rich/network/dependents)!

--- a/README.kr.md
+++ b/README.kr.md
@@ -4,30 +4,30 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich는 터미널에서 _풍부한(rich)_ 텍스트와 아름다운 서식을 지원하기 위한 파이썬 라이브러리입니다.
 
 [Rich API](https://rich.readthedocs.io/en/latest/)는 터미널 출력에 색깔과 스타일을 입히기 쉽게 도와줍니다. 또한 Rich는 별다른 설정 없이 표, 진행 바, 마크다운, 소스코드 구문 강조, tracebacks 등을 예쁘게 보여줄 수 있습니다.
 
-![Features](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Features](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 Rich에 대한 동영상 설명을 보시려면 [@fishnets88](https://twitter.com/fishnets88)의 [calmcode.io](https://calmcode.io/rich/introduction.html)를 확인 바랍니다.
 
@@ -64,7 +64,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -75,7 +75,7 @@ Rich는 파이썬 REPL에도 설치할 수 있습니다. 어떤 데이터 구조
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## 콘솔 사용하기
 
@@ -103,7 +103,7 @@ console.print("Hello", "World!", style="bold red")
 
 다음과 같이 출력됩니다:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 텍스트 한 줄을 한 번에 수정하는 것도 좋습니다. 더욱 세세하게 스타일을 변경하기 위해, Rich는 [bbcode](https://en.wikipedia.org/wiki/BBCode)와 구문이 비슷한 별도의 마크업을 렌더링 할 수 있습니다. 예제는 다음과 같습니다.
 
@@ -111,7 +111,7 @@ console.print("Hello", "World!", style="bold red")
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 Console 객체를 활용해 적은 노력으로 복잡한 출력을 손쉽게 만들 수 있습니다. 자세한 내용은 [Console API](https://rich.readthedocs.io/en/latest/console.html) 문서를 확인해주세요.
 
@@ -125,7 +125,7 @@ Rich는 class나 instance, builtin 같은 파이썬 객체의 레포트를 생�
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 자세한 내용은 [inspect docs](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) 문서를 확인해주세요.
 
@@ -165,7 +165,7 @@ test_log()
 
 위 코드의 실행 결과는 다음과 같습니다:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 `log_locals` 인자를 사용하면 log 메서드가 호출된 곳의 로컬 변수들을 표로 보여준다는 것도 알아두세요.
 
@@ -177,7 +177,7 @@ test_log()
 
 또한 내장된 [Handler class](https://rich.readthedocs.io/en/latest/logging.html)를 사용해 파이썬의 로깅 모듈의 출력을 형태를 꾸미거나 색을 입힐 수 있습니다. 다음은 예제입니다:
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -200,9 +200,9 @@ test_log()
 
 Rich는 유니코드 박스 문자와 함께 [표](https://rich.readthedocs.io/en/latest/tables.html)를 자유롭게 렌더링할 수 있습니다. 가장자리, 스타일, 셀 정렬 등을 정말 다양하게 구성할 수 있습니다.
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-위의 애니메이션은 example 디렉토리의 [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py)로 생성되었습니다.
+위의 애니메이션은 example 디렉토리의 [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py)로 생성되었습니다.
 
 더 간단한 표 예제입니다:
 
@@ -238,13 +238,13 @@ console.print(table)
 
 이는 다음과 같이 출력됩니다:
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 콘솔 출력은 `print()`나 `log()`와 같은 방식으로 렌더링 된다는 것을 주의하세요. 사실, Rich로 표현할 수 있는 것은 무엇이든 headers / rows (심지어 다른 표들도)에 포함할 수 있습니다.
 
 `Table` 클래스는 터미널의 폭에 맞춰 필요한 만큼 줄을 내리고 열 길이를 스스로 조절합니다. 위의 표보다 작은 터미널에서 만들어진 표 예시입니다:
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -264,13 +264,13 @@ for step in track(range(100)):
 
 여러개의 진행 바를 추가하는 것도 어렵지 않습니다. 아래는 공식문서에서 따온 예시입니다:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 칼럼들은 수정해 원하는 세부정보를 보여줄 수도 있습니다. 기본으로 내장된 칼럼들은 완료 퍼센티지, 파일 크기, 파일 속도, 남은 시간입니다. 다운로드 진행을 보여주는 다른 예제입니다:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-직접 해보시려면, 진행 바와 함께 여러개의 URL들을 동시에 다운로드 받는 예제인 [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py)를 확인해주세요.
+직접 해보시려면, 진행 바와 함께 여러개의 URL들을 동시에 다운로드 받는 예제인 [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py)를 확인해주세요.
 
 </details>
 
@@ -295,7 +295,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 이 예제는 터미널에 아래와 같이 출력합니다.
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 스피너 애니메이션은 [cli-spinners](https://www.npmjs.com/package/cli-spinners)에서 빌려왔습니다. `spinner` 파라미터를 선택해서 특정 스피너를 선택할 수도 있습니다. 어떤 값을 선택할 수 있는지는 아래 명령어를 통해 확인할 수 있습니다:
 
@@ -305,7 +305,7 @@ python -m rich.spinner
 
 위의 명령어를 입력하면 아래와 같은 출력됩니다:
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -322,9 +322,9 @@ python -m rich.tree
 
 이는 아래와 같이 출력됩니다:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-리눅스의 `tree` 명령어처럼 아무 디렉토리의 트리를 보여주는 스크립트 예제를 보시려면 [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py)를 확인해주세요.
+리눅스의 `tree` 명령어처럼 아무 디렉토리의 트리를 보여주는 스크립트 예제를 보시려면 [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py)를 확인해주세요.
 
 </details>
 
@@ -344,9 +344,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-아래 스크린샷은 API에서 뽑은 데이터를 종렬로 표현하는 [칼럼 예제](https://github.com/willmcgugan/rich/blob/master/examples/columns.py)의 출력 결과입니다:
+아래 스크린샷은 API에서 뽑은 데이터를 종렬로 표현하는 [칼럼 예제](https://github.com/Textualize/rich/blob/master/examples/columns.py)의 출력 결과입니다:
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -369,7 +369,7 @@ console.print(markdown)
 
 위 코드는 아래와 같은 출력 결과를 만들 것입니다:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -404,7 +404,7 @@ console.print(syntax)
 
 위 코드는 아래와 같은 출력 결과를 만들 것입니다:
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -415,7 +415,7 @@ Rich는 [예쁜 tracebacks](https://rich.readthedocs.io/en/latest/traceback.html
 
 OSX에서는 이렇게 출력됩니다 (리눅스도 유사함):
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -457,6 +457,6 @@ Rich를 사용하는 몇가지 프로젝트들입니다:
   Ansible-lint가 playbooks를 확인해 잠재적으로 개선될 수 있는 practices나 동작을 확인합니다.
 - [ansible-community/molecule](https://github.com/ansible-community/molecule)
   Ansible Molecule의 테스트 프레임워크
-- +[Many more](https://github.com/willmcgugan/rich/network/dependents)!
+- +[Many more](https://github.com/Textualize/rich/network/dependents)!
 
 <!-- This is a test, no need to translate -->

--- a/README.md
+++ b/README.md
@@ -5,32 +5,31 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
- • [Indonesian readme](https://github.com/willmcgugan/rich/blob/master/README.id.md)
- • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
-
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [Indonesian readme](https://github.com/Textualize/rich/blob/master/README.id.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich is a Python library for _rich_ text and beautiful formatting in the terminal.
 
 The [Rich API](https://rich.readthedocs.io/en/latest/) makes it easy to add color and style to terminal output. Rich can also render pretty tables, progress bars, markdown, syntax highlighted source code, tracebacks, and more — out of the box.
 
-![Features](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Features](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 For a video introduction to Rich see [calmcode.io](https://calmcode.io/rich/introduction.html) by [@fishnets88](https://twitter.com/fishnets88).
 
@@ -66,7 +65,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -77,7 +76,7 @@ Rich can be installed in the Python REPL, so that any data structures will be pr
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Using the Console
 
@@ -105,7 +104,7 @@ console.print("Hello", "World!", style="bold red")
 
 The output will be something like the following:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 That's fine for styling a line of text at a time. For more finely grained styling, Rich renders a special markup which is similar in syntax to [bbcode](https://en.wikipedia.org/wiki/BBCode). Here's an example:
 
@@ -113,7 +112,7 @@ That's fine for styling a line of text at a time. For more finely grained stylin
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 You can use a Console object to generate sophisticated output with minimal effort. See the [Console API](https://rich.readthedocs.io/en/latest/console.html) docs for details.
 
@@ -127,7 +126,7 @@ Rich has an [inspect](https://rich.readthedocs.io/en/latest/reference/init.html?
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 See the [inspect docs](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) for details.
 
@@ -167,7 +166,7 @@ test_log()
 
 The above produces the following output:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 Note the `log_locals` argument, which outputs a table containing the local variables where the log method was called.
 
@@ -179,7 +178,7 @@ The log method could be used for logging to the terminal for long running applic
 
 You can also use the builtin [Handler class](https://rich.readthedocs.io/en/latest/logging.html) to format and colorize output from Python's logging module. Here's an example of the output:
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -202,9 +201,9 @@ Please use this feature wisely.
 
 Rich can render flexible [tables](https://rich.readthedocs.io/en/latest/tables.html) with unicode box characters. There is a large variety of formatting options for borders, styles, cell alignment etc.
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-The animation above was generated with [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) in the examples directory.
+The animation above was generated with [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) in the examples directory.
 
 Here's a simpler table example:
 
@@ -240,13 +239,13 @@ console.print(table)
 
 This produces the following output:
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 Note that console markup is rendered in the same way as `print()` and `log()`. In fact, anything that is renderable by Rich may be included in the headers / rows (even other tables).
 
 The `Table` class is smart enough to resize columns to fit the available width of the terminal, wrapping text as required. Here's the same example, with the terminal made smaller than the table above:
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -266,13 +265,13 @@ for step in track(range(100)):
 
 It's not much harder to add multiple progress bars. Here's an example taken from the docs:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 The columns may be configured to show any details you want. Built-in columns include percentage complete, file size, file speed, and time remaining. Here's another example showing a download in progress:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-To try this out yourself, see [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) which can download multiple URLs simultaneously while displaying progress.
+To try this out yourself, see [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) which can download multiple URLs simultaneously while displaying progress.
 
 </details>
 
@@ -297,7 +296,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 This generates the following output in the terminal.
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 The spinner animations were borrowed from [cli-spinners](https://www.npmjs.com/package/cli-spinners). You can select a spinner by specifying the `spinner` parameter. Run the following command to see the available values:
 
@@ -307,7 +306,7 @@ python -m rich.spinner
 
 The above command generates the following output in the terminal:
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -324,9 +323,9 @@ python -m rich.tree
 
 This generates the following output:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-See the [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) example for a script that displays a tree view of any directory, similar to the linux `tree` command.
+See the [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) example for a script that displays a tree view of any directory, similar to the linux `tree` command.
 
 </details>
 
@@ -346,9 +345,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-The following screenshot is the output from the [columns example](https://github.com/willmcgugan/rich/blob/master/examples/columns.py) which displays data pulled from an API in columns:
+The following screenshot is the output from the [columns example](https://github.com/Textualize/rich/blob/master/examples/columns.py) which displays data pulled from an API in columns:
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -371,7 +370,7 @@ console.print(markdown)
 
 This will produce output something like the following:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -406,7 +405,7 @@ console.print(syntax)
 
 This will produce the following output:
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -417,7 +416,7 @@ Rich can render [beautiful tracebacks](https://rich.readthedocs.io/en/latest/tra
 
 Here's what it looks like on OSX (similar on Linux):
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -425,9 +424,7 @@ All Rich renderables make use of the [Console Protocol](https://rich.readthedocs
 
 # Rich CLI
 
-
 See also [Rich CLI](https://github.com/textualize/rich-cli) for a command line application powered by Rich. Syntax highlight code, render markdown, display CSVs in tables, and more, directly from the command prompt.
-
 
 ![Rich CLI](https://raw.githubusercontent.com/Textualize/rich-cli/main/imgs/rich-cli-splash.jpg)
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -4,29 +4,29 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich é uma biblioteca Python para _rich_ text e formatação de estilos no terminal.
 
 A [API do Rich](https://rich.readthedocs.io/en/latest/) permite adicionar cores e estilos no output do terminal de forma fácil. Rich também permite formataçao de tabelas, barra de progresso, markdown, highlight de sintaxe de código fonte, rastreio de erros (traceback) e muito mais.
 
-![Funcões](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Funcões](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 Para mais detalhes, veja um vídeo de introdução so Rich em [calmcode.io](https://calmcode.io/rich/introduction.html) por [@fishnets88](https://twitter.com/fishnets88).
 
@@ -62,7 +62,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## REPL do Rich
 
@@ -73,7 +73,7 @@ O Rich pode ser instalado no REPL do Python fazendo com que qualquer estrutura d
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Usando o Console
 
@@ -101,7 +101,7 @@ console.print("Hello", "World!", style="bold red")
 
 O resultado vai ser algo como:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 Isso funciona bem para formatar cada linha do texto individualmente. Para maior controle sobre a formatação, o Rich renderiza um markup especial com uma sintaxe similar ao [bbcode](https://en.wikipedia.org/wiki/BBCode). Veja o exemplo a seguir:
 
@@ -109,7 +109,7 @@ Isso funciona bem para formatar cada linha do texto individualmente. Para maior 
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 Voce pode usar o objeto do Console para gerar facilmente uma saída para o terminal sofisticada. Veja a documentação da [API do Console](https://rich.readthedocs.io/en/latest/console.html) para mais detalhes.
 
@@ -123,7 +123,7 @@ O Rich tem uma função [inspect](https://rich.readthedocs.io/en/latest/referenc
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 Confira a [documentação do inspect](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) para mais detalhes.
 
@@ -163,7 +163,7 @@ test_log()
 
 O código acima vai produzir algo parecido com:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 Note o argumento `log_locals` que imprime uma tabela com as variáveis locais no contexto em que o método `log()` foi chamado.
 
@@ -175,7 +175,7 @@ O método `log()` pode ser usado para logar no terminal em aplicações de proce
 
 Você também pode usar a [classe Handler](https://rich.readthedocs.io/en/latest/logging.html) nativa para formatar e colorir o output do módulo `logging` do Python. Veja aqui um exemplo do output:
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -198,9 +198,9 @@ Por favor use esse recurso com sabedoria.
 
 O Rich pode imprimir [tables](https://rich.readthedocs.io/en/latest/tables.html) flexíveis usando caracteres unicode como bordas. Existem várias opções de formatação de bordas, estilos, alinhamento das celulas, etc.
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-A animação acima foi gerada com o arquivo [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) da pasta de exemplos.
+A animação acima foi gerada com o arquivo [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) da pasta de exemplos.
 
 Veja um exemplo mais simple:
 
@@ -236,13 +236,13 @@ console.print(table)
 
 Que gera o seguinte resultado:
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 Observe que o markup é renderizado da mesma for que em `print()` e `log()`. De fato, tudo que é renderizável pelo Rich pode ser incluído nos cabeçalhos ou linhas (até mesmo outras tabelas).
 
 A classe `Table` é inteligente o suficiente para ajustar o tamanho das colunas para caber na largura do terminal, quebrando o texto em novas linhas quando necessário. Veja a seguir o mesmo exemplo, só que desta vez com um terminal menor do que o tamanho original da tabela:
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -262,13 +262,13 @@ for step in track(range(100)):
 
 Adicionar multiplas barras de progresso também é simples. Veja outro exemplo que existe na documentação:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 As colunas podem ser configuradas pra mostrar qualquer detalho necessário. As colunas nativas incluem a porcentagem completa, tamanho de arquivo, velocidade do arquivo e tempo restante. O exemplo a seguir mostra o progresso de um download:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-Para testar isso no seu terminal, use o arquivo [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) para fazer o download de multiplas URLs simultaneamente, exibindo o progresso de cada download.
+Para testar isso no seu terminal, use o arquivo [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) para fazer o download de multiplas URLs simultaneamente, exibindo o progresso de cada download.
 
 </details>
 
@@ -293,7 +293,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 Este código resultará no seguinte output no terminal:
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 As animações do "spinner" foram emprestadas do [cli-spinners](https://www.npmjs.com/package/cli-spinners). É possível escolher um estilo de "spinner" usando o parametro `spinner`. Execute o comando a seguir para ver todos os tipos de "spinner" disponíveis.
 
@@ -303,7 +303,7 @@ python -m rich.spinner
 
 O comando acima deve exibir o seguinte no seu terminal:
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -320,9 +320,9 @@ python -m rich.tree
 
 Isso gera o seguinte resultado:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-Veja o exemplo em [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) de um código que gera uma árvore de exibição de um dicionário, semelhante ao comando `tree` do linux.
+Veja o exemplo em [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) de um código que gera uma árvore de exibição de um dicionário, semelhante ao comando `tree` do linux.
 
 </details>
 
@@ -342,9 +342,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-O screenshot a seguir é do resultado do [exemplo de colunas](https://github.com/willmcgugan/rich/blob/master/examples/columns.py) formatando em colunas os dados extraidos de uma API:
+O screenshot a seguir é do resultado do [exemplo de colunas](https://github.com/Textualize/rich/blob/master/examples/columns.py) formatando em colunas os dados extraidos de uma API:
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -367,7 +367,7 @@ console.print(markdown)
 
 Isso produzirá um resultado como:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -402,7 +402,7 @@ console.print(syntax)
 
 Este código gerará o seguinte resultado:
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -413,7 +413,7 @@ O Rich renderiza [tracebacks formatados](https://rich.readthedocs.io/en/latest/t
 
 Veja o resultado disso no OSX (resultados semelhantes no Linux):
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -454,6 +454,6 @@ Aqui estão alguns projetos que usam o Rich:
   Biblioteca Python para adicionar rastreio em tempo real de objetos 2D em qualquer detector.
 - [ansible/ansible-lint](https://github.com/ansible/ansible-lint) Ansible-lint verifica boas práticas e comportamento que podem ser melhorados.
 - [ansible-community/molecule](https://github.com/ansible-community/molecule) Framework de test para Ansible Molecule
-- +[Muitos outros](https://github.com/willmcgugan/rich/network/dependents)!
+- +[Muitos outros](https://github.com/Textualize/rich/network/dependents)!
 
 <!-- This is a test, no need to translate -->

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,30 +5,30 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich это Python библиотека, позволяющая отображать _красивый_ текст и форматировать терминал.
 
 [Rich API](https://rich.readthedocs.io/en/latest/) упрощает добавление цветов и стилей к выводу терминала. Rich также позволяет отображать красивые таблицы, прогресс бары, markdown, код с отображением синтаксиса, ошибки, и т.д. — прямо после установки.
 
-![Features](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Features](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 Для видеоинструкции смотрите [calmcode.io](https://calmcode.io/rich/introduction.html) от [@fishnets88](https://twitter.com/fishnets88).
 
@@ -64,7 +64,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -75,7 +75,7 @@ Rich может быть установлен в Python REPL, так, все д�
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Использование класса Console
 
@@ -103,7 +103,7 @@ console.print("Hello", "World!", style="bold red")
 
 Вывод будет выглядить примерно так:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 Этого достаточно чтобы стилизовать 1 строку. Для более детального стилизования, Rich использует специальную разметку похожую по синтаксису на [bbcode](https://en.wikipedia.org/wiki/BBCode). Вот пример:
 
@@ -111,7 +111,7 @@ console.print("Hello", "World!", style="bold red")
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 Вы можете использовать класс Console чтобы генерировать утонченный вывод с минимальными усилиями. Смотрите [документацию Console API](https://rich.readthedocs.io/en/latest/console.html) для детального объяснения.
 
@@ -125,7 +125,7 @@ console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 Смотрите [документацию inspect](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) для детального объяснения.
 
@@ -165,7 +165,7 @@ test_log()
 
 Код выше выведет это:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 Запомните аргумент `log_locals`, он выводит таблицу имеющую локальные переменные функции в которой метод был вызван.
 
@@ -177,7 +177,7 @@ test_log()
 
 Вы также можете использовать встроенный [класс Handler](https://rich.readthedocs.io/en/latest/logging.html) чтобы форматировать и раскрашивать вывод из встроенной библиотеки logging. Вот пример вывода:
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -200,9 +200,9 @@ test_log()
 
 Rich может отображать гибкие [таблицы](https://rich.readthedocs.io/en/latest/tables.html) с символами unicode. Есть большое количество форматов границ, стилей, выравниваний ячеек и т.п.
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-Эта анимация была сгенерирована с помощью [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) в директории примеров.
+Эта анимация была сгенерирована с помощью [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) в директории примеров.
 
 Вот пример более простой таблицы:
 
@@ -238,13 +238,13 @@ console.print(table)
 
 Этот пример выводит:
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 Запомните что разметка консоли отображается таким же способом что и `print()` и `log()`. На самом деле, всё, что может отобразить Rich может быть в заголовках или рядах (даже другие таблицы).
 
 Класс `Table` достаточно умный чтобы менять размер столбцов, так, чтобы они заполняли доступную ширину терминала, обёртывая текст как нужно. Вот тот же самый пример с терминалом меньше таблицы:
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -264,13 +264,13 @@ for step in track(range(100)):
 
 Отслеживать больше чем 1 задание не сложнее. Вот пример взятый из документации:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 Столбцы могут быть настроены чтобы показывать любые детали. Стандартные столбцы содержат проценты исполнения, размер файлы, скорость файла, и оставшееся время. Вот ещё пример показывающий загрузку в прогрессе:
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-Чтобы попробовать самому, скачайте [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) который может скачать несколько URL одновременно пока отображая прогресс.
+Чтобы попробовать самому, скачайте [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) который может скачать несколько URL одновременно пока отображая прогресс.
 
 </details>
 
@@ -295,7 +295,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 Это генерирует вот такой вывод в консоль.
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 Крутящиеся анимации были взяты из [cli-spinners](https://www.npmjs.com/package/cli-spinners). Вы можете выбрать одну из них указав параметр `spinner`. Запустите следующую команду чтобы узнать доступные анимации:
 
@@ -305,7 +305,7 @@ python -m rich.spinner
 
 Эта команда выдаёт вот такой вывод в терминал:
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -322,9 +322,9 @@ python -m rich.tree
 
 Это генерирует следующий вывод:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-Смотрите пример [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) для скрипта который отображает дерево любой директории, похоже на команду linux `tree`.
+Смотрите пример [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) для скрипта который отображает дерево любой директории, похоже на команду linux `tree`.
 
 </details>
 
@@ -344,9 +344,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-Следующий скриншот это вывод из [примера столбцов](https://github.com/willmcgugan/rich/blob/master/examples/columns.py) который изображает данные взятые из API в столбцах:
+Следующий скриншот это вывод из [примера столбцов](https://github.com/Textualize/rich/blob/master/examples/columns.py) который изображает данные взятые из API в столбцах:
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -369,7 +369,7 @@ console.print(markdown)
 
 Это выведет что-то похожее на это:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -404,7 +404,7 @@ console.print(syntax)
 
 Это выведет что-то похожее на это:
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -415,7 +415,7 @@ Rich может отображать [красивые ошибки](https://ric
 
 Вот как это выглядит на OSX (похоже на Linux):
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -455,6 +455,6 @@ Rich доступен как часть подписки Tidelift.
   Простая библиотека Python для добавления 2D отслеживания к любому детектеру в реальном времени.
 - [ansible/ansible-lint](https://github.com/ansible/ansible-lint) Ansible-lint проверяет пьесы для практик и поведений которые могут быть исправлены
 - [ansible-community/molecule](https://github.com/ansible-community/molecule) Ansible Molecule тестинг фреймворк
-- +[Ещё больше](https://github.com/willmcgugan/rich/network/dependents)!
+- +[Ещё больше](https://github.com/Textualize/rich/network/dependents)!
 
 <!-- This is a test, no need to translate -->

--- a/README.sv.md
+++ b/README.sv.md
@@ -4,29 +4,29 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich är ett Python bibliotek för _rich_ text och vacker formattering i terminalen.
 
 [Rich API](https://rich.readthedocs.io/en/latest/) gör det enkelt att lägga till färg och stil till terminal utmatning. Rich kan också framställa fina tabeller, framstegsfält, märkspråk, syntaxmarkerad källkod, tillbaka-spårning, och mera - redo att använda.
 
-![Funktioner](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Funktioner](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 För en video demonstration av Rich kolla [calmcode.io](https://calmcode.io/rich/introduction.html) av [@fishnets88](https://twitter.com/fishnets88).
 
@@ -62,7 +62,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -73,7 +73,7 @@ Rich kan installeras i Python REPL, så att varje datastruktur kommer att skriva
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Användning av konsolen
 
@@ -101,7 +101,7 @@ console.print("Hello", "World!", style="bold red")
 
 Utmatningen kommer bli något liknande:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 Det är bra för att ge stil till en textrad åt gången. För mer finkornad stilisering, Rich framställer en speciell märkspråk vilket liknar [bbcode](https://en.wikipedia.org/wiki/BBCode) i syntax. Här är ett exempel:
 
@@ -109,7 +109,7 @@ Det är bra för att ge stil till en textrad åt gången. För mer finkornad sti
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Konsol märkspråk](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Konsol märkspråk](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 Du kan använda ett `Console` objekt för att generera sofistikerad utmatning med minimal ansträngning. Se [Console API](https://rich.readthedocs.io/en/latest/console.html) dokument för detaljer.
 
@@ -123,7 +123,7 @@ Rich har en [inspektionsfunktion](https://rich.readthedocs.io/en/latest/referenc
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 See [inspektionsdokumentationen](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) för detaljer.
 
@@ -163,7 +163,7 @@ test_log()
 
 Det ovanstående har följande utmatning:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 Notera `log_locals` argumentet, vilket utmatar en tabell innehållandes de lokala variablerna varifrån log metoden kallades från.
 
@@ -175,7 +175,7 @@ Log metoden kan användas för att logga till terminal för långkörande applik
 
 Du kan också använda den inbyggda [Handler klassen](https://rich.readthedocs.io/en/latest/logging.html) för att formatera och färglägga utmatningen från Pythons loggningsmodul. Här är ett exempel av utmatningen:
 
-![Loggning](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Loggning](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -198,9 +198,9 @@ Vänligen använd denna funktion klokt.
 
 Rich kan framställa flexibla [tabeller](https://rich.readthedocs.io/en/latest/tables.html) med unicode boxkaraktärer. Det finns en stor mängd av formateringsalternativ för gränser, stilar, och celljustering etc.
 
-![Tabell film](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![Tabell film](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-Animationen ovan genererades utav [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) i exempelkatalogen.
+Animationen ovan genererades utav [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) i exempelkatalogen.
 
 Här är ett exempel av en enklare tabell:
 
@@ -236,13 +236,13 @@ console.print(table)
 
 Detta producerar följande utmatning:
 
-![tabell](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![tabell](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 Notera att konsol märkspråk är framställt på samma sätt som `print()` och `log()`. I själva verket, vad som helst som är framställt av Rich kan inkluderas i rubriker / rader (även andra tabeller).
 
 `Table` klassen är smart nog att storleksändra kolumner att passa den tillgängliga bredden av terminalen, och slår in text ifall det behövs. Här är samma exempel, med terminalen gjord mindre än tabell ovan:
 
-![tabell2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![tabell2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -262,13 +262,13 @@ for step in track(range(100)):
 
 Det är inte mycket svårare att lägga till flera framstegsfält. Här är ett exempel tagen från dokumentationen:
 
-![framsteg](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![framsteg](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 Dessa kolumner kan konfigureras att visa vilka detaljer du vill. Inbyggda kolumner inkluderar procentuell färdig, filstorlek, filhastighet, och återstående tid. Här är ännu ett exempel som visar en pågående nedladdning:
 
-![framsteg](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![framsteg](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-För att själv testa detta, kolla [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) vilket kan ladda ner flera URLs samtidigt medan visar framsteg.
+För att själv testa detta, kolla [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) vilket kan ladda ner flera URLs samtidigt medan visar framsteg.
 
 </details>
 
@@ -293,7 +293,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 Detta genererar följande utmatning i terminalen.
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 Snurra animationen är lånad ifrån [cli-spinners](https://www.npmjs.com/package/cli-spinners). Du kan välja en snurra genom att specifiera `spinner` parametern. Kör följande kommando för att se tillgängliga värden:
 
@@ -303,7 +303,7 @@ python -m rich.spinner
 
 Kommandot ovan genererar följande utmatning i terminalen:
 
-![Snurror](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![Snurror](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -320,9 +320,9 @@ python -m rich.tree
 
 Detta genererar följande utmatning:
 
-![märkspråk](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![märkspråk](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-Se [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) exemplet för ett skript som visar en trädvy av vilken katalog som helst, som liknar linux `tree` kommandot.
+Se [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) exemplet för ett skript som visar en trädvy av vilken katalog som helst, som liknar linux `tree` kommandot.
 
 </details>
 
@@ -342,9 +342,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-Följande skärmdump är resultatet från [kolumner exempelet](https://github.com/willmcgugan/rich/blob/master/examples/columns.py) vilket visar data tagen från ett API i kolumner:
+Följande skärmdump är resultatet från [kolumner exempelet](https://github.com/Textualize/rich/blob/master/examples/columns.py) vilket visar data tagen från ett API i kolumner:
 
-![kolumner](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![kolumner](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -367,7 +367,7 @@ console.print(markdown)
 
 Detta kommer att producera utmatning som liknar följande:
 
-![märkspråk](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![märkspråk](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -402,7 +402,7 @@ console.print(syntax)
 
 Detta kommer producera följande utmatning:
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -413,7 +413,7 @@ Rich kan framställa [vackra tillbaka-spårningar](https://rich.readthedocs.io/e
 
 Så här ser det ut på OSX (liknande på Linux):
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -453,4 +453,4 @@ Här är ett par projekt som använder Rich:
   Lättvikt Python bibliotek för att addera 2d-objektspårning i realtid till vilken detektor som helst.
 - [ansible/ansible-lint](https://github.com/ansible/ansible-lint) Ansible-lint kontroller playbooks för dess metoder och beteenden som potentiellt kan förbättras
 - [ansible-community/molecule](https://github.com/ansible-community/molecule) Ansible Molecule ramverk för testning
-- +[Many more](https://github.com/willmcgugan/rich/network/dependents)!
+- +[Many more](https://github.com/Textualize/rich/network/dependents)!

--- a/README.tr.md
+++ b/README.tr.md
@@ -5,32 +5,31 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
- • [Indonesian readme](https://github.com/willmcgugan/rich/blob/master/README.id.md)
- • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [Indonesian readme](https://github.com/Textualize/rich/blob/master/README.id.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
-
-Bir Python kütüphanesi olan __rich__, terminal üzerinde gösterişli çıktılar almanızı sağlayan bir araçtır.
+Bir Python kütüphanesi olan **rich**, terminal üzerinde gösterişli çıktılar almanızı sağlayan bir araçtır.
 
 [Rich API](https://rich.readthedocs.io/en/latest/) kullanarak terminal çıktılarınıza sitil ekleyebilir ve renklendirebilirsiniz. Aynı zamanda tabloları, durum çubuklarını, markdown sitillerini, kaynak koddaki syntax gösterimlerini ve bir çok şeyi rich kullanarak yapabilirsiniz.
 
-![Features](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Features](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 Rich'e video ile göz atmak için [@fishnets88](https://twitter.com/fishnets88) tarafından oluşturulan [calmcode.io](https://calmcode.io/rich/introduction.html) sitesine bakabilirsiniz.
 
@@ -52,7 +51,6 @@ python -m pip install rich
 
 Aşağıdaki komut satırını çalıştırarak çıktınızı terminal üzerinden görebilirsiniz.
 
-
 ```sh
 python -m rich
 ```
@@ -68,7 +66,7 @@ print("Merhaba, [bold magenta]Dünya[/bold magenta]!", ":vampire:", locals())
 ```
 
 Buradaki yazıyı değiştiremediğim için siz hello world olarak görüyorsunuz. :D
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -79,7 +77,7 @@ Rich Python REPL içerisine yüklenebilir, böylece her hangi bir veri tipini g�
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Terminali Nasıl Kullanılır?
 
@@ -108,7 +106,7 @@ console.print("Merhaba", "Dünya!", style="bold red")
 
 Eğer çıktıyı değiştirmeseydim aşağıdaki gibi bir görüntü ile karşılaşacaktınız:
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 Tek seferde bir yazıyı renklendirmek için kullanışlı bir yöntem olsa da, eğer çıktımızın sadece belirli bölgelerinde değişiklik yapacaksak [bbcode](https://en.wikipedia.org/wiki/BBCode) syntax'ını kullanmalıyız. Bunun içinde bir örnek:
 
@@ -116,7 +114,7 @@ Tek seferde bir yazıyı renklendirmek için kullanışlı bir yöntem olsa da, 
 console.print("[bold red]Mustafa Kemal Atatürk[/bold red] [u](1881 - 10 Kasım 1938)[/u], [i]Türk asker ve devlet adamıdır[/i]. [bold cyan]Türk Kurtuluş Savaşı'nın başkomutanı ve Türkiye Cumhuriyeti'nin kurucusudur[/bold cyan].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 Console objesini kullanarak sofistike bir çok çıktıyu minimum efor ile oluşturabilirsiniz. [Console API](https://rich.readthedocs.io/en/latest/console.html) dökümanına göz atarak daha fazla bilgi elde edebilirsiniz.
 
@@ -130,7 +128,7 @@ Rich [inspect](https://rich.readthedocs.io/en/latest/reference/init.html?highlig
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 [Bu dökümana](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) göz atarak daha fazla bilgi elde edebilirsiniz..
 
@@ -171,7 +169,7 @@ test_log()
 
 Ve bu kod parçasının çıktısı:
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 `log_locals` argümanı, local olarak bulunan değişkenleri tablo olarak ekrana bastırır.
 
@@ -181,7 +179,7 @@ Ve bu kod parçasının çıktısı:
 
 Python'un logging modülünü de [Handler sınıfı](https://rich.readthedocs.io/en/latest/logging.html) ile formatlayıp renklendirebiliriz.
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -204,9 +202,9 @@ Bu özelliği doğru yerlerde kullanmakta fayda var tabi.
 
 Rich kullanıcılarına esnek bir [tablo](https://rich.readthedocs.io/en/latest/tables.html) imkanı sunar, birden fazla şekilde formatlayıp, stillendirip kullanabilirsiniz.
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-Yukarıdaki tablo örneği [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) örnek kodu ile oluşturulmuştur.
+Yukarıdaki tablo örneği [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) örnek kodu ile oluşturulmuştur.
 
 Basit bir tablo örneği:
 
@@ -242,13 +240,13 @@ console.print(table)
 
 Kodun çıktısı aşağıdaki gibi olmaktadır:
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 Note that console markup is rendered in the same way as `print()` and `log()`. In fact, anything that is renderable by Rich may be included in the headers / rows (even other tables).
 
 `Table` sınıfı kendini terminal ekranına göre ayarlayabilir, genişletip, küçültebilir. Burada bunun ile alakalı bir örnek görüyorsunuz.
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -268,13 +266,13 @@ for step in track(range(100)):
 
 Aşağıdaki görsellerde de görüleceği üzere birden fazla kez progress bar kullanabilirsiniz, ve dökümandan da anlışılacağı üzere bu hiç de zor bir iş değil.
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 Kolonlar kullanıcı tarafından ayarlanabilir, indirme hızını, dosya boyutunui yüzdesel olarak gösterimi gibi bir çok şekilde gösterim sağlayabilir.
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-Eğer size de denemek siterseniz [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) koduna bakarak ve çalıştırarak indirme yapabilirsiniz.
+Eğer size de denemek siterseniz [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) koduna bakarak ve çalıştırarak indirme yapabilirsiniz.
 
 </details>
 
@@ -299,9 +297,9 @@ with console.status("[bold green]Working on tasks...") as status:
 
 Yukarıdaki kod parçacığı aşağıdaki gibi bir çıktı üretecektir.
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
-Spin animasyonu [cli-spinners](https://www.npmjs.com/package/cli-spinners) kütüphanesinden alınmıştır. `spinner` parametresi ile seçeceğiniz spin şekilini kullanabilirsiniz. 
+Spin animasyonu [cli-spinners](https://www.npmjs.com/package/cli-spinners) kütüphanesinden alınmıştır. `spinner` parametresi ile seçeceğiniz spin şekilini kullanabilirsiniz.
 
 ```
 python -m rich.spinner
@@ -309,7 +307,7 @@ python -m rich.spinner
 
 Çıktısı aşağıdaki gibi bir sonuç üretecektir:
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -326,9 +324,9 @@ python -m rich.tree
 
 Kodun çıkartacağı görüntü şu olacaktır:
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-[tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) örnek dosyası ile linux'de bulunan `tree` kodunu rich üzerinden simüle edebilirsiniz.
+[tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) örnek dosyası ile linux'de bulunan `tree` kodunu rich üzerinden simüle edebilirsiniz.
 
 </details>
 
@@ -350,9 +348,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-Yukarıdaki yapıya [columns example](https://github.com/willmcgugan/rich/blob/master/examples/columns.py) bağlantısı üzerinden ulaşabilirsiniz.
+Yukarıdaki yapıya [columns example](https://github.com/Textualize/rich/blob/master/examples/columns.py) bağlantısı üzerinden ulaşabilirsiniz.
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -375,7 +373,7 @@ console.print(markdown)
 
 Aşağıdaki gibi bir çıktıya ulaşacağız.
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -411,7 +409,7 @@ console.print(syntax)
 
 Yukarıdaki kod parçası aşağıdaki gibi bir çıktı üretecektir.
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -422,7 +420,7 @@ Rich sahip oldukları ile güzel [tracebakcs](https://rich.readthedocs.io/en/lat
 
 Burada OSX üzerinde (tıpkı Linux gibi) bir tracebacks çıktısı görüyorsunuz.
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -431,7 +429,6 @@ Tüm rich yapıları [Console Protocol](https://rich.readthedocs.io/en/latest/pr
 # Rich CLI
 
 Aynı zamanda [Rich CLI](https://github.com/textualize/rich-cli) uygulamasını da kontrol edin. Bu uygulama ile konsol çıktılarınızı renklendirebilir, kod çıktılarınıza syntax uygulayabilir, markdown gösterebilir, CSV dosyasını görüntüleyebilir ve bir çok şey daha yapabilirsiniz.
-
 
 ![Rich CLI](https://raw.githubusercontent.com/Textualize/rich-cli/main/imgs/rich-cli-splash.jpg)
 

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -4,30 +4,30 @@
 [![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
-![Logo](https://github.com/willmcgugan/rich/raw/master/imgs/logo.svg)
+![Logo](https://github.com/Textualize/rich/raw/master/imgs/logo.svg)
 
-[English readme](https://github.com/willmcgugan/rich/blob/master/README.md)
- • [简体中文 readme](https://github.com/willmcgugan/rich/blob/master/README.cn.md)
- • [正體中文 readme](https://github.com/willmcgugan/rich/blob/master/README.zh-tw.md)
- • [Lengua española readme](https://github.com/willmcgugan/rich/blob/master/README.es.md)
- • [Deutsche readme](https://github.com/willmcgugan/rich/blob/master/README.de.md)
- • [Läs på svenska](https://github.com/willmcgugan/rich/blob/master/README.sv.md)
- • [日本語 readme](https://github.com/willmcgugan/rich/blob/master/README.ja.md)
- • [한국어 readme](https://github.com/willmcgugan/rich/blob/master/README.kr.md)
- • [Français readme](https://github.com/willmcgugan/rich/blob/master/README.fr.md)
- • [Schwizerdütsch readme](https://github.com/willmcgugan/rich/blob/master/README.de-ch.md)
- • [हिन्दी readme](https://github.com/willmcgugan/rich/blob/master/README.hi.md)
- • [Português brasileiro readme](https://github.com/willmcgugan/rich/blob/master/README.pt-br.md)
- • [Italian readme](https://github.com/willmcgugan/rich/blob/master/README.it.md)
- • [Русский readme](https://github.com/willmcgugan/rich/blob/master/README.ru.md)
-  • [فارسی readme](https://github.com/willmcgugan/rich/blob/master/README.fa.md)
- • [Türkçe readme](https://github.com/willmcgugan/rich/blob/master/README.tr.md)
+[English readme](https://github.com/Textualize/rich/blob/master/README.md)
+• [简体中文 readme](https://github.com/Textualize/rich/blob/master/README.cn.md)
+• [正體中文 readme](https://github.com/Textualize/rich/blob/master/README.zh-tw.md)
+• [Lengua española readme](https://github.com/Textualize/rich/blob/master/README.es.md)
+• [Deutsche readme](https://github.com/Textualize/rich/blob/master/README.de.md)
+• [Läs på svenska](https://github.com/Textualize/rich/blob/master/README.sv.md)
+• [日本語 readme](https://github.com/Textualize/rich/blob/master/README.ja.md)
+• [한국어 readme](https://github.com/Textualize/rich/blob/master/README.kr.md)
+• [Français readme](https://github.com/Textualize/rich/blob/master/README.fr.md)
+• [Schwizerdütsch readme](https://github.com/Textualize/rich/blob/master/README.de-ch.md)
+• [हिन्दी readme](https://github.com/Textualize/rich/blob/master/README.hi.md)
+• [Português brasileiro readme](https://github.com/Textualize/rich/blob/master/README.pt-br.md)
+• [Italian readme](https://github.com/Textualize/rich/blob/master/README.it.md)
+• [Русский readme](https://github.com/Textualize/rich/blob/master/README.ru.md)
+• [فارسی readme](https://github.com/Textualize/rich/blob/master/README.fa.md)
+• [Türkçe readme](https://github.com/Textualize/rich/blob/master/README.tr.md)
 
 Rich 是一款提供終端機介面中 _豐富的_ 文字效果及精美的格式設定的 Python 函式庫。
 
 [Rich API](https://rich.readthedocs.io/en/latest/) 讓終端機介面加上色彩及樣式變得易如反掌。Rich 也可以繪製漂亮的表格、進度條、Markdown、語法醒目標示的程式碼、Traceback（追溯）……。
 
-![Features](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![Features](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 關於 Rich 的介紹，請參見 [@fishnets88](https://twitter.com/fishnets88) 在 [calmcode.io](https://calmcode.io/rich/introduction.html) 錄製的影片。
 
@@ -63,7 +63,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -74,7 +74,7 @@ Rich 可以安裝在 Python REPL 中，如此一來就可以漂亮的輸出與�
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## 使用 Console
 
@@ -102,7 +102,7 @@ console.print("Hello", "World!", style="bold red")
 
 輸出結果如下圖：
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/hello_world.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/hello_world.png)
 
 介紹完了如何對整行文字設定樣式，接著來看看更細部的使用。Rich 可以接受類似 [bbcode](https://en.wikipedia.org/wiki/BBCode) 的語法，對個別文字設定樣式。參考此範例：
 
@@ -110,7 +110,7 @@ console.print("Hello", "World!", style="bold red")
 console.print("Where there is a [bold cyan]Will[/bold cyan] there [u]is[/u] a [i]way[/i].")
 ```
 
-![Console Markup](https://github.com/willmcgugan/rich/raw/master/imgs/where_there_is_a_will.png)
+![Console Markup](https://github.com/Textualize/rich/raw/master/imgs/where_there_is_a_will.png)
 
 您可以用 Console 物件不費吹灰之力地達成細膩的輸出效果。參閱 [Console API](https://rich.readthedocs.io/en/latest/console.html) 說明文件以了解細節。
 
@@ -124,7 +124,7 @@ Rich 提供了 [inspect](https://rich.readthedocs.io/en/latest/reference/init.ht
 >>> inspect(my_list, methods=True)
 ```
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/inspect.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/inspect.png)
 
 參閱 [inspect 說明文件](https://rich.readthedocs.io/en/latest/reference/init.html#rich.inspect) 以了解細節。
 
@@ -164,7 +164,7 @@ test_log()
 
 上面的程式碼會產生下圖結果：
 
-![Log](https://github.com/willmcgugan/rich/raw/master/imgs/log.png)
+![Log](https://github.com/Textualize/rich/raw/master/imgs/log.png)
 
 注意到 `log_locals` 引數，可用來輸出一張表格，用來顯示 log 方法被呼叫時，區域變數的內容。
 
@@ -176,7 +176,7 @@ log 方法可用於伺服器上長時間運作的程式，也很適合一般程�
 
 您也可以使用內建的 [Handler 類別](https://rich.readthedocs.io/en/latest/logging.html) 來將 Python logging 模組的輸出內容格式化並賦予色彩：
 
-![Logging](https://github.com/willmcgugan/rich/raw/master/imgs/logging.png)
+![Logging](https://github.com/Textualize/rich/raw/master/imgs/logging.png)
 
 </details>
 
@@ -199,9 +199,9 @@ log 方法可用於伺服器上長時間運作的程式，也很適合一般程�
 
 Rich 可以用 unicode box 字元繪製彈性的 [表格](https://rich.readthedocs.io/en/latest/tables.html)。格式設定十分多元，包含框線、樣式、儲存格對齊……。
 
-![table movie](https://github.com/willmcgugan/rich/raw/master/imgs/table_movie.gif)
+![table movie](https://github.com/Textualize/rich/raw/master/imgs/table_movie.gif)
 
-上圖的動畫效果是以 [table_movie.py](https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py) 產生的，該檔案位於 examples 資料夾。
+上圖的動畫效果是以 [table_movie.py](https://github.com/Textualize/rich/blob/master/examples/table_movie.py) 產生的，該檔案位於 examples 資料夾。
 
 參考這個簡單的表格範例：
 
@@ -237,13 +237,13 @@ console.print(table)
 
 執行結果如圖：
 
-![table](https://github.com/willmcgugan/rich/raw/master/imgs/table.png)
+![table](https://github.com/Textualize/rich/raw/master/imgs/table.png)
 
 請留意，主控台標記的呈現方式與 `print()`、`log()` 相同。事實上，由 Rich 繪製的任何東西都可以被放在任何標題、列，甚至其他表格裡。
 
 `Table` 類別很聰明，能夠自動調整欄寬來配合終端機的大小，也會在需要時自動將文字換行。此範例的程式碼與上一個相同，然而終端機變小了一點：
 
-![table2](https://github.com/willmcgugan/rich/raw/master/imgs/table2.png)
+![table2](https://github.com/Textualize/rich/raw/master/imgs/table2.png)
 
 </details>
 
@@ -263,13 +263,13 @@ for step in track(range(100)):
 
 新增多個進度條也不是難事，來看看說明文件中的範例：
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 您可以調整要顯示的狀態欄位。內建的欄位包含完成百分比、檔案大小、讀寫速度及剩餘時間。來看看另一個用來顯示下載進度的範例：
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/downloader.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/downloader.gif)
 
-想嘗試看看嗎？您可以在 [examples/downloader.py](https://github.com/willmcgugan/rich/blob/master/examples/downloader.py) 取得此範例程式。此程式可以在下載多個檔案時顯示各自的進度。
+想嘗試看看嗎？您可以在 [examples/downloader.py](https://github.com/Textualize/rich/blob/master/examples/downloader.py) 取得此範例程式。此程式可以在下載多個檔案時顯示各自的進度。
 
 </details>
 
@@ -294,7 +294,7 @@ with console.status("[bold green]Working on tasks...") as status:
 
 終端機的顯示效果如下：
 
-![status](https://github.com/willmcgugan/rich/raw/master/imgs/status.gif)
+![status](https://github.com/Textualize/rich/raw/master/imgs/status.gif)
 
 該 spinner 動畫乃借用自 [cli-spinners](https://www.npmjs.com/package/cli-spinners)。可以用 `spinner` 參數指定 spinner 樣式。執行此命令以顯示可用的值：
 
@@ -304,7 +304,7 @@ python -m rich.spinner
 
 此命令在終端機的輸出結果如下圖：
 
-![spinners](https://github.com/willmcgugan/rich/raw/master/imgs/spinners.gif)
+![spinners](https://github.com/Textualize/rich/raw/master/imgs/spinners.gif)
 
 </details>
 
@@ -321,9 +321,9 @@ python -m rich.tree
 
 這會產生下圖的結果：
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/tree.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/tree.png)
 
-您可以參考 [tree.py](https://github.com/willmcgugan/rich/blob/master/examples/tree.py) 範例程式，此程式可以樹狀圖展示目錄結構，如同 Linux 的 `tree` 命令。
+您可以參考 [tree.py](https://github.com/Textualize/rich/blob/master/examples/tree.py) 範例程式，此程式可以樹狀圖展示目錄結構，如同 Linux 的 `tree` 命令。
 
 </details>
 
@@ -343,9 +343,9 @@ directory = os.listdir(sys.argv[1])
 print(Columns(directory))
 ```
 
-此螢幕截圖為 [資料欄範例](https://github.com/willmcgugan/rich/blob/master/examples/columns.py) 的輸出結果。此程式從某 API 取得資料，並以資料欄呈現：
+此螢幕截圖為 [資料欄範例](https://github.com/Textualize/rich/blob/master/examples/columns.py) 的輸出結果。此程式從某 API 取得資料，並以資料欄呈現：
 
-![columns](https://github.com/willmcgugan/rich/raw/master/imgs/columns.png)
+![columns](https://github.com/Textualize/rich/raw/master/imgs/columns.png)
 
 </details>
 
@@ -368,7 +368,7 @@ console.print(markdown)
 
 執行結果如下圖：
 
-![markdown](https://github.com/willmcgugan/rich/raw/master/imgs/markdown.png)
+![markdown](https://github.com/Textualize/rich/raw/master/imgs/markdown.png)
 
 </details>
 
@@ -403,7 +403,7 @@ console.print(syntax)
 
 執行結果如下圖：
 
-![syntax](https://github.com/willmcgugan/rich/raw/master/imgs/syntax.png)
+![syntax](https://github.com/Textualize/rich/raw/master/imgs/syntax.png)
 
 </details>
 
@@ -414,7 +414,7 @@ Rich 可以繪製 [漂亮的 tracebacks](https://rich.readthedocs.io/en/latest/t
 
 它在 macOS 上執行的效果如圖（Linux 上差異不大）：
 
-![traceback](https://github.com/willmcgugan/rich/raw/master/imgs/traceback.png)
+![traceback](https://github.com/Textualize/rich/raw/master/imgs/traceback.png)
 
 </details>
 
@@ -454,6 +454,6 @@ Rich 及其他數以千計的套件維護者正與 Tidelift 合作，以提供�
   Lightweight Python library for adding real-time 2D object tracking to any detector.
 - [ansible/ansible-lint](https://github.com/ansible/ansible-lint) Ansible-lint checks playbooks for practices and behaviour that could potentially be improved
 - [ansible-community/molecule](https://github.com/ansible-community/molecule) Ansible Molecule testing framework
-- +[Many more](https://github.com/willmcgugan/rich/network/dependents)!
+- +[Many more](https://github.com/Textualize/rich/network/dependents)!
 
 <!-- This is a test, no need to translate -->

--- a/benchmarks/snippets.py
+++ b/benchmarks/snippets.py
@@ -107,7 +107,7 @@ Richは、 _リッチ_ なテキストや美しい書式設定をターミナル
 
 [Rich API](https://rich.readthedocs.io/en/latest/)を使用すると、ターミナルの出力に色やスタイルを簡単に追加することができます。 Richはきれいなテーブル、プログレスバー、マークダウン、シンタックスハイライトされたソースコード、トレースバックなどをすぐに生成・表示することもできます。
 
-![機能](https://github.com/willmcgugan/rich/raw/master/imgs/features.png)
+![機能](https://github.com/Textualize/rich/raw/master/imgs/features.png)
 
 Richの紹介動画はこちらをご覧ください。 [calmcode.io](https://calmcode.io/rich/introduction.html) by [@fishnets88](https://twitter.com/fishnets88).
 
@@ -143,7 +143,7 @@ from rich import print
 print("Hello, [bold magenta]World[/bold magenta]!", ":vampire:", locals())
 ```
 
-![Hello World](https://github.com/willmcgugan/rich/raw/master/imgs/print.png)
+![Hello World](https://github.com/Textualize/rich/raw/master/imgs/print.png)
 
 ## Rich REPL
 
@@ -154,7 +154,7 @@ RichはPythonのREPLでインストールすることができ、データ構造
 >>> pretty.install()
 ```
 
-![REPL](https://github.com/willmcgugan/rich/raw/master/imgs/repl.png)
+![REPL](https://github.com/Textualize/rich/raw/master/imgs/repl.png)
 
 ## Rich Inspect
 

--- a/docs/source/columns.rst
+++ b/docs/source/columns.rst
@@ -19,5 +19,5 @@ The following example is a very basic clone of the ``ls`` command in OSX / Linux
         print(columns)
 
 
-See `columns.py <https://github.com/willmcgugan/rich/blob/master/examples/columns.py>`_ for an example which outputs columns containing more than just text. 
+See `columns.py <https://github.com/Textualize/rich/blob/master/examples/columns.py>`_ for an example which outputs columns containing more than just text. 
 

--- a/docs/source/layout.rst
+++ b/docs/source/layout.rst
@@ -137,4 +137,4 @@ To help visualize complex layouts you can print the ``tree`` attribute which wil
 Example
 -------
 
-See `fullscreen.py <https://github.com/willmcgugan/rich/blob/master/examples/fullscreen.py>`_ for an example that combines :class:`~rich.layout.Layout` and :class:`~rich.live.Live` to create a fullscreen "application".
+See `fullscreen.py <https://github.com/Textualize/rich/blob/master/examples/fullscreen.py>`_ for an example that combines :class:`~rich.layout.Layout` and :class:`~rich.live.Live` to create a fullscreen "application".

--- a/docs/source/live.rst
+++ b/docs/source/live.rst
@@ -160,6 +160,6 @@ In practice this is rarely a problem because you can display any combination of 
 Examples
 --------
 
-See `table_movie.py <https://github.com/willmcgugan/rich/blob/master/examples/table_movie.py>`_ and
-`top_lite_simulator.py <https://github.com/willmcgugan/rich/blob/master/examples/top_lite_simulator.py>`_
+See `table_movie.py <https://github.com/Textualize/rich/blob/master/examples/table_movie.py>`_ and
+`top_lite_simulator.py <https://github.com/Textualize/rich/blob/master/examples/top_lite_simulator.py>`_
 for deeper examples of live displaying.

--- a/docs/source/pretty.rst
+++ b/docs/source/pretty.rst
@@ -237,4 +237,4 @@ If you want to auto-generate the angular type of repr, then set ``angular=True``
 Example
 -------
 
-See `repr.py <https://github.com/willmcgugan/rich/blob/master/examples/repr.py>`_ for the example code used in this page.
+See `repr.py <https://github.com/Textualize/rich/blob/master/examples/repr.py>`_ for the example code used in this page.

--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -234,15 +234,15 @@ Here's an example that reads a url from the internet::
 
 If you expect to be reading from multiple files, you can use :meth:`~rich.progress.Progress.open` or :meth:`~rich.progress.Progress.wrap_file` to add a file progress to an existing Progress instance.
 
-See `cp_progress.py <https://github.com/willmcgugan/rich/blob/master/examples/cp_progress.py>` for a minimal clone of the ``cp`` command which shows a progress bar as the file is copied.
+See `cp_progress.py <https://github.com/Textualize/rich/blob/master/examples/cp_progress.py>` for a minimal clone of the ``cp`` command which shows a progress bar as the file is copied.
 
 
 Multiple Progress
 -----------------
 
-You can't have different columns per task with a single Progress instance. However, you can have as many Progress instances as you like in a :ref:`live`. See `live_progress.py <https://github.com/willmcgugan/rich/blob/master/examples/live_progress.py>`_ and `dynamic_progress.py <https://github.com/willmcgugan/rich/blob/master/examples/dynamic_progress.py>`_ for examples of using multiple Progress instances.
+You can't have different columns per task with a single Progress instance. However, you can have as many Progress instances as you like in a :ref:`live`. See `live_progress.py <https://github.com/Textualize/rich/blob/master/examples/live_progress.py>`_ and `dynamic_progress.py <https://github.com/Textualize/rich/blob/master/examples/dynamic_progress.py>`_ for examples of using multiple Progress instances.
 
 Example
 -------
 
-See `downloader.py <https://github.com/willmcgugan/rich/blob/master/examples/downloader.py>`_ for a realistic application of a progress display. This script can download multiple concurrent files with a progress bar, transfer speed and file size.
+See `downloader.py <https://github.com/Textualize/rich/blob/master/examples/downloader.py>`_ for a realistic application of a progress display. This script can download multiple concurrent files with a progress bar, transfer speed and file size.

--- a/docs/source/prompt.rst
+++ b/docs/source/prompt.rst
@@ -26,7 +26,7 @@ The :class:`~rich.prompt.Confirm` class is a specialized prompt which may be use
     >>> is_rich_great = Confirm.ask("Do you like rich?")
     >>> assert is_rich_great
 
-The Prompt class was designed to be customizable via inheritance. See `prompt.py <https://github.com/willmcgugan/rich/blob/master/rich/prompt.py>`_ for examples.
+The Prompt class was designed to be customizable via inheritance. See `prompt.py <https://github.com/Textualize/rich/blob/master/rich/prompt.py>`_ for examples.
 
 To see some of the prompts in action, run the following command from the command line::
 

--- a/docs/source/traceback.rst
+++ b/docs/source/traceback.rst
@@ -23,7 +23,7 @@ The :meth:`~rich.console.Console.print_exception` method will print a traceback 
 
 The ``show_locals=True`` parameter causes Rich to display the value of local variables for each frame of the traceback.
  
-See `exception.py <https://github.com/willmcgugan/rich/blob/master/examples/exception.py>`_ for a larger example.
+See `exception.py <https://github.com/Textualize/rich/blob/master/examples/exception.py>`_ for a larger example.
 
 
 Traceback Handler
@@ -95,4 +95,3 @@ Here's an example of printing a recursive error::
         foo(1)
     except Exception:
         console.print_exception(max_frames=20)
-

--- a/docs/source/tree.rst
+++ b/docs/source/tree.rst
@@ -41,5 +41,5 @@ If you set ``guide_style`` to bold, Rich will select the thicker variations of u
 Examples
 ~~~~~~~~
 
-For a more practical demonstration, see `tree.py <https://github.com/willmcgugan/rich/blob/master/examples/tree.py>`_ which can generate a tree view of a directory in your hard drive.
+For a more practical demonstration, see `tree.py <https://github.com/Textualize/rich/blob/master/examples/tree.py>`_ which can generate a tree view of a directory in your hard drive.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rich"
-homepage = "https://github.com/willmcgugan/rich"
+homepage = "https://github.com/Textualize/rich"
 documentation = "https://rich.readthedocs.io/en/latest/"
 version = "12.5.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -46,7 +46,7 @@ An [example](http://example.com).
 >
 > Lorem ipsum
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 
 ```

--- a/tests/test_markdown_no_hyperlinks.py
+++ b/tests/test_markdown_no_hyperlinks.py
@@ -46,7 +46,7 @@ An [example](http://example.com).
 >
 > Lorem ipsum
 
-![progress](https://github.com/willmcgugan/rich/raw/master/imgs/progress.gif)
+![progress](https://github.com/Textualize/rich/raw/master/imgs/progress.gif)
 
 
 ```

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -165,7 +165,7 @@ def test_divide():
     ]
 
 
-# https://github.com/willmcgugan/rich/issues/1755
+# https://github.com/Textualize/rich/issues/1755
 def test_divide_complex():
     MAP = (
         "[on orange4]          [on green]XX[on orange4]          \n"

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -758,7 +758,7 @@ def test_slice():
 
 
 def test_wrap_invalid_style():
-    # https://github.com/willmcgugan/rich/issues/987
+    # https://github.com/Textualize/rich/issues/987
     console = Console(width=100, color_system="truecolor")
     a = "[#######.................] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx [#######.................]"
     console.print(a, justify="full")


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This pull request updates multiple links pointing to the original location of this project (https://github.com/willmcgugan/rich). Every time one of these links is opened, a 301 status code is returned, and the page is redirected to the current repo. The links have been updated to point at the current location of the repo (https://github.com/Textualize/rich).

I understand that for posterity's sake, the changelog may require the original repo to be noted for the PR link. Please let me know if this is the case, and I can revert this change.