### PR TITLE
Remove unused height parameter from Layout class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix NO_COLOR support on legacy Windows https://github.com/Textualize/rich/pull/2458
 - Fix pretty printer handling of cyclic references https://github.com/Textualize/rich/pull/2524
 - Fix missing `mode` property on file wrapper breaking uploads via `requests` https://github.com/Textualize/rich/pull/2495
+- Remove unused height parameter in `Layout` class https://github.com/Textualize/rich/pull/2540
 
 ### Changed
 

--- a/rich/layout.py
+++ b/rich/layout.py
@@ -20,8 +20,8 @@ from .console import Console, ConsoleOptions, RenderableType, RenderResult
 from .highlighter import ReprHighlighter
 from .panel import Panel
 from .pretty import Pretty
-from .repr import rich_repr, Result
 from .region import Region
+from .repr import Result, rich_repr
 from .segment import Segment
 from .style import StyleType
 
@@ -162,7 +162,6 @@ class Layout:
         minimum_size: int = 1,
         ratio: int = 1,
         visible: bool = True,
-        height: Optional[int] = None,
     ) -> None:
         self._renderable = renderable or _Placeholder(self)
         self.size = size
@@ -170,7 +169,6 @@ class Layout:
         self.ratio = ratio
         self.name = name
         self.visible = visible
-        self.height = height
         self.splitter: Splitter = self.splitters["column"]()
         self._children: List[Layout] = []
         self._render_map: RenderMap = {}


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The height parameter wasn't used.