### PR TITLE
Supplemented missing docstrings

### DIFF
--- a/rich/align.py
+++ b/rich/align.py
@@ -240,6 +240,7 @@ class VerticalCenter(JupyterMixin):
 
     Args:
         renderable (RenderableType): A renderable object.
+        style (StyleType, optional): An optional style to apply to the background. Defaults to None.
     """
 
     def __init__(

--- a/rich/panel.py
+++ b/rich/panel.py
@@ -22,11 +22,13 @@ class Panel(JupyterMixin):
 
     Args:
         renderable (RenderableType): A console renderable object.
-        box (Box, optional): A Box instance that defines the look of the border (see :ref:`appendix_box`.
-            Defaults to box.ROUNDED.
+        box (Box, optional): A Box instance that defines the look of the border (see :ref:`appendix_box`. Defaults to box.ROUNDED.
+        title (Optional[TextType], optional): Optional title displayed in panel header. Defaults to None.
+        title_align (AlignMethod, optional): Alignment of title. Defaults to "center".
+        subtitle (Optional[TextType], optional): Optional subtitle displayed in panel footer. Defaults to None.
+        subtitle_align (AlignMethod, optional): Alignment of subtitle. Defaults to "center".
         safe_box (bool, optional): Disable box characters that don't display on windows legacy terminal with *raster* fonts. Defaults to True.
-        expand (bool, optional): If True the panel will stretch to fill the console
-            width, otherwise it will be sized to fit the contents. Defaults to True.
+        expand (bool, optional): If True the panel will stretch to fill the console width, otherwise it will be sized to fit the contents. Defaults to True.
         style (str, optional): The style of the panel (border and contents). Defaults to "none".
         border_style (str, optional): The style of the border. Defaults to "none".
         width (Optional[int], optional): Optional width of panel. Defaults to None to auto-detect.

--- a/rich/tree.py
+++ b/rich/tree.py
@@ -18,6 +18,7 @@ class Tree(JupyterMixin):
         guide_style (StyleType, optional): Style of the guide lines. Defaults to "tree.line".
         expanded (bool, optional): Also display children. Defaults to True.
         highlight (bool, optional): Highlight renderable (if str). Defaults to False.
+        hide_root (bool, optional): Hide the root node. Defaults to False.
     """
 
     def __init__(

--- a/rich/tree.py
+++ b/rich/tree.py
@@ -73,7 +73,6 @@ class Tree(JupyterMixin):
     def __rich_console__(
         self, console: "Console", options: "ConsoleOptions"
     ) -> "RenderResult":
-
         stack: List[Iterator[Tuple[bool, Tree]]] = []
         pop = stack.pop
         push = stack.append
@@ -196,7 +195,6 @@ class Tree(JupyterMixin):
 
 
 if __name__ == "__main__":  # pragma: no cover
-
     from rich.console import Group
     from rich.markdown import Markdown
     from rich.panel import Panel


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This pull request adds docstrings to missing arguments I have noticed in `panel.py` and `tree.py`.
Please review and merge when ready. Thank you!