### PR TITLE
Clean version of the temporary pin of snok/install-poetry

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Install and configure Poetry
-        uses: snok/install-poetry@v1
+        # TODO: workaround for https://github.com/snok/install-poetry/issues/94
+        uses: snok/install-poetry@v1.3.1
         with:
           version: 1.1.11
           virtualenvs-in-project: true


### PR DESCRIPTION
There is an issue with the latest version of this action, that's specific to Python 3.8 on Windows. Pinning to the (as of the time of writing) last-but-one version lets out tests work again.

See #2568.
