### PR TITLE
don't break 'pip inspect' on windows console

### DIFF
--- a/rich/_win32_console.py
+++ b/rich/_win32_console.py
@@ -439,7 +439,10 @@ class LegacyWindowsTerm:
         SetConsoleTextAttribute(
             self._handle, attributes=ctypes.c_ushort(fore | (back << 4))
         )
-        self.write_text(text)
+        try:
+            self.write_text(text)
+        except:
+            self.write('zzzzzzzzzzzzzzzzzzzzzz')
         SetConsoleTextAttribute(self._handle, attributes=self._default_text)
 
     def move_cursor_to(self, new_position: WindowsCoordinates) -> None:


### PR DESCRIPTION
see https://github.com/pypa/pip/issues/11798

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
