### PR TITLE
Update "logging.level.warning" to yellow"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Fixed
+
+- `RichHandler` errors and warnings will now use different colors (red and yellow) https://github.com/Textualize/rich/issues/2825
+
 ## [13.3.2] - 2023-02-04
 
 ### Fixed

--- a/rich/default_styles.py
+++ b/rich/default_styles.py
@@ -54,7 +54,7 @@ DEFAULT_STYLES: Dict[str, Style] = {
     "logging.level.notset": Style(dim=True),
     "logging.level.debug": Style(color="green"),
     "logging.level.info": Style(color="blue"),
-    "logging.level.warning": Style(color="red"),
+    "logging.level.warning": Style(color="yellow"),
     "logging.level.error": Style(color="red", bold=True),
     "logging.level.critical": Style(color="red", bold=True, reverse=True),
     "log.level": Style.null(),


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes #2825 by changing the default color of `'logging.WARNING'` to yellow.
