### PR TITLE
Apply pyupgrade suggestions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@ The following people have contributed to the development of Rich:
 - [Michael Milton](https://github.com/multimeric)
 - [Martina Oefelein](https://github.com/oefe)
 - [Nathan Page](https://github.com/nathanrpage97)
+- [Dimitri Papadopoulos Orfanos](https://github.com/DimitriPapadopoulos)
 - [Dave Pearson](https://github.com/davep/)
 - [Avi Perl](https://github.com/avi-perl)
 - [Laurent Peuch](https://github.com/psycojoker)

--- a/examples/print_calendar.py
+++ b/examples/print_calendar.py
@@ -36,9 +36,7 @@ def print_calendar(year):
         )
 
         for week_day in cal.iterweekdays():
-            table.add_column(
-                "{:.3}".format(calendar.day_name[week_day]), justify="right"
-            )
+            table.add_column(f"{calendar.day_name[week_day]:.3}", justify="right")
 
         month_days = cal.monthdayscalendar(year, month)
         for weekdays in month_days:

--- a/rich/_inspect.py
+++ b/rich/_inspect.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import inspect
 from inspect import cleandoc, getdoc, getfile, isclass, ismodule, signature
 from typing import Any, Collection, Iterable, Optional, Tuple, Type, Union

--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -31,7 +31,7 @@ class MarkdownElement:
     new_line: ClassVar[bool] = True
 
     @classmethod
-    def create(cls, markdown: "Markdown", token: Token) -> "MarkdownElement":
+    def create(cls, markdown: Markdown, token: Token) -> MarkdownElement:
         """Factory to create markdown element,
 
         Args:
@@ -43,30 +43,28 @@ class MarkdownElement:
         """
         return cls()
 
-    def on_enter(self, context: "MarkdownContext") -> None:
+    def on_enter(self, context: MarkdownContext) -> None:
         """Called when the node is entered.
 
         Args:
             context (MarkdownContext): The markdown context.
         """
 
-    def on_text(self, context: "MarkdownContext", text: TextType) -> None:
+    def on_text(self, context: MarkdownContext, text: TextType) -> None:
         """Called when text is parsed.
 
         Args:
             context (MarkdownContext): The markdown context.
         """
 
-    def on_leave(self, context: "MarkdownContext") -> None:
+    def on_leave(self, context: MarkdownContext) -> None:
         """Called when the parser leaves the element.
 
         Args:
             context (MarkdownContext): [description]
         """
 
-    def on_child_close(
-        self, context: "MarkdownContext", child: "MarkdownElement"
-    ) -> bool:
+    def on_child_close(self, context: MarkdownContext, child: MarkdownElement) -> bool:
         """Called when a child element is closed.
 
         This method allows a parent element to take over rendering of its children.
@@ -81,8 +79,8 @@ class MarkdownElement:
         return True
 
     def __rich_console__(
-        self, console: "Console", options: "ConsoleOptions"
-    ) -> "RenderResult":
+        self, console: Console, options: ConsoleOptions
+    ) -> RenderResult:
         return ()
 
 
@@ -100,14 +98,14 @@ class TextElement(MarkdownElement):
 
     style_name = "none"
 
-    def on_enter(self, context: "MarkdownContext") -> None:
+    def on_enter(self, context: MarkdownContext) -> None:
         self.style = context.enter_style(self.style_name)
         self.text = Text(justify="left")
 
-    def on_text(self, context: "MarkdownContext", text: TextType) -> None:
+    def on_text(self, context: MarkdownContext, text: TextType) -> None:
         self.text.append(text, context.current_style if isinstance(text, str) else None)
 
-    def on_leave(self, context: "MarkdownContext") -> None:
+    def on_leave(self, context: MarkdownContext) -> None:
         context.leave_style()
 
 
@@ -118,7 +116,7 @@ class Paragraph(TextElement):
     justify: JustifyMethod
 
     @classmethod
-    def create(cls, markdown: "Markdown", token: Token) -> "Paragraph":
+    def create(cls, markdown: Markdown, token: Token) -> Paragraph:
         return cls(justify=markdown.justify or "left")
 
     def __init__(self, justify: JustifyMethod) -> None:
@@ -135,10 +133,10 @@ class Heading(TextElement):
     """A heading."""
 
     @classmethod
-    def create(cls, markdown: "Markdown", token: Token) -> "Heading":
+    def create(cls, markdown: Markdown, token: Token) -> Heading:
         return cls(token.tag)
 
-    def on_enter(self, context: "MarkdownContext") -> None:
+    def on_enter(self, context: MarkdownContext) -> None:
         self.text = Text()
         context.enter_style(self.style_name)
 
@@ -172,7 +170,7 @@ class CodeBlock(TextElement):
     style_name = "markdown.code_block"
 
     @classmethod
-    def create(cls, markdown: "Markdown", token: Token) -> "CodeBlock":
+    def create(cls, markdown: Markdown, token: Token) -> CodeBlock:
         node_info = token.info or ""
         lexer_name = node_info.partition(" ")[0]
         return cls(lexer_name or "text", markdown.code_theme)
@@ -199,9 +197,7 @@ class BlockQuote(TextElement):
     def __init__(self) -> None:
         self.elements: Renderables = Renderables()
 
-    def on_child_close(
-        self, context: "MarkdownContext", child: "MarkdownElement"
-    ) -> bool:
+    def on_child_close(self, context: MarkdownContext, child: MarkdownElement) -> bool:
         self.elements.append(child)
         return False
 
@@ -343,17 +339,15 @@ class ListElement(MarkdownElement):
     """A list element."""
 
     @classmethod
-    def create(cls, markdown: "Markdown", token: Token) -> "ListElement":
+    def create(cls, markdown: Markdown, token: Token) -> ListElement:
         return cls(token.type, int(token.attrs.get("start", 1)))
 
     def __init__(self, list_type: str, list_start: int | None) -> None:
-        self.items: List[ListItem] = []
+        self.items: list[ListItem] = []
         self.list_type = list_type
         self.list_start = list_start
 
-    def on_child_close(
-        self, context: "MarkdownContext", child: "MarkdownElement"
-    ) -> bool:
+    def on_child_close(self, context: MarkdownContext, child: MarkdownElement) -> bool:
         assert isinstance(child, ListItem)
         self.items.append(child)
         return False
@@ -381,9 +375,7 @@ class ListItem(TextElement):
     def __init__(self) -> None:
         self.elements: Renderables = Renderables()
 
-    def on_child_close(
-        self, context: "MarkdownContext", child: "MarkdownElement"
-    ) -> bool:
+    def on_child_close(self, context: MarkdownContext, child: MarkdownElement) -> bool:
         self.elements.append(child)
         return False
 
@@ -419,7 +411,7 @@ class ListItem(TextElement):
 
 class Link(TextElement):
     @classmethod
-    def create(cls, markdown: "Markdown", token: Token) -> "MarkdownElement":
+    def create(cls, markdown: Markdown, token: Token) -> MarkdownElement:
         url = token.attrs.get("href", "#")
         return cls(token.content, str(url))
 
@@ -434,7 +426,7 @@ class ImageItem(TextElement):
     new_line = False
 
     @classmethod
-    def create(cls, markdown: "Markdown", token: Token) -> "MarkdownElement":
+    def create(cls, markdown: Markdown, token: Token) -> MarkdownElement:
         """Factory to create markdown element,
 
         Args:
@@ -449,10 +441,10 @@ class ImageItem(TextElement):
     def __init__(self, destination: str, hyperlinks: bool) -> None:
         self.destination = destination
         self.hyperlinks = hyperlinks
-        self.link: Optional[str] = None
+        self.link: str | None = None
         super().__init__()
 
-    def on_enter(self, context: "MarkdownContext") -> None:
+    def on_enter(self, context: MarkdownContext) -> None:
         self.link = context.current_style.link
         self.text = Text(justify="left")
         super().on_enter(context)
@@ -476,7 +468,7 @@ class MarkdownContext:
         console: Console,
         options: ConsoleOptions,
         style: Style,
-        inline_code_lexer: Optional[str] = None,
+        inline_code_lexer: str | None = None,
         inline_code_theme: str = "monokai",
     ) -> None:
         self.console = console
@@ -484,7 +476,7 @@ class MarkdownContext:
         self.style_stack: StyleStack = StyleStack(style)
         self.stack: Stack[MarkdownElement] = Stack()
 
-        self._syntax: Optional[Syntax] = None
+        self._syntax: Syntax | None = None
         if inline_code_lexer is not None:
             self._syntax = Syntax("", inline_code_lexer, theme=inline_code_theme)
 
@@ -504,7 +496,7 @@ class MarkdownContext:
         else:
             self.stack.top.on_text(self, text)
 
-    def enter_style(self, style_name: Union[str, Style]) -> Style:
+    def enter_style(self, style_name: str | Style) -> Style:
         """Enter a style context."""
         style = self.console.get_style(style_name, default="none")
         self.style_stack.push(style)
@@ -531,7 +523,7 @@ class Markdown(JupyterMixin):
             highlighting, or None for no highlighting. Defaults to None.
     """
 
-    elements: ClassVar[Dict[str, Type[MarkdownElement]]] = {
+    elements: ClassVar[dict[str, type[MarkdownElement]]] = {
         "paragraph_open": Paragraph,
         "heading_open": Heading,
         "fence": CodeBlock,
@@ -556,17 +548,17 @@ class Markdown(JupyterMixin):
         self,
         markup: str,
         code_theme: str = "monokai",
-        justify: Optional[JustifyMethod] = None,
-        style: Union[str, Style] = "none",
+        justify: JustifyMethod | None = None,
+        style: str | Style = "none",
         hyperlinks: bool = True,
-        inline_code_lexer: Optional[str] = None,
-        inline_code_theme: Optional[str] = None,
+        inline_code_lexer: str | None = None,
+        inline_code_theme: str | None = None,
     ) -> None:
         parser = MarkdownIt().enable("strikethrough").enable("table")
         self.markup = markup
         self.parsed = parser.parse(markup)
         self.code_theme = code_theme
-        self.justify: Optional[JustifyMethod] = justify
+        self.justify: JustifyMethod | None = justify
         self.style = style
         self.hyperlinks = hyperlinks
         self.inline_code_lexer = inline_code_lexer

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -1326,7 +1326,7 @@ class Progress(JupyterMixin):
         # normalize the mode (always rb, rt)
         _mode = "".join(sorted(mode, reverse=False))
         if _mode not in ("br", "rt", "r"):
-            raise ValueError("invalid mode {!r}".format(mode))
+            raise ValueError(f"invalid mode {mode!r}")
 
         # patch buffering to provide the same behaviour as the builtin `open`
         line_buffering = buffering == 1

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -432,10 +432,10 @@ def open(
     Args:
         path (Union[str, PathLike[str], BinaryIO]): The path to the file to read, or a file-like object in binary mode.
         mode (str): The mode to use to open the file. Only supports "r", "rb" or "rt".
-        buffering (int): The buffering strategy to use, see :func:`io.open`.
-        encoding (str, optional): The encoding to use when reading in text mode, see :func:`io.open`.
-        errors (str, optional): The error handling strategy for decoding errors, see :func:`io.open`.
-        newline (str, optional): The strategy for handling newlines in text mode, see :func:`io.open`
+        buffering (int): The buffering strategy to use, see :func:`open`.
+        encoding (str, optional): The encoding to use when reading in text mode, see :func:`open`.
+        errors (str, optional): The error handling strategy for decoding errors, see :func:`open`.
+        newline (str, optional): The strategy for handling newlines in text mode, see :func:`open`
         total: (int, optional): Total number of bytes to read. Must be provided if reading from a file handle. Default for a path is os.stat(file).st_size.
         description (str, optional): Description of task show next to progress bar. Defaults to "Reading".
         auto_refresh (bool, optional): Automatic refresh, disable to force a refresh after each iteration. Default is True.
@@ -1309,10 +1309,10 @@ class Progress(JupyterMixin):
         Args:
             path (Union[str, PathLike[str]]): The path to the file to read.
             mode (str): The mode to use to open the file. Only supports "r", "rb" or "rt".
-            buffering (int): The buffering strategy to use, see :func:`io.open`.
-            encoding (str, optional): The encoding to use when reading in text mode, see :func:`io.open`.
-            errors (str, optional): The error handling strategy for decoding errors, see :func:`io.open`.
-            newline (str, optional): The strategy for handling newlines in text mode, see :func:`io.open`.
+            buffering (int): The buffering strategy to use, see :func:`open`.
+            encoding (str, optional): The encoding to use when reading in text mode, see :func:`open`.
+            errors (str, optional): The error handling strategy for decoding errors, see :func:`open`.
+            newline (str, optional): The strategy for handling newlines in text mode, see :func:`open`.
             total (int, optional): Total number of bytes to read. If none given, os.stat(path).st_size is used.
             task_id (TaskID): Task to track. Default is new task.
             description (str, optional): Description of task, if new task is created.
@@ -1353,7 +1353,7 @@ class Progress(JupyterMixin):
             self.update(task_id, total=total)
 
         # open the file in binary mode,
-        handle = io.open(file, "rb", buffering=buffering)
+        handle = open(file, "rb", buffering=buffering)
         reader = _Reader(handle, self, task_id, close_handle=True)
 
         # wrap the reader in a `TextIOWrapper` if text mode

--- a/rich/progress_bar.py
+++ b/rich/progress_bar.py
@@ -108,7 +108,7 @@ class ProgressBar(JupyterMixin):
 
         for index in range(PULSE_SIZE):
             position = index / PULSE_SIZE
-            fade = 0.5 + cos((position * pi * 2)) / 2.0
+            fade = 0.5 + cos(position * pi * 2) / 2.0
             color = blend_rgb(fore_color, back_color, cross_fade=fade)
             append(_Segment(bar, _Style(color=from_triplet(color))))
         return segments

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import linecache
 import os
 import platform


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Apply changes suggested by [`pyupgrade`](https://github.com/asottile/pyupgrade) (with option `--py37-plus`):
* [`__future__` import removal](https://github.com/asottile/pyupgrade#__future__-import-removal)
* [pep 585 typing rewrites](https://github.com/asottile/pyupgrade#__future__-import-removal)
* [pep 604 typing rewrites](https://github.com/asottile/pyupgrade#pep-604-typing-rewrites)
* extraneous parentheses
* [`open` alias](https://github.com/asottile/pyupgrade#open-alias)

I have left out, for now and until you say otherwise:
* [redundant `open` modes](https://github.com/asottile/pyupgrade#redundant-open-modes)
* vendored file [rich/filesize.py](https://github.com/Textualize/rich/blob/master/rich/filesize.py), which could be updated by the way