### PR TITLE
adding syntax column_offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [13.4.0] - Unreleased
+
+### Added
+
+- `Syntax` now takes a `column_offset` argument that will make it render only the columns starting at the offset to the `code_width` if provided
+
 ## [13.3.2] - 2023-02-04
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -68,4 +68,4 @@ The following people have contributed to the development of Rich:
 - [Ke Sun](https://github.com/ksun212)
 - [Qiming Xu](https://github.com/xqm32)
 - [James Addison](https://github.com/jayaddison)
-
+- [Anthony Post](https://github.com/Ayehavgunne)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -40,6 +40,22 @@ def loop_first_last(values: Iterable[T]) -> Iterable[Tuple[bool, bool, T]]:
     yield first, True, previous_value'''
 
 
+LONG_CODE = '''\
+def loop_first_last(values: Iterable[T]) -> Iterable[Tuple[bool, bool, T]]:
+    """Iterate and generate a tuple with a flag for first and last value. Some really long description of this code telling you all about what it does"""
+    iter_values = iter(values)
+    try:
+        previous_value = next(iter_values)
+    except StopIteration:
+        return
+    first = True
+    for value in iter_values:
+        yield first, False, previous_value
+        first = False
+        previous_value = value
+    yield first, True, previous_value'''
+
+
 def test_blank_lines():
     code = "\n\nimport this\n\n"
     syntax = Syntax(
@@ -134,6 +150,107 @@ def test_python_render_line_range_indent_guides():
     rendered_syntax = render(syntax)
     print(repr(rendered_syntax))
     expected = '\x1b[2;37m│   \x1b[0m\x1b[33m"""Iterate and generate a tuple with a flag for first an\x1b[0m\n\x1b[2m│   \x1b[0miter_values = \x1b[36miter\x1b[0m(values)\n'
+    assert rendered_syntax == expected
+
+
+def test_python_render_column_range():
+    syntax = Syntax(
+        LONG_CODE,
+        lexer="python",
+        line_numbers=False,
+        theme="ansi_light",
+        code_width=60,
+        word_wrap=False,
+        column_offset=93,
+        indent_guides=True,
+    )
+    rendered_syntax = render(syntax)
+    print(repr(rendered_syntax))
+    expected = '\n\x1b[33mscription of this code telling you all about what it does"""\x1b[0m\n\n\n\n\n\n\n\n\n\n\n\n'
+    assert rendered_syntax == expected
+
+
+def test_python_render_column_range_at_start():
+    syntax = Syntax(
+        LONG_CODE,
+        lexer="python",
+        line_numbers=False,
+        theme="ansi_light",
+        code_width=60,
+        word_wrap=False,
+        column_offset=0,
+        indent_guides=True,
+    )
+    rendered_syntax = render(syntax)
+    print(repr(rendered_syntax))
+    expected = '\x1b[34mdef\x1b[0m \x1b[32mloop_first_last\x1b[0m(values: Iterable[T]) -> Iterable[Tuple[\x1b[36mb\x1b[0m\n\x1b[2;37m│   \x1b[0m\x1b[33m"""Iterate and generate a tuple with a flag for first an\x1b[0m\n\x1b[2m│   \x1b[0miter_values = \x1b[36miter\x1b[0m(values)\n\x1b[2m│   \x1b[0m\x1b[34mtry\x1b[0m:\n\x1b[2m│   │   \x1b[0mprevious_value = \x1b[36mnext\x1b[0m(iter_values)\n\x1b[2m│   \x1b[0m\x1b[34mexcept\x1b[0m \x1b[36mStopIteration\x1b[0m:\n\x1b[2m│   │   \x1b[0m\x1b[34mreturn\x1b[0m\n\x1b[2m│   \x1b[0mfirst = \x1b[34mTrue\x1b[0m\n\x1b[2m│   \x1b[0m\x1b[34mfor\x1b[0m value \x1b[35min\x1b[0m iter_values:\n\x1b[2m│   │   \x1b[0m\x1b[34myield\x1b[0m first, \x1b[34mFalse\x1b[0m, previous_value\n\x1b[2m│   │   \x1b[0mfirst = \x1b[34mFalse\x1b[0m\n\x1b[2m│   │   \x1b[0mprevious_value = value\n\x1b[2m│   \x1b[0m\x1b[34myield\x1b[0m first, \x1b[34mTrue\x1b[0m, previous_value\n'
+    assert rendered_syntax == expected
+
+
+def test_python_render_column_range_at_two():
+    syntax = Syntax(
+        LONG_CODE,
+        lexer="python",
+        line_numbers=False,
+        theme="ansi_light",
+        code_width=60,
+        word_wrap=False,
+        column_offset=2,
+        indent_guides=True,
+    )
+    rendered_syntax = render(syntax)
+    print(repr(rendered_syntax))
+    expected = '\x1b[34mf\x1b[0m \x1b[32mloop_first_last\x1b[0m(values: Iterable[T]) -> Iterable[Tuple[\x1b[36mboo\x1b[0m\n\x1b[2;37m  \x1b[0m\x1b[33m"""Iterate and generate a tuple with a flag for first and \x1b[0m\n\x1b[2m  \x1b[0miter_values = \x1b[36miter\x1b[0m(values)\n\x1b[2m  \x1b[0m\x1b[34mtry\x1b[0m:\n\x1b[2m│     \x1b[0mprevious_value = \x1b[36mnext\x1b[0m(iter_values)\n\x1b[2m  \x1b[0m\x1b[34mexcept\x1b[0m \x1b[36mStopIteration\x1b[0m:\n\x1b[2m│     \x1b[0m\x1b[34mreturn\x1b[0m\n\x1b[2m  \x1b[0mfirst = \x1b[34mTrue\x1b[0m\n\x1b[2m  \x1b[0m\x1b[34mfor\x1b[0m value \x1b[35min\x1b[0m iter_values:\n\x1b[2m│     \x1b[0m\x1b[34myield\x1b[0m first, \x1b[34mFalse\x1b[0m, previous_value\n\x1b[2m│     \x1b[0mfirst = \x1b[34mFalse\x1b[0m\n\x1b[2m│     \x1b[0mprevious_value = value\n\x1b[2m  \x1b[0m\x1b[34myield\x1b[0m first, \x1b[34mTrue\x1b[0m, previous_value\n'
+    assert rendered_syntax == expected
+
+
+def test_python_render_column_offset_not_at_end():
+    syntax = Syntax(
+        LONG_CODE,
+        lexer="python",
+        line_numbers=False,
+        theme="ansi_light",
+        code_width=60,
+        word_wrap=False,
+        column_offset=92,
+        indent_guides=True,
+    )
+    rendered_syntax = render(syntax)
+    print(repr(rendered_syntax))
+    expected = '\n\x1b[33mescription of this code telling you all about what it does""\x1b[0m\n\n\n\n\n\n\n\n\n\n\n\n'
+    assert rendered_syntax == expected
+
+
+def test_python_render_column_offset_past_code_width():
+    syntax = Syntax(
+        LONG_CODE,
+        lexer="python",
+        line_numbers=False,
+        theme="ansi_light",
+        code_width=60,
+        word_wrap=False,
+        column_offset=94,
+        indent_guides=True,
+    )
+    rendered_syntax = render(syntax)
+    print(repr(rendered_syntax))
+    expected = '\n\x1b[33mcription of this code telling you all about what it does"""\x1b[0m\n\n\n\n\n\n\n\n\n\n\n\n'
+    assert rendered_syntax == expected
+
+
+def test_python_render_column_offset_no_code_width():
+    syntax = Syntax(
+        LONG_CODE,
+        lexer="python",
+        line_numbers=False,
+        theme="ansi_light",
+        word_wrap=False,
+        column_offset=90,
+        indent_guides=True,
+    )
+    rendered_syntax = render(syntax)
+    print(repr(rendered_syntax))
+    expected = '\x1b[2m \x1b[0m\n\x1b[2;33m \x1b[0m\x1b[33mdescription of this code telling you all about what it does"""\x1b[0m\n\n\n\n\n\n\n\n\n\n\n\n'
     assert rendered_syntax == expected
 
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [x] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Added a new column_offset argument to the Syntax class that will have it only render the columns starting at the offset.
