### PR TITLE
Introduce the uninstall method

### DIFF
--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -161,6 +161,7 @@ def install(
             *args, is_syntax=True, **kwargs
         )
 
+    global _UNINSTALL_CALLABLE
     try:  # pragma: no cover
         # if within ipython, use customized traceback
         ip = get_ipython()  # type: ignore[name-defined]


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description
Related #2461, #1947

This is a very rough draft but it's a working solution. List of questions that I have

* Is manual testing enough? I am not sure how can I write an automated test for this and need some help
* Previously when running `install` for IPython, it returns a `sys.excepthook` which isn't useful, because it's just a pointer to the object and the old hooks that we want to preserve are gone.
* It's also not very consistent now with this change as for Python path, it returns a hook but for IPython path it returns a list of method which need to be recover when `uninstall`
* Should a global variable or a stateful class be used? This will make it easier to use `rich.traceback.uninstall()`, but it will also be a breaking change so I haven't implement in this way yet, would love to get some feedback.


## Manual Test
### Python
![image](https://github.com/Textualize/rich/assets/18221871/6e5e4f4c-8fec-498b-83b7-c739fdb7a4eb)

### IPython
![image](https://github.com/Textualize/rich/assets/18221871/6d264e55-a9c9-4a25-afba-cc8a8c66cfef)

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
I have tested this on Github workspace, you can use this script to verify the behavior.

```
python
import rich.traceback

hooks = rich.traceback.install()
rich.traceback.uninstall(hooks)
error # trigger error
```

```
ipython

import rich.traceback

hooks = rich.traceback.install()
rich.traceback.uninstall(hooks)
error # trigger error
```
