### PR TITLE
Solves issue #2464: Add print_json to __all__ in __init__.py

### DIFF
--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -5,7 +5,7 @@ from typing import IO, TYPE_CHECKING, Any, Callable, Optional, Union
 
 from ._extension import load_ipython_extension  # noqa: F401
 
-__all__ = ["get_console", "reconfigure", "print", "inspect"]
+__all__ = ["get_console", "reconfigure", "print", "inspect", "print_json"]
 
 if TYPE_CHECKING:
     from .console import Console


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [X] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

I didn't run Black, added tests, nor updated the other files, because this update is just like a few characters long of code (check the diff in "Files changed")

PR details:
"When I import print_json i get an underline in PyCharm because print_json is not listed in the __all__ of the init.py module.
Please add it so that IDE's don't complain."

This PR adds print_json function to __all__ in __init__.py