### PR TITLE
Allow RichHandler to accept a 'style' attribute passed via LogRecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [13.4.3] - 2023-07-26
+
+### Added
+
+- 'RichHandler' now accepts a 'style' attribute passed via the logging 'extra' field in addition to 'markup' 
+
 ## [13.4.2] - 2023-06-12
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,6 +27,7 @@ The following people have contributed to the development of Rich:
 - [Jan Katins](https://github.com/jankatins)
 - [Hugo van Kemenade](https://github.com/hugovk)
 - [Andrew Kettmann](https://github.com/akettmann)
+- [Koshell](https://github.com/koshell)
 - [Martin Larralde](https://github.com/althonos)
 - [Hedy Li](https://github.com/hedythedev)
 - [Luka Mamukashvili](https://github.com/UltraStudioLTD)

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -182,7 +182,8 @@ class RichHandler(Handler):
             ConsoleRenderable: Renderable to display log message.
         """
         use_markup = getattr(record, "markup", self.markup)
-        message_text = Text.from_markup(message) if use_markup else Text(message)
+        style = getattr(record, "style", "")
+        message_text = Text.from_markup(message,style=style) if use_markup else Text(message,style=style)
 
         highlighter = getattr(record, "highlighter", self.highlighter)
         if highlighter:

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -183,7 +183,11 @@ class RichHandler(Handler):
         """
         use_markup = getattr(record, "markup", self.markup)
         style = getattr(record, "style", "")
-        message_text = Text.from_markup(message,style=style) if use_markup else Text(message,style=style)
+        message_text = (
+            Text.from_markup(message, style=style)
+            if use_markup
+            else Text(message, style=style)
+        )
 
         highlighter = getattr(record, "highlighter", self.highlighter)
         if highlighter:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -122,7 +122,7 @@ def test_stderr_and_stdout_are_none(monkeypatch):
     assert "message" in actual_record.msg
 
 
-def test_markup_and_highlight():
+def test_markup_highlight_style():
     console = Console(
         file=io.StringIO(),
         force_terminal=True,
@@ -160,6 +160,23 @@ def test_markup_and_highlight():
     render_plain = handler.console.file.getvalue()
     assert "FORMATTER" in render_plain
     assert log_message in render_plain
+
+    handler.console.file = io.StringIO()
+    log.error(log_message, extra={"style": "bold"})
+    render_fancy_bold = handler.console.file.getvalue()
+    assert "FORMATTER" in render_fancy_bold
+    assert log_message not in render_fancy_bold
+    assert "\x1b[1m" in render_fancy_bold
+
+    handler.console.file = io.StringIO()
+    log.error(log_message, extra={"style": "bold", "highlighter": None})
+    render_simple_bold = handler.console.file.getvalue()
+    assert "FORMATTER" in render_simple_bold
+    assert log_message in render_simple_bold 
+    assert "\x1b[1m" in render_simple_bold
+    
+    assert render_fancy_bold not in render_simple_bold
+    assert render_simple_bold not in render_fancy_bold
 
 
 if __name__ == "__main__":

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -155,26 +155,29 @@ def test_markup_highlight_style():
     assert log_message not in render_markup
     assert "red" not in render_markup
 
+    bold_ansi = "\x1b[1m"
+
     handler.console.file = io.StringIO()
     log.error(log_message, extra={"highlighter": None})
     render_plain = handler.console.file.getvalue()
     assert "FORMATTER" in render_plain
     assert log_message in render_plain
+    assert bold_ansi not in render_plain
 
     handler.console.file = io.StringIO()
     log.error(log_message, extra={"style": "bold"})
     render_fancy_bold = handler.console.file.getvalue()
     assert "FORMATTER" in render_fancy_bold
     assert log_message not in render_fancy_bold
-    assert "\x1b[1m" in render_fancy_bold
+    assert bold_ansi in render_fancy_bold
 
     handler.console.file = io.StringIO()
     log.error(log_message, extra={"style": "bold", "highlighter": None})
     render_simple_bold = handler.console.file.getvalue()
     assert "FORMATTER" in render_simple_bold
-    assert log_message in render_simple_bold 
-    assert "\x1b[1m" in render_simple_bold
-    
+    assert log_message in render_simple_bold
+    assert bold_ansi in render_simple_bold
+
     assert render_fancy_bold not in render_simple_bold
     assert render_simple_bold not in render_fancy_bold
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I frequently use loggers with multiple handlers attached. It would be convenient to be able to pass style as an extra parameter. Currently if I want to use markup then other non-rich loggers will have that markup left in, however using style allows the RichHandler to print pretty text while keeping other handlers free of markup.

