### PR TITLE
match expected IPython formatter spec in rich.pretty

### DIFF
--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -122,14 +122,14 @@ def _ipy_display_hook(
     max_string: Optional[int] = None,
     max_depth: Optional[int] = None,
     expand_all: bool = False,
-) -> None:
+) -> str | None:
     # needed here to prevent circular import:
     from ._inspect import is_object_one_of_types
     from .console import ConsoleRenderable
 
     # always skip rich generated jupyter renderables or None values
     if _safe_isinstance(value, JupyterRenderable) or value is None:
-        return
+        return None
 
     console = console or get_console()
     if console.is_jupyter:
@@ -138,7 +138,7 @@ def _ipy_display_hook(
         # What does this do?
         # --> if the class has "matplotlib.artist.Artist" in its hierarchy for example, we don't render it.
         if is_object_one_of_types(value, JUPYTER_CLASSES_TO_NOT_RENDER):
-            return
+            return None
 
     with console.capture() as capture:
         # certain renderables should start on a new line

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -55,13 +55,6 @@ if TYPE_CHECKING:
     )
 
 
-JUPYTER_CLASSES_TO_NOT_RENDER = {
-    # Matplotlib "Artists" manage their own rendering in a Jupyter notebook, and we should not try to render them too.
-    # "Typically, all [Matplotlib] visible elements in a figure are subclasses of Artist."
-    "matplotlib.artist.Artist",
-}
-
-
 def _is_attr_object(obj: Any) -> bool:
     """Check if an object was created with attrs module."""
     return _has_attrs and _attr_module.has(type(obj))
@@ -124,7 +117,6 @@ def _ipy_display_hook(
     expand_all: bool = False,
 ) -> Union[str, None]:
     # needed here to prevent circular import:
-    from ._inspect import is_object_one_of_types
     from .console import ConsoleRenderable
 
     # always skip rich generated jupyter renderables or None values
@@ -132,13 +124,6 @@ def _ipy_display_hook(
         return None
 
     console = console or get_console()
-    if console.is_jupyter:
-        # When in a Jupyter notebook let's avoid the display of some specific classes,
-        # as they result in the rendering of useless and noisy lines such as `<Figure size 432x288 with 1 Axes>`.
-        # What does this do?
-        # --> if the class has "matplotlib.artist.Artist" in its hierarchy for example, we don't render it.
-        if is_object_one_of_types(value, JUPYTER_CLASSES_TO_NOT_RENDER):
-            return None
 
     with console.capture() as capture:
         # certain renderables should start on a new line

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -122,7 +122,7 @@ def _ipy_display_hook(
     max_string: Optional[int] = None,
     max_depth: Optional[int] = None,
     expand_all: bool = False,
-) -> str | None:
+) -> Union[str, None]:
     # needed here to prevent circular import:
     from ._inspect import is_object_one_of_types
     from .console import ConsoleRenderable

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -78,16 +78,17 @@ def test_ipy_display_hook__multiple_special_reprs():
     console = Console(file=io.StringIO(), force_jupyter=True)
 
     class Thing:
+        def __repr__(self):
+            return "A Thing"
+
         def _repr_latex_(self):
             return None
 
         def _repr_html_(self):
             return "hello"
 
-    console.begin_capture()
-    _ipy_display_hook(Thing(), console=console)
-
-    assert console.end_capture() == ""
+    result = _ipy_display_hook(Thing(), console=console)
+    assert result == "A Thing"
 
 
 def test_ipy_display_hook__no_special_repr_methods():
@@ -97,11 +98,9 @@ def test_ipy_display_hook__no_special_repr_methods():
         def __repr__(self) -> str:
             return "hello"
 
-    console.begin_capture()
-    _ipy_display_hook(Thing(), console=console)
-
-    # No IPython special repr methods, so printed by Rich
-    assert console.end_capture() == "hello\n"
+    result = _ipy_display_hook(Thing(), console=console)
+    # should be repr as-is
+    assert result == "hello"
 
 
 def test_ipy_display_hook__special_repr_raises_exception():
@@ -121,17 +120,18 @@ def test_ipy_display_hook__special_repr_raises_exception():
         def _repr_html_(self):
             return "hello"
 
-    console.begin_capture()
-    _ipy_display_hook(Thing(), console=console)
+        def __repr__(self):
+            return "therepr"
 
-    assert console.end_capture() == ""
+    result = _ipy_display_hook(Thing(), console=console)
+    assert result == "therepr"
 
 
 def test_ipy_display_hook__console_renderables_on_newline():
     console = Console(file=io.StringIO(), force_jupyter=True)
     console.begin_capture()
-    _ipy_display_hook(Text("hello"), console=console)
-    assert console.end_capture() == "\nhello\n"
+    result = _ipy_display_hook(Text("hello"), console=console)
+    assert result == "\nhello"
 
 
 def test_ipy_display_hook__classes_to_not_render():
@@ -146,8 +146,8 @@ def test_ipy_display_hook__classes_to_not_render():
     with patch(
         "rich.pretty.JUPYTER_CLASSES_TO_NOT_RENDER", {class_fully_qualified_name}
     ):
-        _ipy_display_hook(Thing(), console=console)
-    assert console.end_capture() == ""
+        result = _ipy_display_hook(Thing(), console=console)
+    assert result is None
 
 
 def test_pretty():

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -5,7 +5,6 @@ from array import array
 from collections import UserDict, defaultdict
 from dataclasses import dataclass, field
 from typing import Any, List, NamedTuple
-from unittest.mock import patch
 
 import attr
 import pytest
@@ -132,22 +131,6 @@ def test_ipy_display_hook__console_renderables_on_newline():
     console.begin_capture()
     result = _ipy_display_hook(Text("hello"), console=console)
     assert result == "\nhello"
-
-
-def test_ipy_display_hook__classes_to_not_render():
-    console = Console(file=io.StringIO(), force_jupyter=True)
-    console.begin_capture()
-
-    class Thing:
-        def __repr__(self) -> str:
-            return "hello"
-
-    class_fully_qualified_name = f"{__name__}.{Thing.__qualname__}"
-    with patch(
-        "rich.pretty.JUPYTER_CLASSES_TO_NOT_RENDER", {class_fully_qualified_name}
-    ):
-        result = _ipy_display_hook(Thing(), console=console)
-    assert result is None
 
 
 def test_pretty():


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

More context [in #2803](https://github.com/Textualize/rich/issues/2803#issuecomment-1427886362), but the IPython formatter spec expects slightly different behavior than the hook currently in `rich.pretty`. In particular:

1. formatters should _return_ their output, not publish it on a side channel, and
2. registered formatters should not gate their behavior on what other formatters may be registered

From looking through the code, I think these two are related, because when multiple formats are produced in a mimebundle, a Jupyter frontend displays only one. But because the IPython hook _printed_ output instead of returning it, it was always _in addition to_ other reprs - making it necessary to check if it was probably going to be the only one. Following the spec and returning output removes the need to check if it's likely to be the only output.

This PR changes the registered formatter to match IPython's expectations - _return_ the text representation instead of publishing it separately, and remove checks for possible other formatters. This will fix all cases where duplicate output was produced because the checks were incomplete (not accounting for `Formatter.for_type`, for instance). The only downside is one of size/performance if rich text output is expensive and/or large, but might not be seen because. This is standard for IPython and Jupyter output, however, and Rich shouldn't be blamed for it.

closes #2803

