### PR TITLE
Add 'encapsulated' boolean parameter (default: true) to rich.console.export_svg method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add type annotation for key_separator of pretty.Node https://github.com/Textualize/rich/issues/2625
+- Add an `encapsulated` boolean flag (default: `True`) to `export_svg` to indicate whether namespace encapsulation is required
 
 
 ## [12.6.0] - 2022-10-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped minimum Python version to 3.7 https://github.com/Textualize/rich/pull/2567
 - Pretty-printing of "tagged" `__repr__` results is now greedy when matching tags https://github.com/Textualize/rich/pull/2565
 - `progress.track` now supports deriving total from `__length_hint__`
-- Using the `unique_id` parameter during SVG export emits a warning message
+- Exporting SVG images without a generated unique ID emits a (filterable) warning
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped minimum Python version to 3.7 https://github.com/Textualize/rich/pull/2567
 - Pretty-printing of "tagged" `__repr__` results is now greedy when matching tags https://github.com/Textualize/rich/pull/2565
 - `progress.track` now supports deriving total from `__length_hint__`
+- Using the `unique_id` parameter during SVG export emits a warning message
 
 ### Fixed
 

--- a/rich/console.py
+++ b/rich/console.py
@@ -2381,9 +2381,9 @@ class Console:
             import warnings
 
             msg = (
-                "Using non-checksum prefix for SVG elements.  Non-unique prefixes have "
-                "the potential to cause namespace collisions when an exported SVG is "
-                "embedded into another document."
+                "Using non-checksum prefix for SVG element export.  Non-unique "
+                "prefixes have the potential to cause namespace collisions when an "
+                "exported SVG is embedded into another document."
             )
             warnings.warn(msg)
 

--- a/rich/console.py
+++ b/rich/console.py
@@ -2377,7 +2377,10 @@ class Console:
             if clear:
                 self._record_buffer.clear()
 
-        if unique_id is not None or encapsulated is False:
+        if encapsulated is False:
+            unique_id = "terminal"
+
+        if unique_id is not None:
             import warnings
 
             msg = (
@@ -2386,9 +2389,6 @@ class Console:
                 "exported SVG is embedded into another document."
             )
             warnings.warn(msg)
-
-        if encapsulated is False:
-            unique_id = "terminal"
 
         if unique_id is None:
             unique_id = "terminal-" + str(

--- a/rich/console.py
+++ b/rich/console.py
@@ -2377,11 +2377,11 @@ class Console:
             if clear:
                 self._record_buffer.clear()
 
-        if unique_id is not None:
+        if unique_id is not None or encapsulated is False:
             import warnings
 
             msg = (
-                "'unique_id' parameter passed to SVG export.  This has the potential "
+                "Using non-checksum prefix for SVG elements.  This has the potential "
                 "to cause namespace collisions if the SVG is embedded in a document."
             )
             warnings.warn(msg)

--- a/rich/console.py
+++ b/rich/console.py
@@ -2381,8 +2381,9 @@ class Console:
             import warnings
 
             msg = (
-                "Using non-checksum prefix for SVG elements.  This has the potential "
-                "to cause namespace collisions if the SVG is embedded in a document."
+                "Using non-checksum prefix for SVG elements.  Non-unique prefixes have "
+                "the potential to cause namespace collisions when an exported SVG is "
+                "embedded into another document."
             )
             warnings.warn(msg)
 

--- a/rich/console.py
+++ b/rich/console.py
@@ -2262,6 +2262,7 @@ class Console:
         code_format: str = CONSOLE_SVG_FORMAT,
         font_aspect_ratio: float = 0.61,
         unique_id: Optional[str] = None,
+        encapsulated: Optional[bool] = None,
     ) -> str:
         """
         Generate an SVG from the console contents (requires record=True in Console constructor).
@@ -2278,6 +2279,9 @@ class Console:
                 If you aren't specifying a different font inside ``code_format``, you probably don't need this.
             unique_id (str, optional): unique id that is used as the prefix for various elements (CSS styles, node
                 ids). If not set, this defaults to a computed value based on the recorded content.
+            encapsulated (bool, optional): whether to generate unique prefixes for various elements (CSS styles, node
+                ids) to approximate local scoping (useful, for example, when embedding multiple SVG exports in an XML
+                document).
         """
 
         from rich.cells import cell_len
@@ -2372,6 +2376,18 @@ class Console:
             segments = list(Segment.filter_control(self._record_buffer))
             if clear:
                 self._record_buffer.clear()
+
+        if unique_id is not None:
+            import warnings
+
+            msg = (
+                "'unique_id' parameter passed to SVG export.  This has the potential "
+                "to cause namespace collisions if the SVG is embedded in a document."
+            )
+            warnings.warn(msg)
+
+        if encapsulated is False:
+            unique_id = "terminal"
 
         if unique_id is None:
             unique_id = "terminal-" + str(
@@ -2514,6 +2530,7 @@ class Console:
         code_format: str = CONSOLE_SVG_FORMAT,
         font_aspect_ratio: float = 0.61,
         unique_id: Optional[str] = None,
+        encapsulated: Optional[bool] = True,
     ) -> None:
         """Generate an SVG file from the console contents (requires record=True in Console constructor).
 
@@ -2530,6 +2547,9 @@ class Console:
                 If you aren't specifying a different font inside ``code_format``, you probably don't need this.
             unique_id (str, optional): unique id that is used as the prefix for various elements (CSS styles, node
                 ids). If not set, this defaults to a computed value based on the recorded content.
+            encapsulated (bool, optional): whether to generate unique prefixes for various elements (CSS styles, node
+                ids) to approximate local scoping (useful, for example, when embedding multiple SVG exports in an XML
+                document).
         """
         svg = self.export_svg(
             title=title,
@@ -2538,6 +2558,7 @@ class Console:
             code_format=code_format,
             font_aspect_ratio=font_aspect_ratio,
             unique_id=unique_id,
+            encapsulated=encapsulated,
         )
         with open(path, "wt", encoding="utf-8") as write_file:
             write_file.write(svg)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -554,6 +554,7 @@ def test_export_svg():
     assert svg == EXPECTED_SVG
 
 
+@pytest.mark.filterwarnings("ignore:'unique_id'")
 def test_export_svg_specified_unique_id():
     expected_svg = EXPECTED_SVG.replace("terminal-3526644552", "given-id")
     console = Console(record=True, width=100)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -554,7 +554,7 @@ def test_export_svg():
     assert svg == EXPECTED_SVG
 
 
-@pytest.mark.filterwarnings("ignore:'unique_id'")
+@pytest.mark.filterwarnings("ignore:Using non-checksum prefix")
 def test_export_svg_specified_unique_id():
     expected_svg = EXPECTED_SVG.replace("terminal-3526644552", "given-id")
     console = Console(record=True, width=100)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

- Adds a (filterable) warning when the `unique_id` parameter added by #2537 is used.
- Adds an `encapsulated` parameter that is intended to provide a migration path towards the removal of the `unique_id` variable in future