### PR TITLE
Fix Panel logic for selecting priority of title/subtitle styling 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.2] - 2023-01-11
+
+### Fixed
+
+- Added logic for `Panel.__rich_console__` to check for existing title/subtitle styles before falling back on `border_style`. Fixes https://github.com/Textualize/rich/issues/2745
+
 ## [13.0.1] - 2023-01-06
 
 ### Fixed
@@ -1860,6 +1866,7 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 
 - First official release, API still to be stabilized
 
+[13.0.2]: https://github.com/textualize/rich/compare/v13.0.1...v13.0.2
 [13.0.1]: https://github.com/textualize/rich/compare/v13.0.0...v13.0.1
 [13.0.0]: https://github.com/textualize/rich/compare/v12.6.0...v13.0.0
 [12.6.0]: https://github.com/textualize/rich/compare/v12.5.2...v12.6.0

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ The following people have contributed to the development of Rich:
 <!-- Add your name below, sort alphabetically by surname. Link to GitHub profile / your home page. -->
 
 - [Patrick Arminio](https://github.com/patrick91)
+- [Jeff Barfield](https://github.com/noprobelm)
 - [Gregory Beauregard](https://github.com/GBeauregard/pyffstream)
 - [Dennis Brakhane](https://github.com/brakhane)
 - [Darren Burns](https://github.com/darrenburns)

--- a/rich/panel.py
+++ b/rich/panel.py
@@ -195,7 +195,7 @@ class Panel(JupyterMixin):
             return text
 
         title_text = self._title
-        if title_text is not None:
+        if title_text is not None and not title_text.style:
             title_text.stylize_before(border_style)
 
         child_width = (
@@ -244,7 +244,7 @@ class Panel(JupyterMixin):
             yield new_line
 
         subtitle_text = self._subtitle
-        if subtitle_text is not None:
+        if subtitle_text is not None and not subtitle_text.style:
             subtitle_text.stylize_before(border_style)
 
         if subtitle_text is None or width <= 4:


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This is a proposed fix for the issue described in #2745.

- The existing behavior of the `Panel.__rich_console__` method is to check if `title_text` and `subtitle_text` are present, and if so, apply the Panel's border style indicated by `border_style`.
- My proposed change is to extend the existing conditional statements to refrain from setting the styles for `title_text` and `subtitle_text` if they were already defined in the `Panel` instance when the console protocol was initiated.