### PR TITLE
improving tests in test_cells and test_pick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Updated test_cells to cover boundary cases of cell_len
+
 ## [13.3.1] - 2023-01-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Changed
-
-- Updated test_cells to cover boundary cases of cell_len
-- Updated test_pick to cover untested inputs of pick_bool
-
 ## [13.3.1] - 2023-01-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated test_cells to cover boundary cases of cell_len
+- Updated test_pick to cover untested inputs of pick_bool
 
 ## [13.3.1] - 2023-01-28
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,6 +17,7 @@ The following people have contributed to the development of Rich:
 - [Michał Górny](https://github.com/mgorny)
 - [Nok Lam Chan](https://github.com/noklam)
 - [Leron Gray](https://github.com/daddycocoaman)
+- [Andre Hora](https://github.com/andrehora)
 - [Kenneth Hoste](https://github.com/boegel)
 - [Lanqing Huang](https://github.com/lqhuang)
 - [Finn Hughes](https://github.com/finnhughes)

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -4,6 +4,15 @@ from rich import cells
 def test_cell_len_long_string():
     # Long strings don't use cached cell length implementation
     assert cells.cell_len("abc" * 200) == 3 * 200
+    # Boundary case
+    assert cells.cell_len("a" * 512) == 512
+
+
+def test_cell_len_short_string():
+    # Short strings use cached cell length implementation
+    assert cells.cell_len("abc" * 100) == 3 * 100
+    # Boundary case
+    assert cells.cell_len("a" * 511) == 511
 
 
 def test_set_cell_size():

--- a/tests/test_pick.py
+++ b/tests/test_pick.py
@@ -2,6 +2,9 @@ from rich._pick import pick_bool
 
 
 def test_pick_bool():
+    assert pick_bool(False) == False
+    assert pick_bool(True) == True
+    assert pick_bool(None) == False
     assert pick_bool(False, True) == False
     assert pick_bool(None, True) == True
     assert pick_bool(True, None) == True


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

It seems that `test_cells` misses some inputs like boundary cases. Those are important to avoid regressions. I updated `test_cell_len_long_string` and created `test_cell_len_short_string` to overcome this possible issue.

Also improved `test_pick`to cover untested inputs of `pick_bool`.