### PR TITLE
Add the type annotation `str` for `pretty.Node.key_separator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped minimum Python version to 3.7 https://github.com/Textualize/rich/pull/2567
 - Pretty-printing of "tagged" `__repr__` results is now greedy when matching tags https://github.com/Textualize/rich/pull/2565
 
+### Added
+- Add type annotation for key_separator of pretty.Node https://github.com/Textualize/rich/issues/2625
+
 ## [12.6.0] - 2022-10-02
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,3 +57,4 @@ The following people have contributed to the development of Rich:
 - [Tomer Shalev](https://github.com/tomers)
 - [Serkan UYSAL](https://github.com/uysalserkan)
 - [Zhe Huang](https://github.com/onlyacat)
+- [Ke Sun](https://github.com/ksun212)

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -433,7 +433,7 @@ class Node:
     is_tuple: bool = False
     is_namedtuple: bool = False
     children: Optional[List["Node"]] = None
-    key_separator = ": "
+    key_separator: str = ": "
     separator: str = ", "
 
     def iter_tokens(self) -> Iterable[str]:


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I added the type annotation `str` for `pretty.Node.key_separator`, which is a dataclass that should have its attributes annotated. Otherwise, Python treats the unannotated attributes as class attributes. 
