### PR TITLE
Fix #2951 - rich.filesize - Typing, Precision on filesizes smaller than Base, and Ignore precision on filesizes ending in `.0`.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ The following people have contributed to the development of Rich:
 - [Artur Borecki](https://github.com/pufereq)
 - [Dennis Brakhane](https://github.com/brakhane)
 - [Darren Burns](https://github.com/darrenburns)
+- [rlaphoenix](https://github.com/rlaphoenix)
 - [Jim Crist-Harif](https://github.com/jcrist)
 - [Ed Davis](https://github.com/davised)
 - [Pete Davison](https://github.com/pd93)

--- a/rich/filesize.py
+++ b/rich/filesize.py
@@ -13,16 +13,16 @@ See Also:
 
 __all__ = ["decimal"]
 
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, Tuple, Union
 
 
 def _to_str(
-    size: int,
+    size: Union[float, int],
     suffixes: Iterable[str],
     base: int,
     *,
-    precision: Optional[int] = 1,
-    separator: Optional[str] = " ",
+    precision: int = 1,
+    separator: str = " "
 ) -> str:
     if size == 1:
         return "1 byte"
@@ -41,7 +41,7 @@ def _to_str(
     )
 
 
-def pick_unit_and_suffix(size: int, suffixes: List[str], base: int) -> Tuple[int, str]:
+def pick_unit_and_suffix(size: int, suffixes: Iterable[str], base: int) -> Tuple[int, str]:
     """Pick a suffix and base for the given size."""
     for i, suffix in enumerate(suffixes):
         unit = base**i
@@ -51,10 +51,10 @@ def pick_unit_and_suffix(size: int, suffixes: List[str], base: int) -> Tuple[int
 
 
 def decimal(
-    size: int,
+    size: Union[float, int],
     *,
-    precision: Optional[int] = 1,
-    separator: Optional[str] = " ",
+    precision: int = 1,
+    separator: str = " "
 ) -> str:
     """Convert a filesize in to a string (powers of 1000, SI prefixes).
 
@@ -66,7 +66,7 @@ def decimal(
     or used by **Mac OS X** since v10.6 to report file sizes.
 
     Arguments:
-        int (size): A file size.
+        float/int (size): A file size.
         int (precision): The number of decimal places to include (default = 1).
         str (separator): The string to separate the value from the units (default = " ").
 

--- a/rich/filesize.py
+++ b/rich/filesize.py
@@ -28,11 +28,16 @@ def _to_str(
         unit = base**i
         if size < unit:
             break
+
+    size = base * size / unit
+    if size == int(size):
+        precision = 0
+
     return "{:,.{precision}f}{separator}{}".format(
-        (base * size / unit),
+        size,
         suffix,
         precision=precision,
-        separator=separator,
+        separator=separator
     )
 
 

--- a/rich/filesize.py
+++ b/rich/filesize.py
@@ -33,6 +33,9 @@ def _to_str(
     if size == int(size):
         precision = 0
 
+    if size == 1 and suffix == "bytes":
+        suffix = "byte"
+
     return "{:,.{precision}f}{separator}{}".format(
         size,
         suffix,

--- a/rich/filesize.py
+++ b/rich/filesize.py
@@ -24,12 +24,7 @@ def _to_str(
     precision: int = 1,
     separator: str = " "
 ) -> str:
-    if size == 1:
-        return "1 byte"
-    elif size < base:
-        return "{:,} bytes".format(size)
-
-    for i, suffix in enumerate(suffixes, 2):  # noqa: B007
+    for i, suffix in enumerate(suffixes, 1):  # noqa: B007
         unit = base**i
         if size < unit:
             break
@@ -76,14 +71,16 @@ def decimal(
     Example:
         >>> filesize.decimal(30000)
         '30.0 kB'
-        >>> filesize.decimal(30000, precision=2, separator="")
-        '30.00kB'
+        >>> filesize.decimal(30000, separator="")
+        '30.0kB'
+        >>> filesize.decimal(361.3816634069428, precision=1)
+        '361.3 bytes'
 
     """
     return _to_str(
         size,
-        ("kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"),
+        ("bytes", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"),
         1000,
         precision=precision,
-        separator=separator,
+        separator=separator
     )

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -5,7 +5,7 @@ def test_traditional():
     assert filesize.decimal(0) == "0 bytes"
     assert filesize.decimal(1) == "1 byte"
     assert filesize.decimal(2) == "2 bytes"
-    assert filesize.decimal(1000) == "1.0 kB"
+    assert filesize.decimal(1000) == "1 kB"
     assert filesize.decimal(1.5 * 1000 * 1000) == "1.5 MB"
     assert filesize.decimal(0, precision=2) == "0 bytes"
     assert filesize.decimal(1111, precision=0) == "1 kB"


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [X] Documentation / docstrings
- [X] Tests
- [X] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
  (No, on purpose. It clearly differed from your intentional code style choices from prior commits).
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
  (No changes made to Changelog, it's unclear if you want it to be modified).
- [X] I've added tests for new code.
  (I've modified existing tests only)
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

### Typing

I've corrected a few typing mistakes. I.e., typing size arguments are `int` when realistically they can accept both float and int. I've also removed the use of Optional as the arguments using Optional, aren't actually optional by nature. I.e., you can't set them to `None` and expect the code to work. It was recommended in a PEP somewhere to stop doing this, but I cannot find it now that I search for it (of course...). I've also changed a `List[]` to be `Iterable[]` to be more consistent with another similar arg.

### Precision on filesizes smaller than Base

In the base set in decimal(), this change will only affect the bytes file size. The example in the doc-string has been edited to showcase this precision as well. I also removed the prevision showcase from Example 2, as I felt it best to separate the examples to one change only. I.e., no args, separator arg, and precision arg.

Note that this change with the suffixes list means it may affect user code. The size == 1 code was removed to not assume size == 1 under the specified base means bytes. The code as it stands now will more implicitly return `"1.0 bytes"` when size == 1 (assuming the precision of 1).

You may prefer an alternative suffix to `bytes`, i.e., `b` or `B`, but I chose `bytes` since it's what was already used in the more explicit returns that are now removed.

Closes #2951.

### Ignore precision on filesizes ending in `.0`

E.g., `_to_str(1.0, ...)` will now return "1 bytes" instead of "1.0 bytes". Stuff like `2846` will still return `2.8kB` under the default precision of 1. That same value with the precision of 6 will still return `2.846000kB`. Again, only a value ending in exactly `.0` will have the precision removed.

### Note

I've also re-added code removed within the commits here, after those commits, in a different way. Instead of starting `_to_str` with `if size == 1: return "1 byte"` I changed it to do this check after the actual filesize computation and check explicitly if the suffix is a plural (which we can only currently assume is one suffix, `bytes`, so it was hardcoded just like before kind of). The benefit to all of this is just complimentary to follow the behavior of it doing `1 byte` instead of `1 bytes` like the code previously did while supporting the previous improvements listed here.