### PR TITLE
Extend tabs with styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+
+### Fixed
+
+- Fixed Text.expand_tabs not expanding spans.
+
+### Added
+
+- Added Text.extend_style method.
+
 ## [13.4.2] - 2023-06-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added Text.extend_style method.
+- Added Span.extend method.
 
 ## [13.4.2] - 2023-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Text.extend_style method.
 - Added Span.extend method.
 
+### Changed
+
+- Text.tab_size now defaults to `None` to indicate that Console.tab_size should be used.
+
 ## [13.4.2] - 2023-06-12
 
 ### Changed

--- a/rich/text.py
+++ b/rich/text.py
@@ -822,7 +822,7 @@ class Text(JupyterMixin):
         assert tab_size is not None
         result = self.blank_copy()
 
-        new_text: list[Text] = []
+        new_text: List[Text] = []
         append = new_text.append
 
         for line in self.split("\n", include_separator=True):

--- a/rich/text.py
+++ b/rich/text.py
@@ -821,28 +821,30 @@ class Text(JupyterMixin):
             tab_size = self.tab_size
         assert tab_size is not None
         result = self.blank_copy()
-        append = result.append
+
+        new_text: list[Text] = []
+        append = new_text.append
 
         for line in self.split("\n", include_separator=True):
-            cell_position = 0
             if "\t" not in line.plain:
                 append(line)
             else:
+                cell_position = 0
                 parts = line.split("\t", include_separator=True)
-                tab_parts: list[Text] = []
                 for part in parts:
                     if part.plain.endswith("\t"):
                         part._text[-1] = part._text[-1][:-1] + " "
                         cell_position += part.cell_len
                         tab_remainder = cell_position % tab_size
                         if tab_remainder:
-                            spaces = tab_size - (cell_position % tab_size)
+                            spaces = tab_size - tab_remainder
                             part.extend_style(spaces)
                             cell_position += spaces
                     else:
                         cell_position += part.cell_len
-                    tab_parts.append(part)
-                append(Text("").join(tab_parts))
+                    append(part)
+
+        result = Text("").join(new_text)
 
         self._text = [result.plain]
         self._length = len(self.plain)

--- a/rich/text.py
+++ b/rich/text.py
@@ -565,12 +565,12 @@ class Text(JupyterMixin):
         return style
 
     def extend_style(self, spaces: int) -> None:
-        """Extend the Text and styles by a given number of spaces.
+        """Extend the Text given number of spaces where the spaces have the same style as the last character.
 
         Args:
             spaces (int): Number of spaces to add to the Text.
         """
-        if not spaces:
+        if spaces <= 0:
             return
         spans = self.spans
         new_spaces = " " * spaces

--- a/rich/text.py
+++ b/rich/text.py
@@ -97,18 +97,18 @@ class Span(NamedTuple):
             return self
         return Span(start, min(offset, end), style)
 
-    def add_padding(self, padding: int) -> "Span":
-        """Add spaces the the end of a span.
+    def extend(self, cells: int) -> "Span":
+        """Extend the span by the given number of cells.
 
         Args:
-            padding (int): Number of additional spaces.
+            cells (int): Additional space to add to end of span.
 
         Returns:
             Span: A span.
         """
-        if padding:
+        if cells:
             start, end, style = self
-            return Span(start, end + padding, style)
+            return Span(start, end + cells, style)
         else:
             return self
 
@@ -577,7 +577,7 @@ class Text(JupyterMixin):
         if spans:
             end_offset = len(self)
             self._spans[:] = [
-                span.add_padding(spaces) if span.end >= end_offset else span
+                span.extend(spaces) if span.end >= end_offset else span
                 for span in spans
             ]
             self._text.append(new_spaces)

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -63,9 +63,9 @@ def test_render_size():
     expected = [
         [
             Segment("╭─", Style()),
-            Segment("──────────────────────────────────", Style()),
-            Segment(" Hello ", Style()),
-            Segment("───────────────────────────────────", Style()),
+            Segment(
+                "────────────────────────────────── Hello ───────────────────────────────────"
+            ),
             Segment("─╮", Style()),
         ],
         [

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -898,3 +898,19 @@ def test_markup_property():
         == "[bold]foo [italic]bar[/bold] baz[/italic]"
     )
     assert Text("[bold]foo").markup == "\\[bold]foo"
+
+
+def test_extend_style():
+    text = Text.from_markup("[red]foo[/red] [bold]bar")
+    text.extend_style(0)
+
+    assert text.plain == "foo bar"
+    assert text.spans == [Span(0, 3, "red"), Span(4, 7, "bold")]
+
+    text.extend_style(-1)
+    assert text.plain == "foo bar"
+    assert text.spans == [Span(0, 3, "red"), Span(4, 7, "bold")]
+
+    text.extend_style(2)
+    assert text.plain == "foo bar  "
+    assert text.spans == [Span(0, 3, "red"), Span(4, 9, "bold")]

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -608,6 +608,7 @@ def test_tabs_to_spaces():
         ("\t", 4, "    ", []),
         ("\tbar", 4, "    bar", []),
         ("foo\tbar", 4, "foo bar", []),
+        ("foo\nbar\nbaz", 4, "foo\nbar\nbaz", []),
         (
             "[bold]foo\tbar",
             4,
@@ -617,13 +618,43 @@ def test_tabs_to_spaces():
                 Span(4, 7, "bold"),
             ],
         ),
-        ("[bold]\tbar", 4, "    bar", [Span(0, 4, "bold"), Span(4, 7, "bold")]),
+        (
+            "[bold]\tbar",
+            4,
+            "    bar",
+            [
+                Span(0, 4, "bold"),
+                Span(4, 7, "bold"),
+            ],
+        ),
         (
             "\t[bold]bar",
             4,
             "    bar",
             [
                 Span(4, 7, "bold"),
+            ],
+        ),
+        (
+            "[red]foo\tbar\n[green]egg\tbaz",
+            8,
+            "foo     bar\negg     baz",
+            [
+                Span(0, 8, "red"),
+                Span(8, 12, "red"),
+                Span(12, 20, "red"),
+                Span(12, 20, "green"),
+                Span(20, 23, "red"),
+                Span(20, 23, "green"),
+            ],
+        ),
+        (
+            "[bold]💩\t💩",
+            8,
+            "💩      💩",
+            [
+                Span(0, 7, "bold"),
+                Span(7, 8, "bold"),
             ],
         ),
     ],
@@ -634,7 +665,7 @@ def test_tabs_to_spaces_spans(
     """Test spans are correct after expand_tabs"""
     text = Text.from_markup(markup)
     text.expand_tabs(tab_size)
-    print(expected_spans)
+    print(text._spans)
     assert text.plain == expected_text
     assert text._spans == expected_spans
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,4 +1,5 @@
 from io import StringIO
+from typing import List
 
 import pytest
 
@@ -683,7 +684,7 @@ def test_tabs_to_spaces():
     ],
 )
 def test_tabs_to_spaces_spans(
-    markup: str, tab_size: int, expected_text: str, expected_spans: list[Span]
+    markup: str, tab_size: int, expected_text: str, expected_spans: List[Span]
 ):
     """Test spans are correct after expand_tabs"""
     text = Text.from_markup(markup)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -601,6 +601,44 @@ def test_tabs_to_spaces():
     assert text.plain == "No Tabs"
 
 
+@pytest.mark.parametrize(
+    "markup,tab_size,expected_text,expected_spans",
+    [
+        ("", 4, "", []),
+        ("\t", 4, "    ", []),
+        ("\tbar", 4, "    bar", []),
+        ("foo\tbar", 4, "foo bar", []),
+        (
+            "[bold]foo\tbar",
+            4,
+            "foo bar",
+            [
+                Span(0, 4, "bold"),
+                Span(4, 7, "bold"),
+            ],
+        ),
+        ("[bold]\tbar", 4, "    bar", [Span(0, 4, "bold"), Span(4, 7, "bold")]),
+        (
+            "\t[bold]bar",
+            4,
+            "    bar",
+            [
+                Span(4, 7, "bold"),
+            ],
+        ),
+    ],
+)
+def test_tabs_to_spaces_spans(
+    markup: str, tab_size: int, expected_text: str, expected_spans: list[Span]
+):
+    """Test spans are correct after expand_tabs"""
+    text = Text.from_markup(markup)
+    text.expand_tabs(tab_size)
+    print(expected_spans)
+    assert text.plain == expected_text
+    assert text._spans == expected_spans
+
+
 def test_markup_switch():
     """Test markup can be disabled."""
     console = Console(file=StringIO(), markup=False)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -600,6 +600,11 @@ def test_tabs_to_spaces():
     text.expand_tabs()
     assert text.plain == "No Tabs"
 
+    text = Text("No Tabs", style="bold")
+    text.expand_tabs()
+    assert text.plain == "No Tabs"
+    assert text.style == "bold"
+
 
 @pytest.mark.parametrize(
     "markup,tab_size,expected_text,expected_spans",
@@ -649,12 +654,30 @@ def test_tabs_to_spaces():
             ],
         ),
         (
+            "[bold]X\tY",
+            8,
+            "X       Y",
+            [
+                Span(0, 8, "bold"),
+                Span(8, 9, "bold"),
+            ],
+        ),
+        (
             "[bold]💩\t💩",
             8,
             "💩      💩",
             [
                 Span(0, 7, "bold"),
                 Span(7, 8, "bold"),
+            ],
+        ),
+        (
+            "[bold]💩💩💩💩\t💩",
+            8,
+            "💩💩💩💩        💩",
+            [
+                Span(0, 12, "bold"),
+                Span(12, 13, "bold"),
             ],
         ),
     ],


### PR DESCRIPTION
The `Text.extend_tabs` method was previously not taking in to account the spans.  Basically it would replace tabs with unstyled spaces. This resolves that issue by extending the style(s) on the tab to cover the new space characters

<img width="623" alt="Screenshot 2023-07-28 at 22 00 06" src="https://github.com/Textualize/rich/assets/554369/28c170a0-b154-4a81-af17-a8a334bebd3a">
