### PR TITLE
Fix tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-minversion = 3.9.0
+minversion = 4.0.0
 envlist =
     lint
     docs
-    py{37,38,39,310}
+    py{37,38,39,310,311}
 isolated_build = True
 
 [testenv]
@@ -27,10 +27,20 @@ commands =
 
 [testenv:lint]
 description = Runs all linting tasks
+commands_pre =
+    poetry install -vv --with lint
 commands =
-    black .
-    mypy -p rich --config-file= --ignore-missing-imports --no-implicit-optional --warn-unreachable
+    ; poetry install --only dev
+    # as long GHA pipelines are not configured to use tox, we should call
+    # `make` in order to make testing similar and prevent divergence.
+    make format-check
+    make typecheck
+deps =
+    poetry
 skip_install = true
+allowlist_externals =
+    make
+    poetry
 
 [testenv:docs]
 description = Builds documentation


### PR DESCRIPTION
Because tox is not used in GHA workflows, its configuration diverged
and got broken. This fixes it and makes it less likely to break by
reusing current makefile commands and avoid duplication.

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
