### PR TITLE
New feature - Text.format()

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -44,6 +44,7 @@ The following people have contributed to the development of Rich:
 - [Olivier Philippon](https://github.com/DrBenton)
 - [Kylian Point](https://github.com/p0lux)
 - [Kyle Pollina](https://github.com/kylepollina)
+- [Razvan Popescu](https://github.com/pom11)
 - [Sebastián Ramírez](https://github.com/tiangolo)
 - [Felipe Guedes](https://github.com/guedesfelipe)
 - [Min RK](https://github.com/minrk)

--- a/rich/text.py
+++ b/rich/text.py
@@ -433,6 +433,26 @@ class Text(JupyterMixin):
         )
         copy_self._spans[:] = self._spans
         return copy_self
+        
+    def format(self, *args, **kwargs) -> "Text":
+        """Return a new Text instance with formatted specified value(s) and insert them inside the string's placeholder."""
+        formatted = ""
+        if len(args)!=0:
+            formatted = self.plain.format(*args, **kwargs)
+        elif len(kwargs)!=0:
+            formatted = self.plain.format(**kwargs)
+        if formatted != self.plain and formatted!="":
+            sanitized_text = strip_control_codes(formatted)
+            return Text(
+                sanitized_text,
+                style=self.style,
+                justify=self.justify,
+                overflow=self.overflow,
+                no_wrap=self.no_wrap,
+                end=self.end,
+                tab_size=self.tab_size
+                )
+        return self.copy()
 
     def stylize(
         self,


### PR DESCRIPTION
Replicated `.format()` method of  python `string` to `Text` instance. Returns a formatted copy of `Text` instance.

tested with:
```python
from rich.text import Text
from rich.console import Console
c = Console()

t = Text("my name is {name}",style="red on white")
c.print(t)
tt = t.format(name="pom11")
c.print(t)
c.print(tt)
c.print(Text("\n"))

t = Text("my name is {}",style="red on white")
c.print(t)
tt = t.format("pom11")
c.print(t)
c.print(tt)
c.print(Text("\n"))

t = Text("my name is {0}",style="red on white")
c.print(t)
tt = t.format("pom11")
c.print(t)
c.print(tt)
c.print(Text("\n"))

t = Text("my name is {0}",style="red on white")
c.print(t)
tt = t.format()
c.print(t)
c.print(tt)
```