### PR TITLE
Tests adjustments needed for compatibility with Python 3.12

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@ The following people have contributed to the development of Rich:
 - [Leron Gray](https://github.com/daddycocoaman)
 - [Andre Hora](https://github.com/andrehora)
 - [Kenneth Hoste](https://github.com/boegel)
+- [Tomáš Hrnčiar](https://github.com/hrnciar)
 - [Lanqing Huang](https://github.com/lqhuang)
 - [Finn Hughes](https://github.com/finnhughes)
 - [Ionite](https://github.com/ionite34)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -298,7 +298,8 @@ def test_inspect_integer_with_methods_python310only():
 @skip_py38
 @skip_py39
 @skip_py310
-def test_inspect_integer_with_methods_python311_and_above():
+@skip_py312
+def test_inspect_integer_with_methods_python311():
     # to_bytes and from_bytes methods on int had minor signature change -
     # they now, as of 3.11, have default values for all of their parameters
     expected = (
@@ -327,6 +328,56 @@ def test_inspect_integer_with_methods_python311_and_above():
         "│                    signed=False): Return the   │\n"
         "│                    integer represented by the  │\n"
         "│                    given array of bytes.       │\n"
+        "│         to_bytes = def to_bytes(length=1,      │\n"
+        "│                    byteorder='big', *,         │\n"
+        "│                    signed=False): Return an    │\n"
+        "│                    array of bytes representing │\n"
+        "│                    an integer.                 │\n"
+        "╰────────────────────────────────────────────────╯\n"
+    )
+    assert render(1, methods=True) == expected
+
+
+@skip_py37
+@skip_py38
+@skip_py39
+@skip_py310
+@skip_py311
+def test_inspect_integer_with_methods_python312_and_above():
+    # as_integer_ratio method on int had minor docstring change -
+    # they now, as of 3.12, are consistent across types
+    expected = (
+        "╭──────────────── <class 'int'> ─────────────────╮\n"
+        "│ int([x]) -> integer                            │\n"
+        "│ int(x, base=10) -> integer                     │\n"
+        "│                                                │\n"
+        "│      denominator = 1                           │\n"
+        "│             imag = 0                           │\n"
+        "│        numerator = 1                           │\n"
+        "│             real = 1                           │\n"
+        "│ as_integer_ratio = def as_integer_ratio():     │\n"
+        "│                    Return a pair of integers,  │\n"
+        "│                    whose ratio is equal to the │\n"
+        "│                    original int.               │\n"
+        "│        bit_count = def bit_count(): Number of  │\n"
+        "│                    ones in the binary          │\n"
+        "│                    representation of the       │\n"
+        "│                    absolute value of self.     │\n"
+        "│       bit_length = def bit_length(): Number of │\n"
+        "│                    bits necessary to represent │\n"
+        "│                    self in binary.             │\n"
+        "│        conjugate = def conjugate(...) Returns  │\n"
+        "│                    self, the complex conjugate │\n"
+        "│                    of any int.                 │\n"
+        "│       from_bytes = def from_bytes(bytes,       │\n"
+        "│                    byteorder='big', *,         │\n"
+        "│                    signed=False): Return the   │\n"
+        "│                    integer represented by the  │\n"
+        "│                    given array of bytes.       │\n"
+        "│       is_integer = def is_integer(): Returns   │\n"
+        "│                    True. Exists for duck type  │\n"
+        "│                    compatibility with          │\n"
+        "│                    float.is_integer.           │\n"
         "│         to_bytes = def to_bytes(length=1,      │\n"
         "│                    byteorder='big', *,         │\n"
         "│                    signed=False): Return an    │\n"

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -38,6 +38,11 @@ skip_py311 = pytest.mark.skipif(
     reason="rendered differently on py3.11",
 )
 
+skip_py312 = pytest.mark.skipif(
+    sys.version_info.minor == 12 and sys.version_info.major == 3,
+    reason="rendered differently on py3.12",
+)
+
 skip_pypy3 = pytest.mark.skipif(
     hasattr(sys, "pypy_version_info"),
     reason="rendered differently on pypy3",
@@ -136,6 +141,7 @@ def test_inspect_empty_dict():
 
 
 @skip_py311
+@skip_py312
 @skip_pypy3
 def test_inspect_builtin_function_except_python311():
     # Pre-3.11 Python versions - print builtin has no signature available
@@ -212,6 +218,7 @@ def test_inspect_integer_with_value():
 @skip_py37
 @skip_py310
 @skip_py311
+@skip_py312
 def test_inspect_integer_with_methods_python38_and_python39():
     expected = (
         "╭──────────────── <class 'int'> ─────────────────╮\n"
@@ -249,6 +256,7 @@ def test_inspect_integer_with_methods_python38_and_python39():
 @skip_py38
 @skip_py39
 @skip_py311
+@skip_py312
 def test_inspect_integer_with_methods_python310only():
     expected = (
         "╭──────────────── <class 'int'> ─────────────────╮\n"

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -35,6 +35,11 @@ skip_py311 = pytest.mark.skipif(
     reason="rendered differently on py3.11",
 )
 
+skip_py312 = pytest.mark.skipif(
+    sys.version_info.minor == 12 and sys.version_info.major == 3,
+    reason="rendered differently on py3.12",
+)
+
 
 def test_install():
     console = Console(file=io.StringIO())
@@ -606,6 +611,7 @@ def test_attrs_empty():
 
 @skip_py310
 @skip_py311
+@skip_py312
 def test_attrs_broken():
     @attr.define
     class Foo:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate. (No changes made to Changelog, not sure if this is Changelog-worthy).
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Some tests are failing with Python 3.12, since they were skipped also on 3.11 I suppose it's okay to skip them on 3.12 as well. 
