### PR TITLE
use object.__new__(Style) consistently

### DIFF
--- a/rich/style.py
+++ b/rich/style.py
@@ -210,7 +210,7 @@ class Style:
             color (Optional[Color]): A (foreground) color, or None for no color. Defaults to None.
             bgcolor (Optional[Color]): A (background) color, or None for no color. Defaults to None.
         """
-        style: Style = cls.__new__(Style)
+        style: Style = object.__new__(Style)
         style._ansi = None
         style._style_definition = None
         style._color = color
@@ -231,7 +231,7 @@ class Style:
         Returns:
             meta (Optional[Dict[str, Any]]): A dictionary of meta data. Defaults to None.
         """
-        style: Style = cls.__new__(Style)
+        style: Style = object.__new__(Style)
         style._ansi = None
         style._style_definition = None
         style._color = None
@@ -479,7 +479,7 @@ class Style:
         """Get a copy of the style with color removed."""
         if self._null:
             return NULL_STYLE
-        style: Style = self.__new__(Style)
+        style: Style = object.__new__(Style)
         style._ansi = None
         style._style_definition = None
         style._color = None
@@ -631,7 +631,7 @@ class Style:
         """
         if self._null:
             return NULL_STYLE
-        style: Style = self.__new__(Style)
+        style: Style = object.__new__(Style)
         style._ansi = self._ansi
         style._style_definition = self._style_definition
         style._color = self._color
@@ -654,7 +654,7 @@ class Style:
         Returns:
             Style: A new Style instance.
         """
-        style: Style = self.__new__(Style)
+        style: Style = object.__new__(Style)
         style._ansi = self._ansi
         style._style_definition = self._style_definition
         style._color = self._color
@@ -712,7 +712,7 @@ class Style:
             return self
         if self._null:
             return style
-        new_style: Style = self.__new__(Style)
+        new_style: Style = object.__new__(Style)
         new_style._ansi = None
         new_style._style_definition = None
         new_style._color = style._color or self._color


### PR DESCRIPTION
use `object.__new__(Style)` instead of `(self|cls).__new__(Style)`

* `__new__` appears to be a class method (https://docs.python.org/3/reference/datamodel.html#object.__new__)
* usage is now consistent, whereas before both `self.__new__` and `cls.__new__` were used
* I believe this usage of `__new__` is more "official" Python

Discovered while trying to use `rich` with GraalPython (https://github.com/oracle/graalpython).  Works great with this fix. :)

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
