### PR TITLE
Improve Traceback Frame Suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.3.2] - Unreleased
+
+### Added
+
+- Added `traceback_max_frames` parameter to `logging.RichHandler`
+
+### Changed
+
+- Can now suppress frames using regexes passed via `suppress` parameter to `traceback.Traceback`
+
 ## [13.3.1] - 2023-01-28
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,3 +61,4 @@ The following people have contributed to the development of Rich:
 - [Zhe Huang](https://github.com/onlyacat)
 - [Ke Sun](https://github.com/ksun212)
 - [Qiming Xu](https://github.com/xqm32)
+- [Debanjum Singh Solanky](https://github.com/debanjum)

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -41,6 +41,7 @@ class RichHandler(Handler):
         tracebacks_word_wrap (bool, optional): Enable word wrapping of long tracebacks lines. Defaults to True.
         tracebacks_show_locals (bool, optional): Enable display of locals in tracebacks. Defaults to False.
         tracebacks_suppress (Sequence[Union[str, ModuleType]]): Optional sequence of modules or paths to exclude from traceback.
+        traceback_max_frames (int): Maximum number of frames to show in a traceback, 0 for no maximum. Defaults to 100.
         locals_max_length (int, optional): Maximum length of containers before abbreviating, or None for no abbreviation.
             Defaults to 10.
         locals_max_string (int, optional): Maximum length of string before truncating, or None to disable. Defaults to 80.
@@ -79,6 +80,7 @@ class RichHandler(Handler):
         tracebacks_word_wrap: bool = True,
         tracebacks_show_locals: bool = False,
         tracebacks_suppress: Iterable[Union[str, ModuleType]] = (),
+        traceback_max_frames: int = 100,
         locals_max_length: int = 10,
         locals_max_string: int = 80,
         log_time_format: Union[str, FormatTimeCallable] = "[%x %X]",
@@ -104,6 +106,7 @@ class RichHandler(Handler):
         self.tracebacks_word_wrap = tracebacks_word_wrap
         self.tracebacks_show_locals = tracebacks_show_locals
         self.tracebacks_suppress = tracebacks_suppress
+        self.traceback_max_frames = traceback_max_frames
         self.locals_max_length = locals_max_length
         self.locals_max_string = locals_max_string
         self.keywords = keywords
@@ -147,6 +150,7 @@ class RichHandler(Handler):
                 locals_max_length=self.locals_max_length,
                 locals_max_string=self.locals_max_string,
                 suppress=self.tracebacks_suppress,
+                max_frames=self.traceback_max_frames,
             )
             message = record.getMessage()
             if self.formatter:

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -4,6 +4,7 @@ import linecache
 import os
 import platform
 import sys
+import re
 from dataclasses import dataclass, field
 from traceback import walk_tb
 from types import ModuleType, TracebackType
@@ -651,7 +652,7 @@ class Traceback:
 
             first = frame_index == 0
             frame_filename = frame.filename
-            suppressed = any(frame_filename.startswith(path) for path in self.suppress)
+            suppressed = any(re.match(path, frame_filename) for path in self.suppress)
 
             if os.path.exists(frame.filename):
                 text = Text.assemble(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -91,6 +91,36 @@ def test_exception_with_extra_lines():
     assert "division by zero" in render
 
 
+def test_exception_with_max_frames():
+    # Arrange
+    console = Console(file=io.StringIO(), width=100)
+    handler_with_tracebacks = RichHandler(
+        console=console,
+        rich_tracebacks=True,
+        traceback_max_frames=6,
+    )
+    log.addHandler(handler_with_tracebacks)
+
+    def foo(n):
+        return bar(n)
+
+    def bar(n):
+        return foo(n)
+
+    # Act
+    try:
+        foo(1)
+    except RecursionError:
+        log.exception("message")
+
+    render = handler_with_tracebacks.console.file.getvalue()
+    print(render)
+
+    # Assert
+    assert "frames hidden" in render
+    assert render.count("in foo") < 4
+
+
 def test_stderr_and_stdout_are_none(monkeypatch):
     # This test is specifically to handle cases when using pythonw on
     # windows and stderr and stdout are set to None.

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -91,6 +91,7 @@ def test_exception_with_extra_lines():
     assert "division by zero" in render
 
 
+@skip_win
 def test_exception_with_regex_suppress():
     # Arrange
     console = Console(file=io.StringIO(), width=100)
@@ -122,6 +123,7 @@ def test_exception_with_regex_suppress():
     assert render.count("def bar") == 0
 
 
+@skip_win
 def test_exception_with_max_frames():
     # Arrange
     console = Console(file=io.StringIO(), width=100)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -91,6 +91,37 @@ def test_exception_with_extra_lines():
     assert "division by zero" in render
 
 
+def test_exception_with_regex_suppress():
+    # Arrange
+    console = Console(file=io.StringIO(), width=100)
+    handler_with_tracebacks = RichHandler(
+        console=console,
+        rich_tracebacks=True,
+        tracebacks_suppress=["/.*test_logging.py"],
+    )
+    log.addHandler(handler_with_tracebacks)
+
+    def foo(n):
+        return bar(n)
+
+    def bar(n):
+        return foo(n)
+
+    # Act
+    try:
+        foo(1)
+    except RecursionError:
+        log.exception("message")
+
+    render = handler_with_tracebacks.console.file.getvalue()
+    print(render)
+
+    # Assert
+    assert "frames hidden" in render
+    assert render.count("def foo") == 0
+    assert render.count("def bar") == 0
+
+
 def test_exception_with_max_frames():
     # Arrange
     console = Console(file=io.StringIO(), width=100)


### PR DESCRIPTION
## Type of changes

- [X] New feature

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

### Code Change 
- 266337ad Allow setting max frames in traceback logging
- 5051b47f Allow using regex paths to suppress frame filenames in traceback
  - Generalize suppressing frame filenames by supporting regex matching
    Example: `traceback_suppress=[r"/.*fastapi*"]` will match all frame
    filenames matching a fastapi library in stacktrace
  
  - Maintain backward compatibility to check if frame filename starts
    with path, if plain string passed
    Example: `traceback_suppress=["fastapi"]` will continue to match frame
    filenames starting with fastapi in stacktrace
  
    *Note: Not sure how practically useful this previous behavior is*

### Examples
- To suppress fastapi, uvicorn related frames in traceback
  ``` python
  RichHandler(rich_tracebacks=True, tracebacks_suppress=['/.*fastapi.*', '/.*uvicorn.*'])
  ```
- To only show a maximum of 7 frames in traceback
   ``` python
  RichHandler(rich_tracebacks=True, traceback_max_frames=7)
  ```