### PR TITLE
Remove redundant Python 3.6 code

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,7 +2,7 @@
 
 The following people have contributed to the development of Rich:
 
-<!-- Add your name below, sort alphabetically by surname. Link to Github profile / your home page. -->
+<!-- Add your name below, sort alphabetically by surname. Link to GitHub profile / your home page. -->
 
 - [Patrick Arminio](https://github.com/patrick91)
 - [Gregory Beauregard](https://github.com/GBeauregard/pyffstream)
@@ -21,6 +21,7 @@ The following people have contributed to the development of Rich:
 - [Lanqing Huang](https://github.com/lqhuang)
 - [Finn Hughes](https://github.com/finnhughes)
 - [Josh Karpel](https://github.com/JoshKarpel)
+- [Hugo van Kemenade](https://github.com/hugovk)
 - [Andrew Kettmann](https://github.com/akettmann)
 - [Martin Larralde](https://github.com/althonos)
 - [Hedy Li](https://github.com/hedythedev)

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -642,7 +642,6 @@ def traverse(
             return Node(value_repr="...")
 
         obj_type = type(obj)
-        py_version = (sys.version_info.major, sys.version_info.minor)
         children: List[Node]
         reached_max_depth = max_depth is not None and depth >= max_depth
 
@@ -780,7 +779,7 @@ def traverse(
             is_dataclass(obj)
             and not _safe_isinstance(obj, type)
             and not fake_attributes
-            and (_is_dataclass_repr(obj) or py_version == (3, 6))
+            and _is_dataclass_repr(obj)
         ):
             push_visited(obj_id)
             children = []

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -13,11 +13,6 @@ from rich._inspect import (
 )
 from rich.console import Console
 
-skip_py36 = pytest.mark.skipif(
-    sys.version_info.minor == 6 and sys.version_info.major == 3,
-    reason="rendered differently on py3.6",
-)
-
 skip_py37 = pytest.mark.skipif(
     sys.version_info.minor == 7 and sys.version_info.major == 3,
     reason="rendered differently on py3.7",
@@ -89,7 +84,6 @@ class FooSubclass(Foo):
     pass
 
 
-@skip_py36
 def test_render():
     console = Console(width=100, file=io.StringIO(), legacy_windows=False)
 
@@ -118,7 +112,6 @@ def test_inspect_text():
     assert render("Hello") == expected
 
 
-@skip_py36
 @skip_py37
 @skip_pypy3
 def test_inspect_empty_dict():
@@ -194,7 +187,6 @@ def test_inspect_coroutine():
     assert render(coroutine).startswith(expected)
 
 
-@skip_py36
 def test_inspect_integer():
     expected = (
         "╭────── <class 'int'> ───────╮\n"
@@ -210,7 +202,6 @@ def test_inspect_integer():
     assert expected == render(1)
 
 
-@skip_py36
 def test_inspect_integer_with_value():
     expected = "╭────── <class 'int'> ───────╮\n│ int([x]) -> integer        │\n│ int(x, base=10) -> integer │\n│                            │\n│ ╭────────────────────────╮ │\n│ │ 1                      │ │\n│ ╰────────────────────────╯ │\n│                            │\n│ denominator = 1            │\n│        imag = 0            │\n│   numerator = 1            │\n│        real = 1            │\n╰────────────────────────────╯\n"
     value = render(1, value=True)
@@ -218,7 +209,6 @@ def test_inspect_integer_with_value():
     assert value == expected
 
 
-@skip_py36
 @skip_py37
 @skip_py310
 @skip_py311
@@ -255,7 +245,6 @@ def test_inspect_integer_with_methods_python38_and_python39():
     assert render(1, methods=True) == expected
 
 
-@skip_py36
 @skip_py37
 @skip_py38
 @skip_py39
@@ -297,7 +286,6 @@ def test_inspect_integer_with_methods_python310only():
     assert render(1, methods=True) == expected
 
 
-@skip_py36
 @skip_py37
 @skip_py38
 @skip_py39
@@ -341,7 +329,6 @@ def test_inspect_integer_with_methods_python311_and_above():
     assert render(1, methods=True) == expected
 
 
-@skip_py36
 @skip_py37
 @skip_pypy3
 def test_broken_call_attr():

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -4,7 +4,7 @@ import sys
 from array import array
 from collections import UserDict, defaultdict
 from dataclasses import dataclass, field
-from typing import List, NamedTuple, Any
+from typing import Any, List, NamedTuple
 from unittest.mock import patch
 
 import attr
@@ -14,11 +14,6 @@ from rich.console import Console
 from rich.measure import Measurement
 from rich.pretty import Node, Pretty, _ipy_display_hook, install, pprint, pretty_repr
 from rich.text import Text
-
-skip_py36 = pytest.mark.skipif(
-    sys.version_info.minor == 6 and sys.version_info.major == 3,
-    reason="rendered differently on py3.6",
-)
 
 skip_py37 = pytest.mark.skipif(
     sys.version_info.minor == 7 and sys.version_info.major == 3,
@@ -289,7 +284,6 @@ def test_ansi_in_pretty_repr():
     assert result == "Hello World!\n"
 
 
-@skip_py36
 def test_broken_repr():
     class BrokenRepr:
         def __repr__(self):
@@ -301,7 +295,6 @@ def test_broken_repr():
     assert result == expected
 
 
-@skip_py36
 def test_broken_getattr():
     class BrokenAttr:
         def __getattr__(self, name):
@@ -618,7 +611,6 @@ def test_attrs_empty():
     assert result == expected
 
 
-@skip_py36
 @skip_py310
 @skip_py311
 def test_attrs_broken():
@@ -634,7 +626,6 @@ def test_attrs_broken():
     assert result == expected
 
 
-@skip_py36
 @skip_py37
 @skip_py38
 @skip_py39

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,15 +1,10 @@
-import pytest
 import sys
 from typing import Optional
 
-from rich.console import Console
+import pytest
+
 import rich.repr
-
-
-skip_py36 = pytest.mark.skipif(
-    sys.version_info.minor == 6 and sys.version_info.major == 3,
-    reason="rendered differently on py3.6",
-)
+from rich.console import Console
 
 skip_py37 = pytest.mark.skipif(
     sys.version_info.minor == 7 and sys.version_info.major == 3,
@@ -71,7 +66,6 @@ def test_rich_repr() -> None:
     assert (repr(Foo("hello", bar=3))) == "Foo('hello', 'hello', bar=3, egg=1)"
 
 
-@skip_py36
 @skip_py37
 def test_rich_repr_positional_only() -> None:
     _locals = locals().copy()

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion = 3.9.0
 envlist =
     lint
     docs
-    py{36,37,38,39}
+    py{37,38,39,310}
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [n/a] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

Follow on from https://github.com/Textualize/rich/pull/2567, remove some redundant code now support for EOL Python 3.6 has been dropped.