### PR TITLE
Move spinner docstring to class.

### DIFF
--- a/rich/spinner.py
+++ b/rich/spinner.py
@@ -11,6 +11,18 @@ if TYPE_CHECKING:
 
 
 class Spinner:
+    """A spinner animation.
+
+    Args:
+        name (str): Name of spinner (run python -m rich.spinner).
+        text (RenderableType, optional): A renderable to display at the right of the spinner (str or Text typically). Defaults to "".
+        style (StyleType, optional): Style for spinner animation. Defaults to None.
+        speed (float, optional): Speed factor for animation. Defaults to 1.0.
+
+    Raises:
+        KeyError: If name isn't one of the supported spinner animations.
+    """
+
     def __init__(
         self,
         name: str,
@@ -19,17 +31,6 @@ class Spinner:
         style: Optional["StyleType"] = None,
         speed: float = 1.0,
     ) -> None:
-        """A spinner animation.
-
-        Args:
-            name (str): Name of spinner (run python -m rich.spinner).
-            text (RenderableType, optional): A renderable to display at the right of the spinner (str or Text typically). Defaults to "".
-            style (StyleType, optional): Style for spinner animation. Defaults to None.
-            speed (float, optional): Speed factor for animation. Defaults to 1.0.
-
-        Raises:
-            KeyError: If name isn't one of the supported spinner animations.
-        """
         try:
             spinner = SPINNERS[name]
         except KeyError:


### PR DESCRIPTION
## Type of changes

- [x] Documentation / docstrings

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Move the `rich.spinner.Spinner` docstring from the method `__init__` to the class so that the [reference docs page](https://rich.readthedocs.io/en/stable/reference/spinner.html) isn't empty.