### PR TITLE
Not setting `legacy_windows` when the terminal has been forced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [13.0.0] - Unreleased
 
+### Added
+
+- Not setting `legacy_windows` to `True` when the terminal has been specified https://github.com/Textualize/rich/pull/2623
 ### Changed
 
 - Bumped minimum Python version to 3.7 https://github.com/Textualize/rich/pull/2567

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@ The following people have contributed to the development of Rich:
 - [Patrick Arminio](https://github.com/patrick91)
 - [Gregory Beauregard](https://github.com/GBeauregard/pyffstream)
 - [Dennis Brakhane](https://github.com/brakhane)
+- [David Brownell](https://github.com/davidbrownell)
 - [Darren Burns](https://github.com/darrenburns)
 - [Jim Crist-Harif](https://github.com/jcrist)
 - [Ed Davis](https://github.com/davised)

--- a/rich/console.py
+++ b/rich/console.py
@@ -687,8 +687,22 @@ class Console:
         self._emoji = emoji
         self._emoji_variant: Optional[EmojiVariant] = emoji_variant
         self._highlight = highlight
+
+        self._force_terminal = None
+        if force_terminal is not None:
+            self._force_terminal = force_terminal
+        else:
+            # If FORCE_COLOR env var has any value at all, we force terminal.
+            force_color = self._environ.get("FORCE_COLOR")
+            if force_color is not None:
+                self._force_terminal = True
+
         self.legacy_windows: bool = (
-            (detect_legacy_windows() and not self.is_jupyter)
+            (
+                detect_legacy_windows()
+                and not self.is_jupyter
+                and not self._force_terminal
+            )
             if legacy_windows is None
             else legacy_windows
         )
@@ -707,15 +721,6 @@ class Console:
         self._height = height
 
         self._color_system: Optional[ColorSystem]
-
-        self._force_terminal = None
-        if force_terminal is not None:
-            self._force_terminal = force_terminal
-        else:
-            # If FORCE_COLOR env var has any value at all, we force terminal.
-            force_color = self._environ.get("FORCE_COLOR")
-            if force_color is not None:
-                self._force_terminal = True
 
         self._file = file
         self.quiet = quiet


### PR DESCRIPTION
Addresses issue #2622.

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [X] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
