### PR TITLE
Implement Text comparator methods; fix Text equality checking; implement Text hashing for use as dict keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Document using `None` as name in `__rich_repr__` for tuple positional args https://github.com/Textualize/rich/pull/2379
 - Add `font_aspect_ratio` parameter in SVG export https://github.com/Textualize/rich/pull/2539/files
 - Added `Table.add_section` method. https://github.com/Textualize/rich/pull/2544
-- Implemented `Text.__hash__` method (enables `Text` objects to be used as `dict` keys).
-- Implemented `Text.__le__` and `Text.__lt__` to enable comparison (and thus also sorting) of `Text` objects in a reproducible way based on the string, the style, and the `Span`s.
+- Implemented `Text.__hash__` method (enables `Text` objects to be used as `dict` keys). https://github.com/Textualize/rich/pull/2554
+- Implemented `Text.__le__` and `Text.__lt__` to enable comparison (and thus also sorting) of `Text` objects in a reproducible way based on the string, the style, and the `Span`s. https://github.com/Textualize/rich/pull/2554
 
 ### Fixed
 
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing `mode` property on file wrapper breaking uploads via `requests` https://github.com/Textualize/rich/pull/2495
 - Fix mismatching default value of parameter `ensure_ascii` https://github.com/Textualize/rich/pull/2538
 - Remove unused height parameter in `Layout` class https://github.com/Textualize/rich/pull/2540
-- `Text` equality now checks the string, the style, and the spans instead of just the string and the spans
+- `Text` equality now checks the string, the style, and the spans instead of just the string and the spans. https://github.com/Textualize/rich/pull/2554
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Document using `None` as name in `__rich_repr__` for tuple positional args https://github.com/Textualize/rich/pull/2379
 - Add `font_aspect_ratio` parameter in SVG export https://github.com/Textualize/rich/pull/2539/files
 - Added `Table.add_section` method. https://github.com/Textualize/rich/pull/2544
+- Implemented `Text.__hash__` method (enables `Text` objects to be used as `dict` keys).
+- Implemented `Text.__le__` and `Text.__lt__` to enable comparison (and thus also sorting) of `Text` objects in a reproducible way based on the string, the style, and the `Span`s.
 
 ### Fixed
 
@@ -25,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing `mode` property on file wrapper breaking uploads via `requests` https://github.com/Textualize/rich/pull/2495
 - Fix mismatching default value of parameter `ensure_ascii` https://github.com/Textualize/rich/pull/2538
 - Remove unused height parameter in `Layout` class https://github.com/Textualize/rich/pull/2540
+- `Text` equality now checks the string, the style, and the spans instead of just the string and the spans
 
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ The following people have contributed to the development of Rich:
 - [Dennis Brakhane](https://github.com/brakhane)
 - [Darren Burns](https://github.com/darrenburns)
 - [Jim Crist-Harif](https://github.com/jcrist)
+- [Michel de Cryptadamus](https://github.com/michelcrypt4d4mus)
 - [Ed Davis](https://github.com/davised)
 - [Pete Davison](https://github.com/pd93)
 - [James Estevez](https://github.com/jstvz)

--- a/rich/text.py
+++ b/rich/text.py
@@ -211,6 +211,11 @@ class Text(JupyterMixin):
         else:
             return NotImplemented
 
+    def __lt__(self, other):
+        if self == other:
+            return False
+        return self <= other
+
     def __hash__(self) -> int:
         return hash(self.markup)
 

--- a/rich/text.py
+++ b/rich/text.py
@@ -203,7 +203,7 @@ class Text(JupyterMixin):
             return span < other.spans[i]
         return True
 
-    def __lt__(self, other):
+    def __lt__(self, other: object) -> bool:
         if self == other:
             return False
         return self <= other

--- a/rich/text.py
+++ b/rich/text.py
@@ -173,13 +173,15 @@ class Text(JupyterMixin):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Text):
             return NotImplemented
-        return self.plain == other.plain and self._spans == other._spans
+        return self.plain == other.plain and \
+               self.style == other.style and \
+               self._spans == other._spans
 
     def __le__(self, other: object) -> bool:
         """
-        This Text object is considered less than or equal to the other if:
-          1. It's plain string representation is less than the other's.
-          2. Plain strings are the same but the style string is less than other's style string.
+        A Text object is less than or equal to the other if:
+          1. Its plain string representation is less than the other's.
+          2. The plain strings are the same but the style string is less than other's style string.
           3. Plain strings and style strings are the same but the Nth Span tuple is less than
              the other's Nth Span tuple
           4. Plain strings, style strings, and all N of its Spans are the same as the other's.

--- a/rich/text.py
+++ b/rich/text.py
@@ -173,9 +173,11 @@ class Text(JupyterMixin):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Text):
             return NotImplemented
-        return self.plain == other.plain and \
-               self.style == other.style and \
-               self._spans == other._spans
+        return (
+            self.plain == other.plain
+            and self.style == other.style
+            and self._spans == other._spans
+        )
 
     def __le__(self, other: object) -> bool:
         """

--- a/rich/text.py
+++ b/rich/text.py
@@ -186,32 +186,22 @@ class Text(JupyterMixin):
              the other's Nth Span tuple
           4. Plain strings, style strings, and all N of its Spans are the same as the other's.
         """
-        if isinstance(other, Text):
-            if self.plain != other.plain:
-                return self.plain <= other.plain
-            elif str(self.style) != str(other.style):
-                return str(self.style) <= str(other.style)
-            elif len(self.spans) == len(other.spans) == 0:
-                return True
-
-            # If plain string and style strings match, we compare span by span
-            for i, span in enumerate(self.spans):
-                if len(other.spans) < i + 1:
-                    return False
-                # Normalize the span styles to strings to ensure safe comparison
-                other_span = other.spans[i]
-                this_span = (span.start, span.end, str(span.style))
-                that_span = (other_span.start, other_span.end, str(other_span.style))
-                if this_span == that_span:
-                    continue
-                return this_span < that_span
-            return True
-        elif isinstance(other, str):
-            if other == self.plain:
-                return False
-            return self.plain <= other
-        else:
+        if not isinstance(other, Text):
             return NotImplemented
+        if self.plain != other.plain:
+            return self.plain <= other.plain
+        elif str(self.style) != str(other.style):
+            return str(self.style) <= str(other.style)
+        elif len(self.spans) == 0:
+            return True
+        # If plain string and style strings match, we compare span by span
+        for i, span in enumerate(self.spans):
+            if len(other.spans) < i + 1:
+                return False
+            if repr(span) == repr(other.spans[i]):
+                continue
+            return span < other.spans[i]
+        return True
 
     def __lt__(self, other):
         if self == other:

--- a/rich/text.py
+++ b/rich/text.py
@@ -211,6 +211,8 @@ class Text(JupyterMixin):
         else:
             return NotImplemented
 
+    def __hash__(self) -> int:
+        return hash(self.markup)
 
     def __contains__(self, other: object) -> bool:
         if isinstance(other, str):

--- a/rich/text.py
+++ b/rich/text.py
@@ -191,6 +191,7 @@ class Text(JupyterMixin):
                 return str(self.style) <= str(other.style)
             elif len(self.spans) == len(other.spans) == 0:
                 return True
+
             # If plain string and style strings match, we compare span by span
             for i, span in enumerate(self.spans):
                 if len(other.spans) < i + 1:
@@ -199,10 +200,9 @@ class Text(JupyterMixin):
                 other_span = other.spans[i]
                 this_span = (span.start, span.end, str(span.style))
                 that_span = (other_span.start, other_span.end, str(other_span.style))
-                if this_span < that_span:
-                    return True
-                elif that_span < this_span:
-                    return False
+                if this_span == that_span:
+                    continue
+                return this_span < that_span
             return True
         elif isinstance(other, str):
             if other == self.plain:

--- a/rich/text.py
+++ b/rich/text.py
@@ -181,12 +181,13 @@ class Text(JupyterMixin):
 
     def __le__(self, other: object) -> bool:
         """
-        A Text object is less than or equal to the other if:
+        A Text object is less than or equal to another Text object if:
           1. Its plain string representation is less than the other's.
           2. The plain strings are the same but the style string is less than other's style string.
           3. Plain strings and style strings are the same but the Nth Span tuple is less than
              the other's Nth Span tuple
-          4. Plain strings, style strings, and all N of its Spans are the same as the other's.
+          4. It is equal to the other Text object (plain strings, style strings, and all of its
+             Spans are the same as the other Text object).
         """
         if not isinstance(other, Text):
             return NotImplemented

--- a/rich/text.py
+++ b/rich/text.py
@@ -175,6 +175,43 @@ class Text(JupyterMixin):
             return NotImplemented
         return self.plain == other.plain and self._spans == other._spans
 
+    def __le__(self, other: object) -> bool:
+        """
+        This Text object is considered less than or equal to the other if:
+          1. It's plain string representation is less than the other's.
+          2. Plain strings are the same but the style string is less than other's style string.
+          3. Plain strings and style strings are the same but the Nth Span tuple is less than
+             the other's Nth Span tuple
+          4. Plain strings, style strings, and all N of its Spans are the same as the other's.
+        """
+        if isinstance(other, Text):
+            if self.plain != other.plain:
+                return self.plain <= other.plain
+            elif str(self.style) != str(other.style):
+                return str(self.style) <= str(other.style)
+            elif len(self.spans) == len(other.spans) == 0:
+                return True
+            # If plain string and style strings match, we compare span by span
+            for i, span in enumerate(self.spans):
+                if len(other.spans) < i + 1:
+                    return False
+                # Normalize the span styles to strings to ensure safe comparison
+                other_span = other.spans[i]
+                this_span = (span.start, span.end, str(span.style))
+                that_span = (other_span.start, other_span.end, str(other_span.style))
+                if this_span < that_span:
+                    return True
+                elif that_span < this_span:
+                    return False
+            return True
+        elif isinstance(other, str):
+            if other == self.plain:
+                return False
+            return self.plain <= other
+        else:
+            return NotImplemented
+
+
     def __contains__(self, other: object) -> bool:
         if isinstance(other, str):
             return other in self.plain

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -39,11 +39,20 @@ def test_lines_justify():
     console = Console()
     lines1 = Lines([Text("foo", style="b"), Text("test", style="b")])
     lines1.justify(console, 10, justify="left")
-    assert lines1._lines == [Text("foo       ", style="b"), Text("test      ", style="b")]
+    assert lines1._lines == [
+        Text("foo       ", style="b"),
+        Text("test      ", style="b"),
+    ]
     lines1.justify(console, 10, justify="center")
-    assert lines1._lines == [Text("   foo    ", style="b"), Text("   test   ", style="b")]
+    assert lines1._lines == [
+        Text("   foo    ", style="b"),
+        Text("   test   ", style="b"),
+    ]
     lines1.justify(console, 10, justify="right")
-    assert lines1._lines == [Text("       foo", style="b"), Text("      test", style="b")]
+    assert lines1._lines == [
+        Text("       foo", style="b"),
+        Text("      test", style="b"),
+    ]
 
     lines2 = Lines([Text("foo bar", style="b"), Text("test", style="b")])
     lines2.justify(console, 7, justify="full")

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -39,11 +39,11 @@ def test_lines_justify():
     console = Console()
     lines1 = Lines([Text("foo", style="b"), Text("test", style="b")])
     lines1.justify(console, 10, justify="left")
-    assert lines1._lines == [Text("foo       "), Text("test      ")]
+    assert lines1._lines == [Text("foo       ", style="b"), Text("test      ", style="b")]
     lines1.justify(console, 10, justify="center")
-    assert lines1._lines == [Text("   foo    "), Text("   test   ")]
+    assert lines1._lines == [Text("   foo    ", style="b"), Text("   test   ", style="b")]
     lines1.justify(console, 10, justify="right")
-    assert lines1._lines == [Text("       foo"), Text("      test")]
+    assert lines1._lines == [Text("       foo", style="b"), Text("      test", style="b")]
 
     lines2 = Lines([Text("foo bar", style="b"), Text("test", style="b")])
     lines2.justify(console, 7, justify="full")
@@ -53,5 +53,5 @@ def test_lines_justify():
             "foo bar",
             spans=[Span(0, 3, "b"), Span(3, 4, Style.parse("bold")), Span(4, 7, "b")],
         ),
-        Text("test"),
+        Text("test", style="b"),
     ]

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -70,7 +70,7 @@ def test_text_column():
     text_column = TextColumn("[b]bar", markup=False)
     task = Task(1, "test", 100, 20, _get_time=lambda: 1.0)
     text = text_column.render(task)
-    assert text == Text("[b]bar")
+    assert text == Text("[b]bar", style="none")
 
 
 def test_time_elapsed_column():

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -64,6 +64,33 @@ def test_eq():
     assert Text("foo").__eq__(1) == NotImplemented
 
 
+def test_le():
+    def assert_less_than(a, b):
+        assert a <= b
+        assert not b <= a
+
+    foo = Text("foo")
+    goo = Text("goo")
+    assert_less_than(foo, goo)
+    assert foo <= foo
+    red_foo = Text("foo", style="red")
+    green_foo = Text("foo", style="green")
+    assert_less_than(green_foo, red_foo)
+    assert red_foo <= red_foo
+
+    def partially_styled(style_start, style):
+        hello = Text("Hello, cold world!")
+        hello.stylize(style, style_start)
+        return hello
+
+    half_red_hello = partially_styled(6, 'red')
+    half_green_hello = partially_styled(6, 'green')
+    assert_less_than(half_green_hello, half_red_hello)
+    quarter_red_hello = partially_styled(3, 'red')
+    assert_less_than(quarter_red_hello, half_red_hello)
+    assert_less_than(quarter_red_hello, half_green_hello)
+    assert foo.__le__(1) == NotImplemented
+
 def test_contain():
     text = Text("foobar")
     assert "foo" in text

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -76,7 +76,6 @@ def test_le():
     red_foo_styled_with_obj = Text("foo", Style(color="red"))
     assert_less_than(foo, goo)
     assert foo <= foo
-    assert foo <= "goo"
     assert red_foo <= red_foo
     assert red_foo_styled_with_obj <= red_foo
     assert red_foo <= red_foo_styled_with_obj

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -82,6 +82,7 @@ def test_le():
     assert red_foo <= red_foo_styled_with_obj
     assert_less_than(green_foo, red_foo)
     assert_less_than(green_foo, red_foo_styled_with_obj)
+    assert red_foo > green_foo
 
     def partially_styled(initial_style='', style_start=None, partial_style=''):
         hello = Text("hello, cold world!", initial_style)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -73,6 +73,7 @@ def test_le():
     goo = Text("goo")
     assert_less_than(foo, goo)
     assert foo <= foo
+    assert foo <= "goo"
     red_foo = Text("foo", style="red")
     green_foo = Text("foo", style="green")
     assert_less_than(green_foo, red_foo)
@@ -90,6 +91,7 @@ def test_le():
     assert_less_than(quarter_red_hello, half_red_hello)
     assert_less_than(quarter_red_hello, half_green_hello)
     assert foo.__le__(1) == NotImplemented
+
 
 def test_contain():
     text = Text("foobar")

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -84,26 +84,27 @@ def test_le():
     assert_less_than(green_foo, red_foo_styled_with_obj)
     assert red_foo > green_foo
 
-    def partially_styled(initial_style='', style_start=None, partial_style=''):
+    def partially_styled(initial_style="", style_start=None, partial_style=""):
         hello = Text("hello, cold world!", initial_style)
         if style_start:
             hello.stylize(partial_style, style_start)
         return hello
 
-    red_hello = partially_styled('red')
-    half_red_hello = partially_styled(style_start=6, partial_style='red')
-    half_green_hello = partially_styled(style_start=6, partial_style='green')
-    quarter_red_hello = partially_styled(style_start=3, partial_style='red')
-    half_red_half_green_hello = partially_styled('red', 6, 'green')
+    red_hello = partially_styled("red")
+    half_red_hello = partially_styled(style_start=6, partial_style="red")
+    half_green_hello = partially_styled(style_start=6, partial_style="green")
+    quarter_red_hello = partially_styled(style_start=3, partial_style="red")
+    half_red_half_green_hello = partially_styled("red", 6, "green")
     half_red_quarter_underline = half_red_hello.copy()
-    half_red_quarter_underline.stylize('underline', 9)
+    half_red_quarter_underline.stylize("underline", 9)
     assert_less_than(half_green_hello, half_red_hello)
     assert_less_than(quarter_red_hello, half_red_hello)
     assert_less_than(quarter_red_hello, half_green_hello)
     assert_less_than(red_hello, half_red_half_green_hello)
     assert_less_than(half_red_hello, half_red_quarter_underline)
-    assert sorted([red_hello, half_red_half_green_hello, green_foo, red_foo_styled_with_obj]) == \
-        [green_foo, red_foo_styled_with_obj, red_hello, half_red_half_green_hello]
+    assert sorted(
+        [red_hello, half_red_half_green_hello, green_foo, red_foo_styled_with_obj]
+    ) == [green_foo, red_foo_styled_with_obj, red_hello, half_red_half_green_hello]
     assert foo.__le__(1) == NotImplemented
 
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -71,26 +71,46 @@ def test_le():
 
     foo = Text("foo")
     goo = Text("goo")
+    red_foo = Text("foo", "red")
+    green_foo = Text("foo", style="green")
+    red_foo_styled_with_obj = Text("foo", Style(color="red"))
     assert_less_than(foo, goo)
     assert foo <= foo
     assert foo <= "goo"
-    red_foo = Text("foo", style="red")
-    green_foo = Text("foo", style="green")
-    assert_less_than(green_foo, red_foo)
     assert red_foo <= red_foo
+    assert red_foo_styled_with_obj <= red_foo
+    assert red_foo <= red_foo_styled_with_obj
+    assert_less_than(green_foo, red_foo)
+    assert_less_than(green_foo, red_foo_styled_with_obj)
 
-    def partially_styled(style_start, style):
-        hello = Text("Hello, cold world!")
-        hello.stylize(style, style_start)
+    def partially_styled(initial_style='', style_start=None, partial_style=''):
+        hello = Text("Hello, cold world!", initial_style)
+        if style_start:
+            hello.stylize(partial_style, style_start)
         return hello
 
-    half_red_hello = partially_styled(6, 'red')
-    half_green_hello = partially_styled(6, 'green')
+    red_hello = partially_styled('red')
+    half_red_hello = partially_styled(style_start=6, partial_style='red')
+    half_green_hello = partially_styled(style_start=6, partial_style='green')
+    quarter_red_hello = partially_styled(style_start=3, partial_style='red')
+    half_red_half_green_hello = partially_styled('red', 6, 'green')
+    half_red_quarter_underline = half_red_hello.copy()
+    half_red_quarter_underline.stylize('underline', 9)
     assert_less_than(half_green_hello, half_red_hello)
-    quarter_red_hello = partially_styled(3, 'red')
     assert_less_than(quarter_red_hello, half_red_hello)
     assert_less_than(quarter_red_hello, half_green_hello)
+    assert_less_than(red_hello, half_red_half_green_hello)
+    assert_less_than(half_red_hello, half_red_quarter_underline)
+    assert sorted([red_hello, half_red_half_green_hello, green_foo, red_foo_styled_with_obj]) == \
+        [green_foo, red_foo_styled_with_obj, red_hello, half_red_half_green_hello]
     assert foo.__le__(1) == NotImplemented
+
+
+def test_hash():
+    try:
+        _dict = {Text("foo"): 1, Text("foo", "red"): 2}
+    except Exception as e:
+        assert False, f"Using Text obj as a dict key failed with {e}"
 
 
 def test_contain():

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -84,7 +84,7 @@ def test_le():
     assert_less_than(green_foo, red_foo_styled_with_obj)
 
     def partially_styled(initial_style='', style_start=None, partial_style=''):
-        hello = Text("Hello, cold world!", initial_style)
+        hello = Text("hello, cold world!", initial_style)
         if style_start:
             hello.stylize(partial_style, style_start)
         return hello

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -76,6 +76,7 @@ def test_le():
     red_foo_styled_with_obj = Text("foo", Style(color="red"))
     assert_less_than(foo, goo)
     assert foo <= foo
+    assert not foo < foo
     assert red_foo <= red_foo
     assert red_foo_styled_with_obj <= red_foo
     assert red_foo <= red_foo_styled_with_obj


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

1. Implement `Text.__hash__()` to enable `Text` object as `dict` keys. Given that the markup version of any `Text` object is basically a unique string it seemed reasonable to just call the built in `hash()` method on the markup.
2. "Fix" the equality operator to take the style of a `Text` object into account in addition to the underlying string and the spans in that `Text` object. Seemed pretty odd to check the spans but not the overall style. (Hopefully you regard this as an actual fix.) Had to update a few old tests in the process.
3. Implement `Text.__lt__` and `Text.__le__`, which enables `Text` objects to be compared with `<` and `>` in addition to `==`, and thus also allows lists/tuples of `Text` objects to be sorted with the `sorted()` function.

The overall goal here was to move `Text` closer to a world where it can actually be used interchangeably with `str` as the documentation seems to imply it would like to.