### PR TITLE
fix: bug: python REPL evaluated result ignores custom highlighter

### DIFF
--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -134,7 +134,11 @@ def _ipy_display_hook(
             if _safe_isinstance(value, RichRenderable)
             else Pretty(
                 value,
+                highlighter=console.highlighter,
+                indent_size=console.tab_size,
+                justify=console.options.justify,
                 overflow=overflow,
+                no_wrap=console.options.no_wrap,
                 indent_guides=indent_guides,
                 max_length=max_length,
                 max_string=max_string,
@@ -200,7 +204,11 @@ def install(
                 if _safe_isinstance(value, RichRenderable)
                 else Pretty(
                     value,
+                    highlighter=console.highlighter,
+                    indent_size=console.tab_size,
+                    justify=console.options.justify,
                     overflow=overflow,
+                    no_wrap=console.options.no_wrap,
                     indent_guides=indent_guides,
                     max_length=max_length,
                     max_string=max_string,


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The output format of REPL evaluated result does not follow the customed options of console because the `display_hook` prints the `value` without setting the options to the`console`'s. Specify the params of `Pretty` to fix #2714 