### PR TITLE
chore(spinner): Handle `KeyboardInterrupt` exception

### DIFF
--- a/rich/spinner.py
+++ b/rich/spinner.py
@@ -133,4 +133,7 @@ if __name__ == "__main__":  # pragma: no cover
         refresh_per_second=20,
     ) as live:
         while True:
-            sleep(0.1)
+            try:
+                sleep(0.1)
+            except KeyboardInterrupt:
+                break


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Add exception handler for `KeyboardInterrupt` exception when run `python -m rich.spinner` and use `Ctrl+C` to stop the example.