### PR TITLE
fix: bump dependency on pygments to ^2.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ include = ["rich/py.typed"]
 [tool.poetry.dependencies]
 python = ">=3.7.0"
 typing-extensions = { version = ">=4.0.0, <5.0", python = "<3.9" }
-pygments = "^2.6.0"
+pygments = "^2.14.0"
 ipywidgets = { version = "^7.5.1", optional = true }
 markdown-it-py = "^2.1.0"
 


### PR DESCRIPTION
this is required after https://github.com/Textualize/rich/commit/8e87818d1948a6267fc6b40a6f9c220b2773883d which makes 2.14.0 the minimum pygments version

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
