### PR TITLE
Use `operator.length_hint` to estimate progress total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped minimum Python version to 3.7 https://github.com/Textualize/rich/pull/2567
 - Pretty-printing of "tagged" `__repr__` results is now greedy when matching tags https://github.com/Textualize/rich/pull/2565
+- `progress.track` now supports deriving total from `__length_hint__`
 
 ## [12.6.0] - 2022-10-02
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@ The following people have contributed to the development of Rich:
 - [Kenneth Hoste](https://github.com/boegel)
 - [Lanqing Huang](https://github.com/lqhuang)
 - [Finn Hughes](https://github.com/finnhughes)
+- [Ionite](https://github.com/ionite34)
 - [Josh Karpel](https://github.com/JoshKarpel)
 - [Hugo van Kemenade](https://github.com/hugovk)
 - [Andrew Kettmann](https://github.com/akettmann)

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -4,7 +4,6 @@ import typing
 import warnings
 from abc import ABC, abstractmethod
 from collections import deque
-from collections.abc import Sized
 from dataclasses import dataclass, field
 from datetime import timedelta
 from io import RawIOBase, UnsupportedOperation

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 from io import RawIOBase, UnsupportedOperation
 from math import ceil
 from mmap import mmap
+from operator import length_hint
 from os import PathLike, stat
 from threading import Event, RLock, Thread
 from types import TracebackType
@@ -1197,18 +1198,13 @@ class Progress(JupyterMixin):
         Returns:
             Iterable[ProgressType]: An iterable of values taken from the provided sequence.
         """
-
-        task_total: Optional[float] = None
         if total is None:
-            if isinstance(sequence, Sized):
-                task_total = float(len(sequence))
-        else:
-            task_total = total
+            total = float(length_hint(sequence)) or None
 
         if task_id is None:
-            task_id = self.add_task(description, total=task_total)
+            task_id = self.add_task(description, total=total)
         else:
-            self.update(task_id, total=task_total)
+            self.update(task_id, total=total)
 
         if self.live.auto_refresh:
             with _TrackThread(self, task_id, update_period) as track_thread:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] (N/A) I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This PR changes `progress.track` to use `operator.length_hint` (which calls `__len__` if exists, or `__length_hint__`) instead of `len()` when total is not provided. Allowing most built-in iterators and external library objects implementing the protocol with known length to have accurate progress tracking (such as `range` and `reversed`).

`operator.length_hint` was added in Python 3.4 as [PEP 424](https://peps.python.org/pep-0424/)

Other progress libraries, such as `tqdm`, already use this method:
https://github.com/tqdm/tqdm/blob/6791e8c5b3d6c30bdd2060c346996bfb5a6f10d1/tqdm/contrib/concurrent.py#L61
