### PR TITLE
fix: Typo in the Indonesian readme doc

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -27,7 +27,7 @@
 
 Rich adalah library Python yang membantu _memperindah_ tampilan output suatu program di terminal.
 
-[Rich API](https://rich.readthedocs.io/en/latest/) dapat digunakan untuk mempermudah dalam penambahan gaya dan pewarnaan output di terminal. Rich juga mendukung fitur lain seperti pembuatan tabel, bar progress, penulisan markdown, penghighlightan syntax source code, tracebacks, dan masih banyak lagi.
+[Rich API](https://rich.readthedocs.io/en/latest/) dapat digunakan untuk mempermudah dalam penambahan gaya dan pewarnaan output di terminal. Rich juga mendukung fitur lain seperti pembuatan tabel, bar progress, penulisan markdown, penghilightan syntax source code, tracebacks, dan masih banyak lagi.
 
 ![Features](https://github.com/textualize/rich/raw/master/imgs/features.png)
 

--- a/README.id.md
+++ b/README.id.md
@@ -27,7 +27,7 @@
 
 Rich adalah library Python yang membantu _memperindah_ tampilan output suatu program di terminal.
 
-[Rich API](https://rich.readthedocs.io/en/latest/) dapat digunakan untuk mempermudah dalam penambahan gaya dan pewarnaan output di terminal. Rich juga mendukung fitur lain seperti pembuatan tabel, bar progress, penulisan markdown, penghighitan syntax source code, tracebacks, dan masih banyak lagi.
+[Rich API](https://rich.readthedocs.io/en/latest/) dapat digunakan untuk mempermudah dalam penambahan gaya dan pewarnaan output di terminal. Rich juga mendukung fitur lain seperti pembuatan tabel, bar progress, penulisan markdown, penghighlightan syntax source code, tracebacks, dan masih banyak lagi.
 
 ![Features](https://github.com/textualize/rich/raw/master/imgs/features.png)
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

There's typo in the spelling of "penghilightan".
