### PR TITLE
Fix Traceback.from_exception ignores locals_max_length and locals_max_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Handle passing `locals_max_length` and `locals_max_string` to `Traceback.from_exception`
+- Handle passing `locals_max_length` and `locals_max_string` to `Traceback.from_exception` https://github.com/Textualize/rich/pull/2650
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [13.0.0] - Unreleased
 
+### Fixed
+
+- Handle passing `locals_max_length` and `locals_max_string` to `Traceback.from_exception`
+
 ### Changed
 
 - Bumped minimum Python version to 3.7 https://github.com/Textualize/rich/pull/2567

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ The following people have contributed to the development of Rich:
 <!-- Add your name below, sort alphabetically by surname. Link to GitHub profile / your home page. -->
 
 - [Patrick Arminio](https://github.com/patrick91)
+- [Gilad Barnea](https://github.com/giladbarnea)
 - [Gregory Beauregard](https://github.com/GBeauregard/pyffstream)
 - [Dennis Brakhane](https://github.com/brakhane)
 - [Darren Burns](https://github.com/darrenburns)

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -290,7 +290,12 @@ class Traceback:
             Traceback: A Traceback instance that may be printed.
         """
         rich_traceback = cls.extract(
-            exc_type, exc_value, traceback, show_locals=show_locals
+            exc_type,
+            exc_value,
+            traceback,
+            show_locals=show_locals,
+            locals_max_length=locals_max_length,
+            locals_max_string=locals_max_string,
         )
         return cls(
             rich_traceback,

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -344,6 +344,27 @@ def test_rich_traceback_omit_optional_local_flag(
         assert frame_names == expected_frame_names
 
 
+def test_rich_traceback_from_exception_respects_locals_max():
+    console = Console(width=160, file=io.StringIO())
+    try:
+        local_string = "O" * 145
+        1 / 0
+    except Exception as e:
+        traceback = Traceback.from_exception(
+            e.__class__,
+            e,
+            e.__traceback__,
+            width=console.width,
+            show_locals=True,
+            locals_max_length=console.width,
+            locals_max_string=console.width,
+        )
+        console.print(traceback)
+    result = console.file.getvalue()
+    print(result)
+    assert "O'+" not in result
+
+
 if __name__ == "__main__":  # pragma: no cover
 
     expected = render(get_exception())


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This fixes:
[Issue 2649: `Traceback.from_exception` ignores `locals_max_length` and `locals_max_string` arguments](https://github.com/Textualize/rich/issues/2649). 

### Bug description
Specifying `locals_max_length` and `locals_max_string` when using `Traceback.from_exception` had no effect; the defaults `LOCALS_MAX_LENGTH` and `LOCALS_MAX_STRING` were used instead.

### Fix
`Traceback.from_exception` internally calls `cls.extract`. It passes down all the arguments `Traceback.extract` supports besides `locals_max_length` and `locals_max_string`. I made it also pass `locals_max_length` and `locals_max_string` to `Traceback.extract`. 