### PR TITLE
Fix: Raise MissingStyle error for invalid style when printing to console 

### DIFF
--- a/rich/text.py
+++ b/rich/text.py
@@ -1088,7 +1088,6 @@ class Text(JupyterMixin):
         _Span = Span
 
         for span_start, span_end, style in self._spans:
-
             lower_bound = 0
             upper_bound = line_count
             start_line_no = (lower_bound + upper_bound) // 2

--- a/rich/text.py
+++ b/rich/text.py
@@ -691,7 +691,7 @@ class Text(JupyterMixin):
             if end:
                 yield _Segment(end)
             return
-        get_style = partial(console.get_style, default=Style.null())
+        get_style = console.get_style
 
         enumerated_spans = list(enumerate(self._spans, 1))
         style_map = {index: get_style(span.style) for index, span in enumerated_spans}

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -6,6 +6,7 @@ from rich.console import Console, Group
 from rich.measure import Measurement
 from rich.style import Style
 from rich.text import Span, Text
+from rich.errors import MissingStyle
 
 
 def test_span():
@@ -768,7 +769,8 @@ def test_wrap_invalid_style():
     # https://github.com/textualize/rich/issues/987
     console = Console(width=100, color_system="truecolor")
     a = "[#######.................] xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx [#######.................]"
-    console.print(a, justify="full")
+    with pytest.raises(MissingStyle):
+        console.print(a, justify="full")
 
 
 def test_apply_meta():


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

This fixes #2796 

The `MissingStyle` error will be raised with an appropriate error message whenever an invalid style is detected regardless of the printing method used. In response to changes in behavior for invalid style input, the corresponding test cases are also updated to expect errors to be raised rather than successfully printing strings. 


