### PR TITLE
Fix splitting color definitions when parsing style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Tokenize style definitions using a regex that ignores whitespaces in color definitions.
+
 ## [13.0.1] - 2023-01-06
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -60,3 +60,4 @@ The following people have contributed to the development of Rich:
 - [Serkan UYSAL](https://github.com/uysalserkan)
 - [Zhe Huang](https://github.com/onlyacat)
 - [Ke Sun](https://github.com/ksun212)
+- [Isaac Breen](https://github.com/IsaacBreen)

--- a/rich/style.py
+++ b/rich/style.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from functools import lru_cache
 from marshal import dumps, loads
@@ -5,12 +6,15 @@ from random import randint
 from typing import Any, Dict, Iterable, List, Optional, Type, Union, cast
 
 from . import errors
-from .color import Color, ColorParseError, ColorSystem, blend_rgb
+from .color import Color, ColorParseError, ColorSystem, RE_COLOR, blend_rgb
 from .repr import Result, rich_repr
 from .terminal_theme import DEFAULT_TERMINAL_THEME, TerminalTheme
 
 # Style instances and style definitions are often interchangeable
 StyleType = Union[str, "Style"]
+
+# Patterns for parsing style definitions
+RE_STYLE_DEFINITION = re.compile(f"({RE_COLOR.pattern})|\S+", re.VERBOSE)
 
 
 class _Bit:
@@ -516,7 +520,9 @@ class Style:
         attributes: Dict[str, Optional[Any]] = {}
         link: Optional[str] = None
 
-        words = iter(style_definition.split())
+        words = (
+            match.group() for match in RE_STYLE_DEFINITION.finditer(style_definition)
+        )
         for original_word in words:
             word = original_word.lower()
             if word == "on":


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Problem

The `rich` library's `Style` class had an issue where it would fail to parse style definitions that contained a color definition with spaces, such as `"rgb(0, 0, 0)"`. This would cause exceptions to be raised and caught silently, leading to unexpected behavior in places like `Text.stylize` and `Syntax`.


Style definitions that contain a color definition with a space fail to parse. For example:

```python
>>> from rich.style import Style
>>> Style.parse("rgb(0,0,0)")  # OK
Style(bgcolor=Color('rgb(0,0,0)', ColorType.TRUECOLOR, triplet=ColorTriplet(red=0, green=0, blue=0)))
>>> Style.parse("rgb(0,0,0)")
...
StyleSyntaxError: unable to parse 'rgb(0,' as background color; 'rgb(0,' is not a valid color
```

Furthermore, this exception gets caught silently when `get_style` is called with a `default` argument, as it is in `Text.render`, causing weird behaviour like this:

<img width="766" alt="Screenshot 2023-01-14 at 4 00 50 pm" src="https://user-images.githubusercontent.com/57783927/212463002-0f012d92-27c9-4be8-a4bf-c0ef1cdb8274.png">

The issue is that style definitions are tokenized with `style_definition.split()`. For example, `"on rgb(0, 0, 0)"` gets becomes `["on", "rgb(0,", "0,", "0)"]` rather than `["on", "rgb(0, 0, 0)"]` as it should be.

Color definitions, on the other hand, are parsed with `rich.color.RE_COLOR`, which ignores whitespaces.

This PR basically replaces `style_definition.split()` with `RE_STYLE_DEFINITION.finditer(style_definition)`, where `RE_STYLE_DEFINITION` embeds the color regex:

```python
RE_STYLE_DEFINITION = re.compile(f"({RE_COLOR.pattern})|\S+", re.VERBOSE)
```

<img width="769" alt="Screenshot 2023-01-14 at 4 14 03 pm" src="https://user-images.githubusercontent.com/57783927/212463006-31e51c39-8cde-4fea-874f-9baa0639faee.png">