### PR TITLE
fix: fix `pretty_repr` for `deque`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Fixed
+
+- Fix pretty repr for `collections.deque` https://github.com/Textualize/rich/pull/2864
+
 ## [13.3.2] - 2023-02-04
 
 ### Fixed
@@ -41,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed failing tests due to Pygments dependency https://github.com/Textualize/rich/issues/2757
 - Relaxed ipywidgets https://github.com/Textualize/rich/issues/2767
 
-### Added 
+### Added
 
 - Added `encoding` parameter in `Theme.read`
 

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -15,6 +15,7 @@ from typing import (
     Any,
     Callable,
     DefaultDict,
+    Deque,
     Dict,
     Iterable,
     List,
@@ -352,6 +353,12 @@ def _get_braces_for_defaultdict(_object: DefaultDict[Any, Any]) -> Tuple[str, st
     )
 
 
+def _get_braces_for_deque(_object: Deque[Any]) -> Tuple[str, str, str]:
+    if _object.maxlen is None:
+        return ("deque([", "])", "deque()")
+    return ("deque([", f"], maxlen={_object.maxlen})", f"deque(maxlen={_object.maxlen})")
+
+
 def _get_braces_for_array(_object: "array[Any]") -> Tuple[str, str, str]:
     return (f"array({_object.typecode!r}, [", "])", f"array({_object.typecode!r})")
 
@@ -361,7 +368,7 @@ _BRACES: Dict[type, Callable[[Any], Tuple[str, str, str]]] = {
     array: _get_braces_for_array,
     defaultdict: _get_braces_for_defaultdict,
     Counter: lambda _object: ("Counter({", "})", "Counter()"),
-    deque: lambda _object: ("deque([", "])", "deque()"),
+    deque: _get_braces_for_deque,
     dict: lambda _object: ("{", "}", "{}"),
     UserDict: lambda _object: ("{", "}", "{}"),
     frozenset: lambda _object: ("frozenset({", "})", "frozenset()"),

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -2,7 +2,7 @@ import collections
 import io
 import sys
 from array import array
-from collections import UserDict, defaultdict
+from collections import UserDict, defaultdict, deque
 from dataclasses import dataclass, field
 from typing import Any, List, NamedTuple
 
@@ -486,6 +486,33 @@ def test_defaultdict():
     test_dict = defaultdict(int, {"foo": 2})
     result = pretty_repr(test_dict)
     assert result == "defaultdict(<class 'int'>, {'foo': 2})"
+
+
+def test_deque():
+    test_deque = deque([1, 2, 3])
+    result = pretty_repr(test_deque)
+    assert result == "deque([1, 2, 3])"
+    test_deque = deque([1, 2, 3], maxlen=None)
+    result = pretty_repr(test_deque)
+    assert result == "deque([1, 2, 3])"
+    test_deque = deque([1, 2, 3], maxlen=5)
+    result = pretty_repr(test_deque)
+    assert result == "deque([1, 2, 3], maxlen=5)"
+    test_deque = deque([1, 2, 3], maxlen=0)
+    result = pretty_repr(test_deque)
+    assert result == "deque([], maxlen=0)"
+    test_deque = deque([])
+    result = pretty_repr(test_deque)
+    assert result == "deque([])"
+    test_deque = deque([], maxlen=None)
+    result = pretty_repr(test_deque)
+    assert result == "deque([])"
+    test_deque = deque([], maxlen=5)
+    result = pretty_repr(test_deque)
+    assert result == "deque([], maxlen=5)"
+    test_deque = deque([], maxlen=0)
+    result = pretty_repr(test_deque)
+    assert result == "deque([], maxlen=0)"
 
 
 def test_array():


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

Fixes #2863

Add new function `_get_braces_for_deque` to respect `maxlen` for `collections.deque`.
Add tests for `pretty_repr` with non-empty and empty `deque`.