### PR TITLE
Add support for `pipx run rich`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add type annotation for key_separator of pretty.Node https://github.com/Textualize/rich/issues/2625
-
+- Add support for `pipx run rich` to run a demo without a separate installation step
 
 ## [12.6.0] - 2022-10-02
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@ The following people have contributed to the development of Rich:
 - [Lanqing Huang](https://github.com/lqhuang)
 - [Finn Hughes](https://github.com/finnhughes)
 - [Ionite](https://github.com/ionite34)
+- [Claudio Jolowicz](https://github.com/cjolowicz)
 - [Josh Karpel](https://github.com/JoshKarpel)
 - [Hugo van Kemenade](https://github.com/hugovk)
 - [Andrew Kettmann](https://github.com/akettmann)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ For a video introduction to Rich see [calmcode.io](https://calmcode.io/rich/intr
 
 See what [people are saying about Rich](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
 
+Use `pipx run rich` to try Rich in your terminal using [pipx](https://pypa.github.io/pipx/).
+
 ## Compatibility
 
 Rich works with Linux, OSX, and Windows. True color / emoji works with new Windows Terminal, classic terminal is limited to 16 colors. Rich requires Python 3.7 or later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ attrs = "^21.4.0"
 pre-commit = "^2.17.0"
 asv = "^0.5.1"
 
+[tool.poetry.plugins."pipx.run"]
+rich = "rich.__main__:main"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/rich/__main__.py
+++ b/rich/__main__.py
@@ -206,8 +206,7 @@ Supports much of the *markdown* __syntax__!
     return table
 
 
-if __name__ == "__main__":  # pragma: no cover
-
+def main() -> None:  # pragma: no cover
     console = Console(
         file=io.StringIO(),
         force_terminal=True,
@@ -272,3 +271,7 @@ Rich is maintained with [red]:heart:[/] by [link=https://www.textualize.io]Textu
         ),
         justify="center",
     )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Allow users to quickly try out rich in their terminal by typing `pipx run rich`. Running the demo does not require an explicit and permanent installation of rich. It's equivalent to running `python -m rich` from a temporary virtual environment.

This change declares an entry-point for `pipx run`. It does _not_ add a console script for rich, nor does it enable installation using `pipx install`.

There is some potential for confusion with `pipx install rich-cli`, which adds a `rich` command to the system. This needs to be weighed against the convenience of getting a quick demo of rich's capabilities. Personally, I like the convenience--your call though.

## Manual tests

Test the basic feature using the following commands:

```
$ poetry build
$ pipx run --spec dist/rich-13.0.0-py3-none-any.whl rich
[output from python -m rich]
```

Test that you still can't install rich as an app like this:

```
$ poetry build
$ pipx install dist/rich-13.0.0-py3-none-any.whl
No apps associated with package rich. [...]
```
