### PR TITLE
Style link id cache

### DIFF
--- a/rich/text.py
+++ b/rich/text.py
@@ -746,18 +746,19 @@ class Text(JupyterMixin):
         stack_append = stack.append
         stack_pop = stack.remove
 
-        style_cache: Dict[Tuple[Style, ...], Style] = {}
+        style_cache: Dict[Tuple[int, ...], Style] = {}
         style_cache_get = style_cache.get
         combine = Style.combine
 
         def get_current_style() -> Style:
             """Construct current style from stack."""
-            styles = tuple(style_map[_style_id] for _style_id in sorted(stack))
-            cached_style = style_cache_get(styles)
+            cache_key = tuple(sorted(stack))
+            cached_style = style_cache_get(cache_key)
             if cached_style is not None:
                 return cached_style
+            styles = tuple(style_map[_style_id] for _style_id in sorted(stack))
             current_style = combine(styles)
-            style_cache[styles] = current_style
+            style_cache[cache_key] = current_style
             return current_style
 
         for (offset, leaving, style_id), (next_offset, _, _) in zip(spans, spans[1:]):


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.


The changes proposed here pass all tests.
No regression tests have been added yet.

## Description

This follows https://github.com/Textualize/textual/issues/1587 and https://github.com/Textualize/rich/issues/2949.
The issue we're dealing with boils down to the fact that the attribute `Style._link_id` is not taken into account when hashing a `Style` which then introduces caching collisions with styles that have the same `_link`/`_meta` attributes but that have a different `_link_id`.

 > Can't we include `_link_id` in the hash of a style?

We can't, because we don't want equality comparison to depend on `_link_id`, and if two objects are compared as equal, then [their hash should be the same](https://docs.python.org/3/reference/datamodel.html#object.__hash__).

When working on https://github.com/Textualize/textual/issues/1587, the first fix I found was that I could disable the cache inside `rich.text.Text.render` and the `functools.lru_cache` around `rich.style.Style._add` and that would fix the issue.
So, this does show it is a caching issue.
In particular, it has to do with the clashes that can exist when styles have the same meta values but originally have different `_link_id` attributes:

```py
from rich.style import Style
meta = {"click": "something"}
s1 = Style.from_meta(meta)
s2 = Style.from_meta(meta)
print(s1.link_id, s2.link_id)  # Different link_id.
# (
#     '6311506187629892456089155',
#     '4273756187629892456089155'
# )

base = Style(color="red")
print((base + s1).link_id)  # This is the link_id of s1.
# '6311506187629892456089155'

# Now, we add base to s2:
#             vv
print((base + s2).link_id)  # This is the link_id of s1!
# '6311506187629892456089155'
```

Now, we can take a look at how addition is implemented and this reveals a promising workaround:

```py
class Style:
    # ...
    def __add__(self, style: Optional["Style"]) -> "Style":
        combined_style = self._add(style)
        return combined_style.copy() if combined_style.link else combined_style
```

The call to `.copy()` refreshes the `link_id` if the resulting combined style has a link.
So, one might think it is a good idea to change the return statement to

```py
return combined_style.copy() if combined_style.link or combined_style.meta else combined_style
```

However, this breaks link highlighting on the Textual side entirely – as in, _no_ link gets _any_ highlighting – because Textual relies on the link IDs to know what to highlight.
When the markup is first parsed, Textual will keep tabs on the link IDs of the styles it created, so if the rendering of the widget will come back with a style with a new link ID, Textual won't know what to highlight.

A potential fix is to bypass the cache entirely when adding styles that have link IDs but no links.