### PR TITLE
Text.format() feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+
+- Added Text.format()
 
 ## [13.3.2] - 2023-02-04
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -44,6 +44,7 @@ The following people have contributed to the development of Rich:
 - [Olivier Philippon](https://github.com/DrBenton)
 - [Kylian Point](https://github.com/p0lux)
 - [Kyle Pollina](https://github.com/kylepollina)
+- [Razvan Popescu](https://github.com/pom11)
 - [Sebastián Ramírez](https://github.com/tiangolo)
 - [Felipe Guedes](https://github.com/guedesfelipe)
 - [Min RK](https://github.com/minrk)

--- a/rich/text.py
+++ b/rich/text.py
@@ -433,6 +433,26 @@ class Text(JupyterMixin):
         )
         copy_self._spans[:] = self._spans
         return copy_self
+        
+    def format(self, *args, **kwargs) -> "Text":
+        """Return a new Text instance with formatted specified value(s) and insert them inside the string's placeholder."""
+        formatted = ""
+        if len(args)!=0:
+            formatted = self.plain.format(*args, **kwargs)
+        elif len(kwargs)!=0:
+            formatted = self.plain.format(**kwargs)
+        if formatted != self.plain and formatted!="":
+            sanitized_text = strip_control_codes(formatted)
+            return Text(
+                sanitized_text,
+                style=self.style,
+                justify=self.justify,
+                overflow=self.overflow,
+                no_wrap=self.no_wrap,
+                end=self.end,
+                tab_size=self.tab_size
+                )
+        return self.copy()
 
     def stylize(
         self,

--- a/rich/text.py
+++ b/rich/text.py
@@ -438,88 +438,121 @@ class Text(JupyterMixin):
     def format(self, *args, **kwargs) -> "Text":
         """Return a new Text instance with formatted specified value(s) and insert them inside the string's placeholder"""
 
-        initial_parsing = [x for x in Formatter().parse(self.plain)]
-        if len(initial_parsing) == 1 and initial_parsing[0][1] == None:
-            return self.copy()
-        formatted = ""
-        parsed_len = 0
-        _args = list(args)
-        _kwargs = kwargs
-        _spans = [[s.start, s.end, s.style] for s in self._spans]
-        if len(_args) != 0 or len(kwargs) != 0:
-            _field_numbers = [
-                "{"
-                + x[1]
-                + f'{":"+x[2] if x[2]!="" and x[2]!=None else ""}'
-                + f'{"!"+x[3] if x[3]!="" and x[3]!=None else ""}'
-                + "}"
-                for x in initial_parsing
-                if x[1] != None and x[1].isdigit() and x[1] != ""
-            ]
-            _field_brackets = [
-                "{"
-                + x[1]
-                + f'{":"+x[2] if x[2]!="" and x[2]!=None else ""}'
-                + f'{"!"+x[3] if x[3]!="" and x[3]!=None else ""}'
-                + "}"
-                for x in initial_parsing
-                if x[1] != None and not x[1].isdigit() and x[1] == ""
-            ]
-            if len(_field_numbers) != 0 and len(_field_brackets) != 0:
-                raise TypeError(
-                    "Cannot switch from manual field specification to automatic field numbering"
-                )
-
-            for (
-                _literal_text,
-                _field_name,
-                _format_spec,
-                _conversion,
-            ) in initial_parsing:
-                extra_len = 0
-                _formatted = _literal_text
-                if _field_name != None:
-                    format_spec = (
-                        "" if _format_spec in [None, ""] else f":{_format_spec}"
-                    )
-                    conversion = "" if _conversion in [None, ""] else f"!{_conversion}"
-                    _to_replace = "{" + _field_name + format_spec + conversion + "}"
-                    _new_string = _to_replace.format(*tuple(_args), **_kwargs)
-                    if _to_replace in _field_brackets:
-                        _args.pop(0)
-                    _str_index = (formatted + _formatted + _to_replace).index(
-                        _to_replace, parsed_len
-                    )
-                    _spans_indices = [
-                        i for i, s in enumerate(_spans) if s[0] <= _str_index <= s[1]
-                    ]
-                    for _span_index in _spans_indices:
-                        _spans[_span_index][0] += extra_len
-                        _spans[_span_index][1] += (
-                            extra_len + len(_new_string) - len(_to_replace)
-                        )
-                        extra_len = len(_new_string) - len(_to_replace)
-                        for _s in range(len(_spans[_span_index + 1 :])):
-                            _spans[_span_index + _s + 1][0] += extra_len
-                            _spans[_span_index + _s + 1][1] += extra_len
-                    _formatted += _new_string
-                    parsed_len += len(_to_replace)
-                formatted += _formatted
-                parsed_len += len(_literal_text)
-
-        if formatted != self.plain and formatted != "":
-            _spans = [Span(start=s[0], end=s[1], style=s[2]) for s in _spans]
+        def get_newtext_w_style_from_index(string: str, index: int, texts_list: List[Text]) -> "Text":
+            text = texts_list[index]
             return Text(
-                formatted,
-                style=self.style,
-                justify=self.justify,
-                overflow=self.overflow,
-                no_wrap=self.no_wrap,
-                end=self.end,
-                tab_size=self.tab_size,
-                spans=_spans,
+                string,
+                style=text.style,
+                justify=text.justify,
+                overflow=text.overflow,
+                no_wrap=text.no_wrap,
+                end=text.end,
+                tab_size=text.tab_size,
+                spans=text.spans
             )
-        return self.copy()
+        copy = self.copy()
+        # get fields to substitute
+        initial_parsing = [fields for fields in Formatter().parse(self.plain)]
+        # if there is nothing to substitute return copy
+        if len(initial_parsing) == 1 and initial_parsing[0][1] == None:
+            return copy
+        # this will be returned as a final result
+        formatted = Text()
+        # how much of the initial length was parsed
+        parsed_len = 0
+        #arg as strings even for Text params
+        _args = [text.plain if type(text)==Text else text for text in list(args)]
+        #kwargs as strings even for Text params
+        _kwargs = {key:text.plain if type(text)==Text else text for key,text in kwargs.items()}
+        # substitute only if there are args or kwargs
+        if len(args)!=0 or len(_kwargs)!=0:
+            # get {0} number type placeholders
+            field_numbers = [
+                "{"
+                + field_name
+                + f'{":"+format_spec if format_spec not in [None,""] else ""}'
+                + f'{"!"+conversion if conversion not in [None,""] else ""}' 
+                + "}"
+                for literal_text, field_name, format_spec, conversion in initial_parsing
+                if field_name and field_name.isdigit()
+            ]
+            # get {} brackets type placeholders
+            field_brackets = [
+                "{"
+                + field_name
+                + f'{":"+format_spec if format_spec not in [None,""] else ""}'
+                + f'{"!"+conversion if conversion not in [None,""] else ""}' 
+                + "}"
+                for literal_text, field_name, format_spec, conversion in initial_parsing
+                if field_name != None and not field_name.isdigit() and field_name == ""
+            ]
+            # raise standard type error, {0} and {} can't coexist
+            if len(field_numbers)!=0 and len(field_brackets)!=0:
+                raise TypeError("Cannot switch from manual field specification to automatic field numbering")
+            # parse fields to substitute
+            for literal_text, field_name, format_spec, conversion in initial_parsing:
+                # partial Text of literal_text - get substring from parsed_len till end of literal_text
+                split_at = parsed_len
+                # as Formatter replaces double brackets with single brackets we need to add "count" to split_at
+                split_at += formatted.divide([parsed_len])[0].plain.count('{')
+                split_at += formatted.divide([parsed_len])[0].plain.count('}')
+                formatted_partially = copy.divide([split_at])[1].divide([len(literal_text)])[0]
+                # if there is something to substitute
+                if field_name!=None:
+                    format_spec = '' if format_spec in [None,''] else f":{format_spec}"
+                    conversion = '' if conversion in [None, ''] else f"!{conversion}"
+                    # field to substitute
+                    to_replace = '{'+field_name+format_spec+conversion+'}'
+                    # result after substitution
+                    new_string = to_replace.format(*tuple(_args),**_kwargs)
+                    # get Spans for replaced string
+                    start_index = self.plain.index(to_replace, parsed_len)
+                    end_index = start_index+len(to_replace)
+                    spans = [Span(start=0,end=len(new_string),style=span.style) for span in self._spans if start_index<=span.start<=end_index or start_index<=span.end<=end_index]
+                    # init new text with style
+                    new_text = Text(new_string,
+                                    style=self.style,
+                                    justify=self.justify,
+                                    overflow=self.overflow,
+                                    no_wrap=self.no_wrap,
+                                    end=self.end,
+                                    tab_size=self.tab_size,
+                                    spans=spans
+                                )
+                    # check either kwargs or args is used
+                    # if in kwargs
+                    if field_name in kwargs.keys():
+                        # check if param is Text
+                        if type(kwargs[field_name])==Text:
+                            # replace new_text with provided Text
+                            new_text = get_newtext_w_style_from_index(new_string,list(kwargs.keys()).index(field_name),list(kwargs.values()))
+                    # if in args
+                    else:
+                        #if is {0} placeholder
+                        if str(field_name).isdigit():
+                            # check if param is Text
+                            if type(list(args)[int(field_name)])==Text:
+                                # replace new_text with provided Text
+                                new_text = get_newtext_w_style_from_index(new_string,int(field_name),list(args))
+                        # if is {} placeholder
+                        else:
+                            # check if param is Text
+                            if type(list(args)[0])==Text:
+                                # replace new_text with provided Text
+                                new_text = get_newtext_w_style_from_index(new_string,0,list(args))
+                            _args.pop(0)
+                            args = tuple(list(args)[1:])
+                    #add replaced value to formatted_partially
+                    formatted_partially.append_text(new_text)
+                    # keep track how much of plain we parsed
+                    parsed_len += len(to_replace)
+                #add to end result
+                formatted.append_text(formatted_partially)
+                # keep track how much of plain we parsed
+                parsed_len += len(literal_text)
+        if formatted!=Text():
+            return formatted
+        return copy
 
     def stylize(
         self, style: Union[str, Style], start: int = 0, end: Optional[int] = None,

--- a/rich/text.py
+++ b/rich/text.py
@@ -158,7 +158,7 @@ class Text(JupyterMixin):
         return self.plain
 
     def __repr__(self) -> str:
-        return f"<text {self.plain!r} {self._spans!r}>"
+        return f"<text {self.plain!r} {self.spans!r}>"
 
     def __add__(self, other: Any) -> "Text":
         if isinstance(other, (str, Text)):

--- a/rich/text.py
+++ b/rich/text.py
@@ -438,7 +438,9 @@ class Text(JupyterMixin):
     def format(self, *args, **kwargs) -> "Text":
         """Return a new Text instance with formatted specified value(s) and insert them inside the string's placeholder"""
 
-        def get_newtext_w_style_from_index(string: str, index: int, texts_list: List[Text]) -> "Text":
+        def get_newtext_w_style_from_index(
+            string: str, index: int, texts_list: List[Text]
+        ) -> "Text":
             text = texts_list[index]
             return Text(
                 string,
@@ -448,8 +450,9 @@ class Text(JupyterMixin):
                 no_wrap=text.no_wrap,
                 end=text.end,
                 tab_size=text.tab_size,
-                spans=text.spans
+                spans=text.spans,
             )
+
         copy = self.copy()
         # get fields to substitute
         initial_parsing = [fields for fields in Formatter().parse(self.plain)]
@@ -460,18 +463,21 @@ class Text(JupyterMixin):
         formatted = Text()
         # how much of the initial length was parsed
         parsed_len = 0
-        #arg as strings even for Text params
-        _args = [text.plain if type(text)==Text else text for text in list(args)]
-        #kwargs as strings even for Text params
-        _kwargs = {key:text.plain if type(text)==Text else text for key,text in kwargs.items()}
+        # arg as strings even for Text params
+        _args = [text.plain if type(text) == Text else text for text in list(args)]
+        # kwargs as strings even for Text params
+        _kwargs = {
+            key: text.plain if type(text) == Text else text
+            for key, text in kwargs.items()
+        }
         # substitute only if there are args or kwargs
-        if len(args)!=0 or len(_kwargs)!=0:
+        if len(args) != 0 or len(_kwargs) != 0:
             # get {0} number type placeholders
             field_numbers = [
                 "{"
                 + field_name
                 + f'{":"+format_spec if format_spec not in [None,""] else ""}'
-                + f'{"!"+conversion if conversion not in [None,""] else ""}' 
+                + f'{"!"+conversion if conversion not in [None,""] else ""}'
                 + "}"
                 for literal_text, field_name, format_spec, conversion in initial_parsing
                 if field_name and field_name.isdigit()
@@ -481,76 +487,94 @@ class Text(JupyterMixin):
                 "{"
                 + field_name
                 + f'{":"+format_spec if format_spec not in [None,""] else ""}'
-                + f'{"!"+conversion if conversion not in [None,""] else ""}' 
+                + f'{"!"+conversion if conversion not in [None,""] else ""}'
                 + "}"
                 for literal_text, field_name, format_spec, conversion in initial_parsing
                 if field_name != None and not field_name.isdigit() and field_name == ""
             ]
             # raise standard type error, {0} and {} can't coexist
-            if len(field_numbers)!=0 and len(field_brackets)!=0:
-                raise TypeError("Cannot switch from manual field specification to automatic field numbering")
+            if len(field_numbers) != 0 and len(field_brackets) != 0:
+                raise TypeError(
+                    "Cannot switch from manual field specification to automatic field numbering"
+                )
             # parse fields to substitute
             for literal_text, field_name, format_spec, conversion in initial_parsing:
                 # partial Text of literal_text - get substring from parsed_len till end of literal_text
                 split_at = parsed_len
                 # as Formatter replaces double brackets with single brackets we need to add "count" to split_at
-                split_at += formatted.divide([parsed_len])[0].plain.count('{')
-                split_at += formatted.divide([parsed_len])[0].plain.count('}')
-                formatted_partially = copy.divide([split_at])[1].divide([len(literal_text)])[0]
+                split_at += formatted.divide([parsed_len])[0].plain.count("{")
+                split_at += formatted.divide([parsed_len])[0].plain.count("}")
+                formatted_partially = copy.divide([split_at])[1].divide(
+                    [len(literal_text)]
+                )[0]
                 # if there is something to substitute
-                if field_name!=None:
-                    format_spec = '' if format_spec in [None,''] else f":{format_spec}"
-                    conversion = '' if conversion in [None, ''] else f"!{conversion}"
+                if field_name != None:
+                    format_spec = "" if format_spec in [None, ""] else f":{format_spec}"
+                    conversion = "" if conversion in [None, ""] else f"!{conversion}"
                     # field to substitute
-                    to_replace = '{'+field_name+format_spec+conversion+'}'
+                    to_replace = "{" + field_name + format_spec + conversion + "}"
                     # result after substitution
-                    new_string = to_replace.format(*tuple(_args),**_kwargs)
+                    new_string = to_replace.format(*tuple(_args), **_kwargs)
                     # get Spans for replaced string
                     start_index = self.plain.index(to_replace, parsed_len)
-                    end_index = start_index+len(to_replace)
-                    spans = [Span(start=0,end=len(new_string),style=span.style) for span in self._spans if start_index<=span.start<=end_index or start_index<=span.end<=end_index]
+                    end_index = start_index + len(to_replace)
+                    spans = [
+                        Span(start=0, end=len(new_string), style=span.style)
+                        for span in self._spans
+                        if start_index <= span.start <= end_index
+                        or start_index <= span.end <= end_index
+                    ]
                     # init new text with style
-                    new_text = Text(new_string,
-                                    style=self.style,
-                                    justify=self.justify,
-                                    overflow=self.overflow,
-                                    no_wrap=self.no_wrap,
-                                    end=self.end,
-                                    tab_size=self.tab_size,
-                                    spans=spans
-                                )
+                    new_text = Text(
+                        new_string,
+                        style=self.style,
+                        justify=self.justify,
+                        overflow=self.overflow,
+                        no_wrap=self.no_wrap,
+                        end=self.end,
+                        tab_size=self.tab_size,
+                        spans=spans,
+                    )
                     # check either kwargs or args is used
                     # if in kwargs
                     if field_name in kwargs.keys():
                         # check if param is Text
-                        if type(kwargs[field_name])==Text:
+                        if type(kwargs[field_name]) == Text:
                             # replace new_text with provided Text
-                            new_text = get_newtext_w_style_from_index(new_string,list(kwargs.keys()).index(field_name),list(kwargs.values()))
+                            new_text = get_newtext_w_style_from_index(
+                                new_string,
+                                list(kwargs.keys()).index(field_name),
+                                list(kwargs.values()),
+                            )
                     # if in args
                     else:
-                        #if is {0} placeholder
+                        # if is {0} placeholder
                         if str(field_name).isdigit():
                             # check if param is Text
-                            if type(list(args)[int(field_name)])==Text:
+                            if type(list(args)[int(field_name)]) == Text:
                                 # replace new_text with provided Text
-                                new_text = get_newtext_w_style_from_index(new_string,int(field_name),list(args))
+                                new_text = get_newtext_w_style_from_index(
+                                    new_string, int(field_name), list(args)
+                                )
                         # if is {} placeholder
                         else:
                             # check if param is Text
-                            if type(list(args)[0])==Text:
+                            if type(list(args)[0]) == Text:
                                 # replace new_text with provided Text
-                                new_text = get_newtext_w_style_from_index(new_string,0,list(args))
+                                new_text = get_newtext_w_style_from_index(
+                                    new_string, 0, list(args)
+                                )
                             _args.pop(0)
                             args = tuple(list(args)[1:])
-                    #add replaced value to formatted_partially
+                    # add replaced value to formatted_partially
                     formatted_partially.append_text(new_text)
                     # keep track how much of plain we parsed
                     parsed_len += len(to_replace)
-                #add to end result
+                # add to end result
                 formatted.append_text(formatted_partially)
                 # keep track how much of plain we parsed
                 parsed_len += len(literal_text)
-        if formatted!=Text():
+        if formatted != Text():
             return formatted
         return copy
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -124,12 +124,96 @@ def test_copy():
     assert text is not test_copy
 
 def test_format():
-    text = Text.from_markup("Hello, [b]{title}[/] [red]{name}[/]!")
-    text_formatted = text.format(title="Mr.",name="World")
+    text = Text("Hello {name}",style="red on white")
+    text_formatted = text.format(name="pom11")
     assert text is not text_formatted
-    assert str(text_formatted) == "Hello, Mr. World!"
-    assert text_formatted._spans == [Span(7, 10, "bold"), Span(11, 16, "red")]
-    assert text._spans is not text_formatted._spans
+    assert text_formatted.spans == [Span(0, 11, 'red on white'), Span(6, 11, 'red on white')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello pom11"
+    text = Text("Hello {{name}} {{test}} welcome",style="red on white")
+    text_formatted = text.format(name="pom11",test="test2")
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 7, 'red on white'), Span(7, 12, 'red on white'), Span(12, 14, 'red on white'), Span(14, 19, 'red on white'), Span(19, 27, 'red on white')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello {name} {test} welcome"
+    text = Text.from_markup("Hello [b]{name}[/]")
+    text_formatted = text.format(name=Text.from_markup("[red]pom11[/]"))
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 11, ''), Span(6, 11, ''), Span(6, 11, 'red')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello pom11"
+    text = Text.from_markup("Hello [b]{name:.8}[/] [yellow]{greeting}[/] how [blue]{verb}[/] are you?")
+    text_formatted = text.format(name="pom11"*5,greeting="welcome",verb=Text.from_markup('[black on green]busy[/]'))
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 14, ''), Span(6, 14, ''), Span(6, 14, 'bold'), Span(14, 22, ''), Span(15, 22, ''), Span(15, 22, 'yellow'), Span(22, 31, ''), Span(27, 31, ''), Span(27, 31, 'black on green'), Span(31, 40, '')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello pom11pom welcome how busy are you?"
+    text = Text.from_ansi("Hello {name} {greeting}")
+    text_formatted = text.format(name=Text.from_markup(f"[black on white]{'pom11'*2}[/][red on white]{'pom11'*3}[/]"),greeting='welcome')
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 31, ''), Span(6, 31, ''), Span(6, 16, 'black on white'), Span(16, 31, 'red on white'), Span(31, 39, ''), Span(32, 39, ''), Span(32, 39, Style(color=Color('color(0)', ColorType.STANDARD, number=0), bgcolor=Color('color(5)', ColorType.STANDARD, number=5), bold=False, dim=False))]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello pom11pom11pom11pom11pom11 welcome"
+    text = Text("Hello {name} {greeting}  ",spans=[Span(0,15,"black on yellow"),Span(6,12,"black on magenta"),Span(15,16,"black on red")])
+    text_formatted = text.format(name="pom11"*5,greeting='welcome')
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 31, ''), Span(0, 6, 'black on yellow'), Span(6, 31, ''), Span(6, 31, 'black on magenta'), Span(31, 39, ''), Span(31, 32, 'black on yellow'), Span(32, 39, ''), Span(32, 39, 'black on yellow'), Span(32, 39, 'black on red'), Span(39, 41, '')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello pom11pom11pom11pom11pom11 welcome  "
+    text = Text.from_markup("Hello [b]{}[/] [red]{}[/]")
+    text_formatted = text.format("pom11",Text.from_markup("[black on cyan]welcome[/]"))
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 11, ''), Span(6, 11, ''), Span(6, 11, 'bold'), Span(11, 19, ''), Span(12, 19, ''), Span(12, 19, 'black on cyan')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello pom11 welcome"
+    text = Text.from_markup("Hello [b]{:2}[/] [red]{:3}[/] how are you?")
+    text_formatted = text.format("pom11","welcome")
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 11, ''), Span(6, 11, ''), Span(6, 11, 'bold'), Span(11, 19, ''), Span(12, 19, ''), Span(12, 19, 'red'), Span(19, 32, '')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello pom11 welcome how are you?"
+    text = Text.from_markup("Hello [b]{0}[/] [red]{1}[/]")
+    text_formatted = text.format("pom11","welcome")
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 11, ''), Span(6, 11, ''), Span(6, 11, 'bold'), Span(11, 19, ''), Span(12, 19, ''), Span(12, 19, 'red')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello pom11 welcome"
+    text = Text.from_markup("Hello [b]{1}[/] [red]{0}[/]")
+    text_formatted = text.format("pom11",Text("welcome"))
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 13, ''), Span(6, 13, ''), Span(13, 19, ''), Span(14, 19, ''), Span(14, 19, 'red')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello welcome pom11"
+    text = Text.from_markup("Hello [b]{}[/] [red]{}[/]")
+    text_formatted = text.format("pom11","welcome")
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 11, ''), Span(6, 11, ''), Span(6, 11, 'bold'), Span(11, 19, ''), Span(12, 19, ''), Span(12, 19, 'red')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello pom11 welcome"
+    text = Text.from_markup("Hello [b]{:^10.2f}[/] [red]{}[/]")
+    text_formatted = text.format(420.420,"welcome")
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 16, ''), Span(6, 16, ''), Span(6, 16, 'bold'), Span(16, 24, ''), Span(17, 24, ''), Span(17, 24, 'red')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello   420.42   welcome"
+    text = Text.from_markup("Hello [underline black on white]{0:0.0f}[/] [red]{1}[/]")
+    text_formatted = text.format(420.420,"welcome")
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 9, ''), Span(6, 9, ''), Span(6, 9, 'underline black on white'), Span(9, 17, ''), Span(10, 17, ''), Span(10, 17, 'red')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello 420 welcome"
+    text = Text.from_markup("Hello [b]{0:.2%}[/] [red]{1:.0%}[/]")
+    text_formatted = text.format(0.5,0.5)
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 12, ''), Span(6, 12, ''), Span(6, 12, 'bold'), Span(12, 16, ''), Span(13, 16, ''), Span(13, 16, 'red')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello 50.00% 50%"
+    text = Text.from_markup("Hello [b]{0:d}[/] [b]{0:x}[/] [b]{0:o}[/] [b]{0:b}[/]")
+    text_formatted = text.format(42)
+    assert text is not text_formatted
+    assert text_formatted.spans == [Span(0, 8, ''), Span(6, 8, ''), Span(6, 8, 'bold'), Span(8, 11, ''), Span(9, 11, ''), Span(9, 11, 'bold'), Span(11, 14, ''), Span(12, 14, ''), Span(12, 14, 'bold'), Span(14, 21, ''), Span(15, 21, ''), Span(15, 21, 'bold')]
+    assert text.spans is not text_formatted.spans
+    assert str(text_formatted) == "Hello 42 2a 52 101010"
 
 def test_rstrip():
     text = Text("Hello, World!    ")

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -123,6 +123,13 @@ def test_copy():
     assert text == test_copy
     assert text is not test_copy
 
+def test_format():
+    text = Text.from_markup("Hello, [b]{title}[/] [red]{name}[/]!")
+    text_formatted = text.format(title="Mr.",name="World")
+    assert text is not text_formatted
+    assert str(text_formatted) == "Hello, Mr. World!"
+    assert text_formatted._spans == [Span(7, 10, "bold"), Span(11, 16, "red")]
+    assert text._spans is not text_formatted._spans
 
 def test_rstrip():
     text = Text("Hello, World!    ")


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [X] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description
Added `format` method for `Text`. Currently works just for string placeholders like `{name}`. 

Supported placeholders: `{string}`
Unsupported placeholders: `{0}` `{}`

TODO:
Support all types of placeholders