### PR TITLE
Replace deprecated dev-dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 ]
 include = ["rich/py.typed"]
 
-
 [tool.poetry.dependencies]
 python = ">=3.7.0"
 typing-extensions = { version = ">=4.0.0, <5.0", python = "<3.9" }
@@ -32,11 +31,10 @@ pygments = "^2.6.0"
 commonmark = "^0.9.0"
 ipywidgets = { version = "^7.5.1", optional = true }
 
-
 [tool.poetry.extras]
 jupyter = ["ipywidgets"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"
 black = "^22.6"
 mypy = "^0.971"
@@ -48,7 +46,6 @@ asv = "^0.5.1"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-
 
 [tool.mypy]
 files = ["rich"]


### PR DESCRIPTION
See https://python-poetry.org/docs/master/managing-dependencies/ for details.

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Replace deprecated dev-dependencies in pyproject.toml with a group.  This requires developers to use poetry version 1.2+.