### PR TITLE
update task total will no longer cause an interruption in speed calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+
+### Fixed
+
+- Update task total will no longer cause an interruption in speed calculation.
+
+
 ## [13.3.4] - 2023-04-12
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -69,3 +69,4 @@ The following people have contributed to the development of Rich:
 - [Qiming Xu](https://github.com/xqm32)
 - [James Addison](https://github.com/jayaddison)
 - [Pierro](https://github.com/xpierroz)
+- [HFrost0](https://github.com/HFrost0)

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -1428,7 +1428,8 @@ class Progress(JupyterMixin):
 
             if total is not None and total != task.total:
                 task.total = total
-                task._reset()
+                task.finished_time = None
+                task.finished_speed = None
             if advance is not None:
                 task.completed += advance
             if completed is not None:


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Hey, thanks for the great tool 👍! I love the progress module in rich and use it as a core part in my download project. In some download case, we will update a task's total very frequently, such as add a new file's content length to task total, or update total by current predicted byte ratio. But `progress.update(task_id=..., total=...)` will clear the task speed which I think is no need and might be confusing for user and bad for speed control in download. Let me know if you have any thought about this!
