### PR TITLE
Fix auto detection of terminal size on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix auto detection of terminal size on Windows https://github.com/Textualize/rich/pull/2916
+
 ## [13.3.4] - 2023-04-12
 
 ### Fixed
@@ -52,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed failing tests due to Pygments dependency https://github.com/Textualize/rich/issues/2757
 - Relaxed ipywidgets https://github.com/Textualize/rich/issues/2767
 
-### Added 
+### Added
 
 - Added `encoding` parameter in `Theme.read`
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -67,5 +67,6 @@ The following people have contributed to the development of Rich:
 - [Adrian Zuber](https://github.com/xadrianzetx)
 - [Ke Sun](https://github.com/ksun212)
 - [Qiming Xu](https://github.com/xqm32)
+- [L. Yeung](https://github.com/lewis-yeung)
 - [James Addison](https://github.com/jayaddison)
 - [Pierro](https://github.com/xpierroz)

--- a/rich/console.py
+++ b/rich/console.py
@@ -1005,19 +1005,13 @@ class Console:
         width: Optional[int] = None
         height: Optional[int] = None
 
-        if WINDOWS:  # pragma: no cover
+        for file_descriptor in _STD_STREAMS_OUTPUT if WINDOWS else _STD_STREAMS:
             try:
-                width, height = os.get_terminal_size()
+                width, height = os.get_terminal_size(file_descriptor)
             except (AttributeError, ValueError, OSError):  # Probably not a terminal
                 pass
-        else:
-            for file_descriptor in _STD_STREAMS:
-                try:
-                    width, height = os.get_terminal_size(file_descriptor)
-                except (AttributeError, ValueError, OSError):
-                    pass
-                else:
-                    break
+            else:
+                break
 
         columns = self._environ.get("COLUMNS")
         if columns is not None and columns.isdigit():


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Currently, the automatic detection of terminal size on Windows is only performed for `_STDOUT_FILENO` which is the default value passed to `os.get_terminal_size`. So if we redirect the standard output (`stdout`) to a file and create a `Console` on the standard error (`stderr`) with `width` and `height` left `None`, the auto-detected terminal size will always be a fallback value `(80, 25)` (supposing that `legacy_windows` is `False`).

A simple example to illustrate this problem: I ran the following test script with only `stdout` redirected to a file (`stderr` was still connected to a terminal with width = 110 and height = 45):

```python
import sys
from rich.console import Console

console = Console(stderr=True, legacy_windows=False)
print(console.size, file=sys.stderr)
```

and I got following output:

```
ConsoleDimensions(width=80, height=25)
```

which is not what I expected:

```
ConsoleDimensions(width=110, height=45)
```

On Linux, it works as expected.

To resolve the problem on Windows, we should perform the automatic detection for both `_STDOUT_FILENO` and `_STDERR_FILENO`.
