### PR TITLE
ExceptionGroup PEP654 proof of concept.

### DIFF
--- a/examples/exception_group.py
+++ b/examples/exception_group.py
@@ -1,0 +1,36 @@
+"""
+
+Demonstrates Rich tracebacks for recursion errors.
+
+Rich can exclude frames in the middle to avoid huge tracebacks.
+
+"""
+
+from rich.console import Console
+
+console = Console()
+
+def a():
+    b()
+
+def b():
+    try:
+        c()
+    except Exception as exception:
+        raise ExceptionGroup(
+            "Created in B",
+            [exception, exception]
+        )
+
+def c():
+    raise RuntimeError("I was raised in C")
+    raise ExceptionGroup(
+        "exception group",
+        [RuntimeError("I'm a runtime error"), ValueError("I'm a value error")]
+    )
+
+try:
+    a()
+except Exception:
+    console.print_exception(max_frames=20)
+    raise

--- a/rich/default_styles.py
+++ b/rich/default_styles.py
@@ -119,6 +119,8 @@ DEFAULT_STYLES: Dict[str, Style] = {
     "traceback.title": Style(color="red", bold=True),
     "traceback.exc_type": Style(color="bright_red", bold=True),
     "traceback.exc_value": Style.null(),
+    "exception_group.title": Style(color="magenta", bold=True),
+    "exception_group.border": Style(color="magenta"),
     "traceback.offset": Style(color="bright_red", bold=True),
     "bar.back": Style(color="grey23"),
     "bar.complete": Style(color="rgb(249,38,114)"),


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This is just a proof of concept for how exception groups may look, primarily looking to get some feedback on:
1. How people would like for it to look.
2. How the implementation should be done primarily, so feedback on the data structure changes and where to put the code.

This implementation does not (yet) care about backwards-compatibility or supportng the exceptiongroup pypi backport, that is to be added later. This is how the current example I've added looks when running, 

![image](https://github.com/Textualize/rich/assets/1593486/83f67d3c-7763-4ac8-b05c-58a5f48ed29b)

Compared to the default (which is also printed below it): 

![image](https://github.com/Textualize/rich/assets/1593486/879f4171-4ada-4f4a-8137-146bf65ef62b)

This resolves #1859.