### PR TITLE
Fix typing of Progress.add_task signature.

### DIFF
--- a/rich/progress.py
+++ b/rich/progress.py
@@ -1590,7 +1590,7 @@ class Progress(JupyterMixin):
         self,
         description: str,
         start: bool = True,
-        total: Optional[float] = 100.0,
+        total: Optional[Union[float, None]] = 100.0,
         completed: int = 0,
         visible: bool = True,
         **fields: Any,
@@ -1601,7 +1601,7 @@ class Progress(JupyterMixin):
             description (str): A description of the task.
             start (bool, optional): Start the task immediately (to calculate elapsed time). If set to False,
                 you will need to call `start` manually. Defaults to True.
-            total (float, optional): Number of total steps in the progress if known.
+            total (Union[float, None], optional): Number of total steps in the progress if known.
                 Set to None to render a pulsing animation. Defaults to 100.
             completed (int, optional): Number of steps completed so far. Defaults to 0.
             visible (bool, optional): Enable display of the task. Defaults to True.


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] ~~I've added tests for new code.~~ Does not apply
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The parameter `start` of `Progress.add_task` can be set to `None` for an indeterminate progress bar but the typing of the parameter says it must be a float. This fixes the typing so that static checkers like mypy don't complain about otherwise perfectly sane code.