### PR TITLE
expand requirements

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,7 @@ The following people have contributed to the development of Rich:
 - [Michael Milton](https://github.com/multimeric)
 - [Martina Oefelein](https://github.com/oefe)
 - [Nathan Page](https://github.com/nathanrpage97)
+- [Jeremiah Paige](https://github.com/ucodery)
 - [Dave Pearson](https://github.com/davep/)
 - [Avi Perl](https://github.com/avi-perl)
 - [Laurent Peuch](https://github.com/psycojoker)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ alabaster==0.7.12
 Sphinx==5.1.1
 sphinx-rtd-theme==1.0.0
 sphinx-copybutton==0.5.1
+setuptools==67.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ ipywidgets = { version = ">=7.5.1,<9", optional = true }
 markdown-it-py = "^2.2.0"
 
 [tool.poetry.extras]
-jupyter = ["ipywidgets"]
+jupyter = ["ipywidgets", "ipython"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.0"
@@ -44,6 +44,7 @@ attrs = "^21.4.0"
 pre-commit = "^2.17.0"
 asv = "^0.5.1"
 setuptools = "^67.5"
+wcwidth = "^0.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ pre-commit = "^2.17.0"
 asv = "^0.5.1"
 setuptools = "^67.5"
 wcwidth = "^0.2"
+emoji = "^2.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ pytest-cov = "^3.0.0"
 attrs = "^21.4.0"
 pre-commit = "^2.17.0"
 asv = "^0.5.1"
+setuptools = "^67.5"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tools/make_emoji.py
+++ b/tools/make_emoji.py
@@ -1,8 +1,4 @@
-try:
-    import emoji
-except ImportError:
-    print("pip install emoji")
-    raise
+import emoji
 
 from emoji.unicode_codes import EMOJI_ALIAS_UNICODE
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This is a small issue, but some packages that rich imports it does not also directly depend on.
The first one is the highest risk; since rich doesn't even require setuptools to build, if it isn't preinstalled pkg_resources will never be there.
The last commit was mostly about convenience as there was obviously an acknowledgement that emoji might not be present, but it seemed odd to promote mixing poetry and pip in a dev environment.
The versions are all arbitrary, as the features used from each package are all quite old.