### PR TITLE
Fix rich.print to treat dataclasses the same as print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.5.2] - 2023-08-30
+
+### Fixed
+
+- rich.print doesn't obey __str__ on dataclasses
+
 ## [13.5.2] - 2023-08-01
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,6 +34,7 @@ The following people have contributed to the development of Rich:
 - [Alexander Mancevice](https://github.com/amancevice)
 - [Will McGugan](https://github.com/willmcgugan)
 - [Paul McGuire](https://github.com/ptmcg)
+- [Dan Mills](https://github.com/evilhamsterman)
 - [Antony Milne](https://github.com/AntonyMilneQB)
 - [Michael Milton](https://github.com/multimeric)
 - [Martina Oefelein](https://github.com/oefe)

--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -70,6 +70,7 @@ def print(
     """
     from .console import Console
 
+    objects = tuple(str(o) for o in objects)
     write_console = get_console() if file is None else Console(file=file)
     return write_console.print(*objects, sep=sep, end=end)
 

--- a/tests/test_rich_print.py
+++ b/tests/test_rich_print.py
@@ -4,6 +4,8 @@ import json
 import rich
 from rich.console import Console
 
+from dataclasses import dataclass
+
 
 def test_get_console():
     console = rich.get_console()
@@ -70,5 +72,22 @@ def test_rich_print_X():
         rich.print("fooX")
         rich.print("fooXX")
         assert output.getvalue() == "foo\nfooX\nfooXX\n"
+    finally:
+        console.file = backup_file
+
+def test_rich_print_dataclass_str():
+    console = rich.get_console()
+    output = io.StringIO()
+    backup_file = console.file
+    @dataclass
+    class test:
+        name: str = "foo"
+        def __str__(self) -> str:
+            return f"Name: {self.name}"
+    try:
+        t = test()
+        console.file = output
+        rich.print(t)
+        assert output.getvalue() == "Name: foo\n"
     finally:
         console.file = backup_file

--- a/tests/test_rich_print.py
+++ b/tests/test_rich_print.py
@@ -75,15 +75,19 @@ def test_rich_print_X():
     finally:
         console.file = backup_file
 
+
 def test_rich_print_dataclass_str():
     console = rich.get_console()
     output = io.StringIO()
     backup_file = console.file
+
     @dataclass
     class test:
         name: str = "foo"
+
         def __str__(self) -> str:
             return f"Name: {self.name}"
+
     try:
         t = test()
         console.file = output


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

As described in #3074 the rich.print function doesn't obey `__str__` on dataclasses. After reviewing the code it looks like that is the expected result on `Console.print`, but since `rich.print` is supposed to be a replacement for the builtin `print()` this change brings it in line for expected output.
