### PR TITLE
Update the homepage in pyproject.toml

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -7,4 +7,4 @@ jobs:
       - uses: actions/checkout@v3
       - run: python3 -m pip install codespell
       - run: codespell --ignore-words-list="ba,fo,hel,revered,womens"
-          --skip="./README.*.md,*.svg,./benchmarks/snippets.py,./tests,./tools"
+          --skip="./README.*.md,*.svg,*.ai,./benchmarks/snippets.py,./tests,./tools"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rich"
-homepage = "https://github.com/willmcgugan/rich"
+homepage = "https://github.com/Textualize/rich"
 documentation = "https://rich.readthedocs.io/en/latest/"
 version = "13.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"


### PR DESCRIPTION
It was still pointing to the older location within Will's GitHub, but now it lives under the Textualize organisation.
