### PR TITLE
improving test_box_substitute to cover more inputs of substitute()

### DIFF
--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -1,7 +1,19 @@
 import pytest
 
 from rich.console import ConsoleOptions, ConsoleDimensions
-from rich.box import ASCII, DOUBLE, ROUNDED, HEAVY, SQUARE
+from rich.box import (
+    ASCII,
+    DOUBLE,
+    ROUNDED,
+    HEAVY,
+    SQUARE,
+    MINIMAL_HEAVY_HEAD,
+    MINIMAL,
+    SIMPLE_HEAVY,
+    SIMPLE,
+    HEAVY_EDGE,
+    HEAVY_HEAD,
+)
 
 
 def test_str():
@@ -46,10 +58,29 @@ def test_box_substitute():
         encoding="utf-8",
         max_height=25,
     )
+
+    # A different Box due to legacy_windows
+    assert ROUNDED.substitute(options) == SQUARE
+    assert MINIMAL_HEAVY_HEAD.substitute(options) == MINIMAL
+    assert SIMPLE_HEAVY.substitute(options) == SIMPLE
     assert HEAVY.substitute(options) == SQUARE
+    assert HEAVY_EDGE.substitute(options) == SQUARE
+    assert HEAVY_HEAD.substitute(options) == SQUARE
 
+    # The same box
     options.legacy_windows = False
+    assert ROUNDED.substitute(options) == ROUNDED
+    assert MINIMAL_HEAVY_HEAD.substitute(options) == MINIMAL_HEAVY_HEAD
+    assert SIMPLE_HEAVY.substitute(options) == SIMPLE_HEAVY
     assert HEAVY.substitute(options) == HEAVY
+    assert HEAVY_EDGE.substitute(options) == HEAVY_EDGE
+    assert HEAVY_HEAD.substitute(options) == HEAVY_HEAD
 
+    # A different Box due to ascii encoding
     options.encoding = "ascii"
+    assert ROUNDED.substitute(options) == ASCII
+    assert MINIMAL_HEAVY_HEAD.substitute(options) == ASCII
+    assert SIMPLE_HEAVY.substitute(options) == ASCII
     assert HEAVY.substitute(options) == ASCII
+    assert HEAVY_EDGE.substitute(options) == ASCII
+    assert HEAVY_HEAD.substitute(options) == ASCII

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -48,7 +48,26 @@ def test_get_bottom():
     assert bottom == "┗━┻━━┻━━━┛"
 
 
-def test_box_substitute():
+def test_box_substitute_for_same_box():
+    options = ConsoleOptions(
+        ConsoleDimensions(80, 25),
+        legacy_windows=False,
+        min_width=1,
+        max_width=100,
+        is_terminal=True,
+        encoding="utf-8",
+        max_height=25,
+    )
+
+    assert ROUNDED.substitute(options) == ROUNDED
+    assert MINIMAL_HEAVY_HEAD.substitute(options) == MINIMAL_HEAVY_HEAD
+    assert SIMPLE_HEAVY.substitute(options) == SIMPLE_HEAVY
+    assert HEAVY.substitute(options) == HEAVY
+    assert HEAVY_EDGE.substitute(options) == HEAVY_EDGE
+    assert HEAVY_HEAD.substitute(options) == HEAVY_HEAD
+
+
+def test_box_substitute_for_different_box_legacy_windows():
     options = ConsoleOptions(
         ConsoleDimensions(80, 25),
         legacy_windows=True,
@@ -59,7 +78,6 @@ def test_box_substitute():
         max_height=25,
     )
 
-    # A different Box due to legacy_windows
     assert ROUNDED.substitute(options) == SQUARE
     assert MINIMAL_HEAVY_HEAD.substitute(options) == MINIMAL
     assert SIMPLE_HEAVY.substitute(options) == SIMPLE
@@ -67,17 +85,18 @@ def test_box_substitute():
     assert HEAVY_EDGE.substitute(options) == SQUARE
     assert HEAVY_HEAD.substitute(options) == SQUARE
 
-    # The same box
-    options.legacy_windows = False
-    assert ROUNDED.substitute(options) == ROUNDED
-    assert MINIMAL_HEAVY_HEAD.substitute(options) == MINIMAL_HEAVY_HEAD
-    assert SIMPLE_HEAVY.substitute(options) == SIMPLE_HEAVY
-    assert HEAVY.substitute(options) == HEAVY
-    assert HEAVY_EDGE.substitute(options) == HEAVY_EDGE
-    assert HEAVY_HEAD.substitute(options) == HEAVY_HEAD
 
-    # A different Box due to ascii encoding
-    options.encoding = "ascii"
+def test_box_substitute_for_different_box_ascii_encoding():
+    options = ConsoleOptions(
+        ConsoleDimensions(80, 25),
+        legacy_windows=True,
+        min_width=1,
+        max_width=100,
+        is_terminal=True,
+        encoding="ascii",
+        max_height=25,
+    )
+
     assert ROUNDED.substitute(options) == ASCII
     assert MINIMAL_HEAVY_HEAD.substitute(options) == ASCII
     assert SIMPLE_HEAVY.substitute(options) == ASCII


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Improving `test_box_substitute` to cover more inputs of `substitute()`, like legacy_windows and ascii encoding. I believe this is important to avoid regressions.

Also refactored `test_box_substitute` to reduce its size: smaller and focused tests are better than large ones. We have now three tests: 
- test_box_substitute_for_same_box
- test_box_substitute_for_different_box_legacy_windows
- test_box_substitute_for_different_box_ascii_encoding