### PR TITLE
Fix tag RegEx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1966,6 +1966,7 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 
 - First official release, API still to be stabilized
 
+[13.4.3]: https://github.com/textualize/rich/compare/v13.4.2...v13.4.3
 [13.4.2]: https://github.com/textualize/rich/compare/v13.4.1...v13.4.2  
 [13.4.1]: https://github.com/textualize/rich/compare/v13.4.0...v13.4.1  
 [13.4.0]: https://github.com/textualize/rich/compare/v13.3.5...v13.4.0  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.4.3] - 2023-07-05
+
+### Fixed
+
+- Fixed tag highlighting in reprs, where tag colors would break after the first one, or an unmatched `<`. https://github.com/Textualize/rich/pull/3025
+
 ## [13.4.2] - 2023-06-12
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,6 +23,7 @@ The following people have contributed to the development of Rich:
 - [Lanqing Huang](https://github.com/lqhuang)
 - [Finn Hughes](https://github.com/finnhughes)
 - [Ionite](https://github.com/ionite34)
+- [Micael Jarniac](https://github.com/MicaelJarniac)
 - [Josh Karpel](https://github.com/JoshKarpel)
 - [Jan Katins](https://github.com/jankatins)
 - [Hugo van Kemenade](https://github.com/hugovk)

--- a/rich/highlighter.py
+++ b/rich/highlighter.py
@@ -82,7 +82,7 @@ class ReprHighlighter(RegexHighlighter):
 
     base_style = "repr."
     highlights = [
-        r"(?P<tag_start><)(?P<tag_name>[-\w.:|]*)(?P<tag_contents>[\w\W]*)(?P<tag_end>>)",
+        r"(?P<tag_start><)(?P<tag_name>[-\w.:|]*)(?P<tag_contents>[^<]*?)(?P<tag_end>>)",
         r'(?P<attrib_name>[\w_]{1,50})=(?P<attrib_value>"?[\w_]+"?)?',
         r"(?P<brace>[][{}()])",
         _combine_regex(


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Closes #3024

Updated regex pattern to improve color formatting. The `tag_contents` group was updated to exclude `<` character (`[^<]`), preventing the matching of tags that contain other tags inside. Additionally, a `*?` was used for a non-greedy match, making the group match as little as possible, thus avoiding overreaching matches.