### PR TITLE
Capture output goes to terminal by default

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -327,10 +327,10 @@ class Capture:
         console (Console): A console instance to capture output.
     """
 
-    def __init__(self, console: "Console", **kwargs: Any) -> None:
+    def __init__(self, console: "Console", echo: bool=True) -> None:
+        self._echo = echo
         self._console = console
         self._result: Optional[str] = None
-        self._echo = kwargs.get("echo", True)
 
     def __enter__(self) -> "Capture":
         self._console.begin_capture()
@@ -344,7 +344,7 @@ class Capture:
     ) -> None:
         self._result = self._console.end_capture()
         if self._echo:
-            self._console.out(self._result)
+            self._console.print(self._result)
 
     def get(self) -> str:
         """Get the result of the capture."""
@@ -1083,7 +1083,7 @@ class Console:
         """Play a 'bell' sound (if supported by the terminal)."""
         self.control(Control.bell())
 
-    def capture(self, **kwargs: Any) -> Capture:
+    def capture(self, echo: bool=True) -> Capture:
         """A context manager to *capture* the result of print() or log() in a string,
         rather than writing it to the console.
 
@@ -1097,7 +1097,7 @@ class Console:
         Returns:
             Capture: Context manager with disables writing to the terminal.
         """
-        return Capture(self, **kwargs)
+        return Capture(self, echo)
 
     def pager(
         self, pager: Optional[Pager] = None, styles: bool = False, links: bool = False

--- a/rich/console.py
+++ b/rich/console.py
@@ -327,9 +327,10 @@ class Capture:
         console (Console): A console instance to capture output.
     """
 
-    def __init__(self, console: "Console") -> None:
+    def __init__(self, console: "Console", **kwargs) -> None:
         self._console = console
         self._result: Optional[str] = None
+        self._echo = kwargs.get('echo', True)
 
     def __enter__(self) -> "Capture":
         self._console.begin_capture()
@@ -342,6 +343,8 @@ class Capture:
         exc_tb: Optional[TracebackType],
     ) -> None:
         self._result = self._console.end_capture()
+        if self._echo:
+            self._console.out(self._result)
 
     def get(self) -> str:
         """Get the result of the capture."""
@@ -1080,7 +1083,7 @@ class Console:
         """Play a 'bell' sound (if supported by the terminal)."""
         self.control(Control.bell())
 
-    def capture(self) -> Capture:
+    def capture(self, **kwargs) -> Capture:
         """A context manager to *capture* the result of print() or log() in a string,
         rather than writing it to the console.
 
@@ -1094,8 +1097,7 @@ class Console:
         Returns:
             Capture: Context manager with disables writing to the terminal.
         """
-        capture = Capture(self)
-        return capture
+        return Capture(self, **kwargs)
 
     def pager(
         self, pager: Optional[Pager] = None, styles: bool = False, links: bool = False

--- a/rich/console.py
+++ b/rich/console.py
@@ -327,10 +327,10 @@ class Capture:
         console (Console): A console instance to capture output.
     """
 
-    def __init__(self, console: "Console", **kwargs) -> None:
+    def __init__(self, console: "Console", **kwargs: Any) -> None:
         self._console = console
         self._result: Optional[str] = None
-        self._echo = kwargs.get('echo', True)
+        self._echo = kwargs.get("echo", True)
 
     def __enter__(self) -> "Capture":
         self._console.begin_capture()
@@ -1083,7 +1083,7 @@ class Console:
         """Play a 'bell' sound (if supported by the terminal)."""
         self.control(Control.bell())
 
-    def capture(self, **kwargs) -> Capture:
+    def capture(self, **kwargs: Any) -> Capture:
         """A context manager to *capture* the result of print() or log() in a string,
         rather than writing it to the console.
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -371,7 +371,7 @@ def test_control():
     assert console.file.getvalue() == "\x1b[2JBAR\n"
 
 
-def test_capture():
+def test_capture(capsys):
     console = Console()
     with console.capture() as capture:
         with pytest.raises(CaptureError):
@@ -379,11 +379,19 @@ def test_capture():
         console.print("Hello")
     assert capture.get() == "Hello\n"
 
+    sysout = capsys.readouterr()
+    assert sysout.err == ""
+    assert sysout.out == "Hello\n\n"
+
     with console.capture(echo=False) as capture:
         with pytest.raises(CaptureError):
             capture.get()
         console.print("World")
     assert capture.get() == "World\n"
+
+    sysout = capsys.readouterr()
+    assert sysout.err == ""
+    assert sysout.out == ""
 
 
 def test_capture_and_record(capsys):

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -379,22 +379,33 @@ def test_capture():
         console.print("Hello")
     assert capture.get() == "Hello\n"
 
+    with console.capture(echo=False) as capture:
+        with pytest.raises(CaptureError):
+            capture.get()
+        console.print("World")
+    assert capture.get() == "World\n"
+
 
 def test_capture_and_record(capsys):
     recorder = Console(record=True)
-    recorder.print("ABC")
 
+    recorder.print("ABC")
     with recorder.capture() as capture:
         recorder.print("Hello")
 
     assert capture.get() == "Hello\n"
-
-    recorded_text = recorder.export_text()
-    out, err = capsys.readouterr()
-
-    assert recorded_text == "ABC\nHello\n"
+    assert recorder.export_text() == "ABC\nHello\nHello\n\n"
     assert capture.get() == "Hello\n"
-    assert out == "ABC\n"
+    assert capsys.readouterr() == ("ABC\nHello\n\n", "")
+
+    recorder.print("DEF")
+    with recorder.capture(echo=False) as capture:
+        recorder.print("World")
+
+    assert capture.get() == "World\n"
+    assert recorder.export_text() == "DEF\nWorld\n"
+    assert capture.get() == "World\n"
+    assert capsys.readouterr() == ("DEF\n", "")
 
 
 def test_input(monkeypatch, capsys):


### PR DESCRIPTION
Capture and console.capture() accepts a kwargs, where you may specify echo=False to silence output being sent to terminal.

## Type of changes

- [x] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Attempts a fix for https://github.com/Textualize/rich/issues/2172 by implementing @willmcgugan's [suggestion](https://github.com/Textualize/rich/issues/2172#issuecomment-1154942255)
