### PR TITLE
Tweaked SVG generation to be more readable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ typing-extensions = { version = ">=4.0.0, <5.0", python = "<3.9" }
 pygments = "^2.13.0"
 ipywidgets = { version = ">=7.5.1,<9", optional = true }
 markdown-it-py = "^2.2.0"
+soda-svg = "1.1.8"
 
 [tool.poetry.extras]
 jupyter = ["ipywidgets"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ typing-extensions = { version = ">=4.0.0, <5.0", python = "<3.9" }
 pygments = "^2.13.0"
 ipywidgets = { version = ">=7.5.1,<9", optional = true }
 markdown-it-py = "^2.2.0"
-soda-svg = "1.1.8"
+soda-svg = "1.1.9"
 
 [tool.poetry.extras]
 jupyter = ["ipywidgets"]


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature (probably)
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I've stumbled across the SVG export code in Rich and I thought a quick migration to an XML generation library would make the code significantly better in readability. As I'm maintaining [one](https://github.com/evtn/soda), I decided to experiment and here's the result.

This is a quick draft-ish PR, the old tests for SVG export are failing due to whitespace differences.

Also, this PR has two weak points to be discussed:

- This PR introduces a new dependency (even though a relatively small one), for a task that's not the primary one for Rich (I think). It could be made optional, but I'm not sure about how to add optional dependencies properly.
- This PR introduces a breaking change in export_svg/save_svg functions since string templates have to be replaced with tag objects.