### PR TITLE
add missing import to doc example

### DIFF
--- a/docs/source/layout.rst
+++ b/docs/source/layout.rst
@@ -74,6 +74,8 @@ Setting renderables
 
 The first position argument to ``Layout`` can be any Rich renderable, which will be sized to fit within the layout's area. Here's how we might divide the "right" layout in to two panels::
 
+    from rich.panel import Panel
+    
     layout["right"].split(
         Layout(Panel("Hello")),
         Layout(Panel("World!"))


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Noticed a missing import while reading through the docs, drive-by PR.
