### PR TITLE
Added console named argument to rich.reconfigure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Handle stdout/stderr being null https://github.com/Textualize/rich/pull/2513
 - Fix NO_COLOR support on legacy Windows https://github.com/Textualize/rich/pull/2458
+- `rich.reconfigure` accepts `console` argument as was in the documentation but was not implemented
 
 ## [12.5.2] - 2022-07-18
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ The following people have contributed to the development of Rich:
 <!-- Add your name below, sort alphabetically by surname. Link to Github profile / your home page. -->
 
 - [Patrick Arminio](https://github.com/patrick91)
+- [Andreas Backx](https://github.com/AndreasBackx)
 - [Gregory Beauregard](https://github.com/GBeauregard/pyffstream)
 - [Dennis Brakhane](https://github.com/brakhane)
 - [Darren Burns](https://github.com/darrenburns)

--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -36,12 +36,17 @@ def get_console() -> "Console":
     return _console
 
 
-def reconfigure(*args: Any, **kwargs: Any) -> None:
+def reconfigure(*args: Any, console: Optional["Console"] = None, **kwargs: Any) -> None:
     """Reconfigures the global console by replacing it with another.
 
     Args:
         console (Console): Replacement console instance.
     """
+    if console is not None:
+        global _console
+        _console = console
+        return
+
     from rich.console import Console
 
     new_console = Console(*args, **kwargs)

--- a/tests/test_rich_print.py
+++ b/tests/test_rich_print.py
@@ -5,6 +5,10 @@ import rich
 from rich.console import Console
 
 
+class CustomConsole(Console):
+    pass
+
+
 def test_get_console():
     console = rich.get_console()
     assert isinstance(console, Console)
@@ -13,6 +17,14 @@ def test_get_console():
 def test_reconfigure_console():
     rich.reconfigure(width=100)
     assert rich.get_console().width == 100
+    assert isinstance(rich.get_console(), Console)
+
+
+def test_reconfigure_custom_console():
+    new_console = CustomConsole(width=100)
+    rich.reconfigure(console=new_console)
+    assert rich.get_console().width == 100
+    assert isinstance(rich.get_console(), CustomConsole)
 
 
 def test_rich_print():


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [x] Tests
- [ ] Other


## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The documentation for `rich.reconfigure` says there is an option for a `console` argument. That however was never implemented and I cannot find any changes around that piece of the code so assume it was forgotten and not removed? 🤔 Instead of making an issue about it, I thought the fastest thing was to add it. I'm open to any changes that you would propose.

I am interested in passing my own `console` so I can pass a custom subclass. The reason I would want this, is so I can change the `LogRender` being used by the `Console` which would require a custom subclass afaik. https://github.com/Textualize/rich/discussions/344 is relevant, though it only does it for the `logging` handler, this would allow a custom `LogRender` for other messages as well.

I was thinking of making it a `Type[Console]`, though that would require the documentation to change as well. Personally I am not very fussed on how this is implemented so let me know what you think/prefer. :)
