### PR TITLE
Fix duplicate progress output in Jupyter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed duplicate output in Jupyter https://github.com/Textualize/rich/pulls/2804
+
 ## [13.3.1] - 2023-01-28
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,6 +42,7 @@ The following people have contributed to the development of Rich:
 - [Kyle Pollina](https://github.com/kylepollina)
 - [Sebastián Ramírez](https://github.com/tiangolo)
 - [Felipe Guedes](https://github.com/guedesfelipe)
+- [Min RK](https://github.com/minrk)
 - [Clément Robert](https://github.com/neutrinoceros)
 - [Brian Rutledge](https://github.com/bhrutledge)
 - [Tushar Sadhwani](https://github.com/tusharsadhwani)

--- a/rich/console.py
+++ b/rich/console.py
@@ -711,11 +711,6 @@ class Console:
         self._force_terminal = None
         if force_terminal is not None:
             self._force_terminal = force_terminal
-        else:
-            # If FORCE_COLOR env var has any value at all, we force terminal.
-            force_color = self._environ.get("FORCE_COLOR")
-            if force_color is not None:
-                self._force_terminal = True
 
         self._file = file
         self.quiet = quiet
@@ -948,6 +943,15 @@ class Console:
         ):
             # Return False for Idle which claims to be a tty but can't handle ansi codes
             return False
+
+        if self.is_jupyter:
+            # return False for Jupyter, which may have FORCE_COLOR set
+            return False
+
+        # If FORCE_COLOR env var has any value at all, we assume a terminal.
+        force_color = self._environ.get("FORCE_COLOR")
+        if force_color is not None:
+            self._force_terminal = True
 
         isatty: Optional[Callable[[], bool]] = getattr(self.file, "isatty", None)
         try:

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -967,3 +967,11 @@ def test_force_color(env_value):
     # means is_terminal returns True.
     console = Console(file=io.StringIO(), _environ={"FORCE_COLOR": env_value})
     assert console.is_terminal
+
+
+def test_force_color_jupyter():
+    # FORCE_COLOR above doesn't happen in a Jupyter kernel
+    console = Console(
+        file=io.StringIO(), _environ={"FORCE_COLOR": "1"}, force_jupyter=True
+    )
+    assert not console.is_terminal


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

#2449 caused FORCE_COLOR to forcefully imply a terminal. This environment variable tends to be set in a Jupyter context. When `Console.is_terminal` is True, duplicate output is produced by progress bars (#2740). I haven't tracked down exactly what output when `is_terminal=True` causes the duplicated output (likely something involving carriage returns or control characters, which Jupyter doesn't _always_ get right), but the fact remains that if you're in a Jupyter kernel, you aren't in a terminal.

This PR shifts the handling of FORCE_COLOR away from `_force_terminal` and into `is_terminal`, where other interactive environment detection happens (idle).

Sample output from b89d0362e8ebcb18902f0f0a206879f1829b5c0b:

<img width="727" alt="Screenshot 2023-02-13 at 00 00 52" src="https://user-images.githubusercontent.com/151929/218342603-1de83268-fad0-4bfe-bccd-fdac3cab87e2.png">

closes #2740