### PR TITLE
use stderr=true instead of file=sys.stderr for traceback handler install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed pretty printing of empty dataclass https://github.com/Textualize/rich/issues/2819
+- Use `Console(stderr=True)` in `rich.traceback.install` to support io redirection.
 
 ## [13.3.1] - 2023-01-28
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,7 @@ The following people have contributed to the development of Rich:
 - [Dave Pearson](https://github.com/davep/)
 - [Avi Perl](https://github.com/avi-perl)
 - [Laurent Peuch](https://github.com/psycojoker)
+- [Ronny Pfannschmidt](https://github.com/RonnyPfannschmidt/)
 - [Olivier Philippon](https://github.com/DrBenton)
 - [Kylian Point](https://github.com/p0lux)
 - [Kyle Pollina](https://github.com/kylepollina)

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -86,7 +86,7 @@ def install(
         Callable: The previous exception handler that was replaced.
 
     """
-    traceback_console = Console(file=sys.stderr) if console is None else console
+    traceback_console = Console(stderr=True) if console is None else console
 
     locals_hide_sunder = (
         True


### PR DESCRIPTION
## Type of changes

- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

i took note that the traceback install code pre-dates the support for `stderr=True` and used `file=sys.stderr`
i believe its more correct to use `stderr=True` (coming from a pytest point of view where accidental install in code under test would lead to the handler eventually having a stale file)
