### PR TITLE
add code_width in traceback

### DIFF
--- a/rich/logging.py
+++ b/rich/logging.py
@@ -36,6 +36,7 @@ class RichHandler(Handler):
         markup (bool, optional): Enable console markup in log messages. Defaults to False.
         rich_tracebacks (bool, optional): Enable rich tracebacks with syntax highlighting and formatting. Defaults to False.
         tracebacks_width (Optional[int], optional): Number of characters used to render tracebacks, or None for full width. Defaults to None.
+        tracebacks_code_width (int, optional): Number of code characters used to render tracebacks, or None for full width. Defaults to 88.
         tracebacks_extra_lines (int, optional): Additional lines of code to render tracebacks, or None for full width. Defaults to None.
         tracebacks_theme (str, optional): Override pygments theme used in traceback.
         tracebacks_word_wrap (bool, optional): Enable word wrapping of long tracebacks lines. Defaults to True.
@@ -74,6 +75,7 @@ class RichHandler(Handler):
         markup: bool = False,
         rich_tracebacks: bool = False,
         tracebacks_width: Optional[int] = None,
+        tracebacks_code_width: int = 88,
         tracebacks_extra_lines: int = 3,
         tracebacks_theme: Optional[str] = None,
         tracebacks_word_wrap: bool = True,
@@ -104,6 +106,7 @@ class RichHandler(Handler):
         self.tracebacks_word_wrap = tracebacks_word_wrap
         self.tracebacks_show_locals = tracebacks_show_locals
         self.tracebacks_suppress = tracebacks_suppress
+        self.tracebacks_code_width = tracebacks_code_width
         self.locals_max_length = locals_max_length
         self.locals_max_string = locals_max_string
         self.keywords = keywords
@@ -140,6 +143,7 @@ class RichHandler(Handler):
                 exc_value,
                 exc_traceback,
                 width=self.tracebacks_width,
+                code_width=self.tracebacks_code_width,
                 extra_lines=self.tracebacks_extra_lines,
                 theme=self.tracebacks_theme,
                 word_wrap=self.tracebacks_word_wrap,

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -49,6 +49,7 @@ def install(
     *,
     console: Optional[Console] = None,
     width: Optional[int] = 100,
+    code_width: Optional[int] = 88,
     extra_lines: int = 3,
     theme: Optional[str] = None,
     word_wrap: bool = False,
@@ -69,6 +70,7 @@ def install(
     Args:
         console (Optional[Console], optional): Console to write exception to. Default uses internal Console instance.
         width (Optional[int], optional): Width (in characters) of traceback. Defaults to 100.
+        code_width (Optional[int], optional): Code width (in characters) of traceback. Defaults to 88.
         extra_lines (int, optional): Extra lines of code. Defaults to 3.
         theme (Optional[str], optional): Pygments theme to use in traceback. Defaults to ``None`` which will pick
             a theme appropriate for the platform.
@@ -105,6 +107,7 @@ def install(
                 value,
                 traceback,
                 width=width,
+                code_width=code_width,
                 extra_lines=extra_lines,
                 theme=theme,
                 word_wrap=word_wrap,
@@ -215,6 +218,7 @@ class Traceback:
         trace (Trace, optional): A `Trace` object produced from `extract`. Defaults to None, which uses
             the last exception.
         width (Optional[int], optional): Number of characters used to traceback. Defaults to 100.
+        code_width (Optional[int], optional): Number of code characters used to traceback. Defaults to 88.
         extra_lines (int, optional): Additional lines of code to render. Defaults to 3.
         theme (str, optional): Override pygments theme used in traceback.
         word_wrap (bool, optional): Enable word wrapping of long lines. Defaults to False.
@@ -243,6 +247,7 @@ class Traceback:
         trace: Optional[Trace] = None,
         *,
         width: Optional[int] = 100,
+        code_width: Optional[int] = 88,
         extra_lines: int = 3,
         theme: Optional[str] = None,
         word_wrap: bool = False,
@@ -266,6 +271,7 @@ class Traceback:
             )
         self.trace = trace
         self.width = width
+        self.code_width = code_width
         self.extra_lines = extra_lines
         self.theme = Syntax.get_theme(theme or "ansi_dark")
         self.word_wrap = word_wrap
@@ -297,6 +303,7 @@ class Traceback:
         traceback: Optional[TracebackType],
         *,
         width: Optional[int] = 100,
+        code_width: Optional[int] = 88,
         extra_lines: int = 3,
         theme: Optional[str] = None,
         word_wrap: bool = False,
@@ -316,6 +323,7 @@ class Traceback:
             exc_value (BaseException): Exception value.
             traceback (TracebackType): Python Traceback object.
             width (Optional[int], optional): Number of characters used to traceback. Defaults to 100.
+            code_width (Optional[int], optional): Number of code characters used to traceback. Defaults to 88.
             extra_lines (int, optional): Additional lines of code to render. Defaults to 3.
             theme (str, optional): Override pygments theme used in traceback.
             word_wrap (bool, optional): Enable word wrapping of long lines. Defaults to False.
@@ -346,6 +354,7 @@ class Traceback:
         return cls(
             rich_traceback,
             width=width,
+            code_width=code_width,
             extra_lines=extra_lines,
             theme=theme,
             word_wrap=word_wrap,
@@ -696,7 +705,7 @@ class Traceback:
                         ),
                         highlight_lines={frame.lineno},
                         word_wrap=self.word_wrap,
-                        code_width=88,
+                        code_width=self.code_width,
                         indent_guides=self.indent_guides,
                         dedent=False,
                     )


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

https://github.com/Textualize/rich/issues/2795

add code_width option for traceback
``` python
from rich.traceback import install

install(
    width=120,
    code_width=120, # new option
    word_wrap=True,
)
```
or
```python
import logging
from rich.logging import RichHandler

logging.basicConfig(
    handlers=[
        RichHandler(
            rich_tracebacks=True,
            tracebacks_code_width=120, # new option
        )
    ],
)
```

before
![image](https://user-images.githubusercontent.com/55623558/223952069-3217a908-d69d-4725-bb82-61e7979cd4e4.png)

after
![image](https://user-images.githubusercontent.com/55623558/223952117-e39dcd39-f575-435f-a1d8-e39114d69da7.png)


