### PR TITLE
Enable per-column enabling or disabling of highlighting

### DIFF
--- a/rich/table.py
+++ b/rich/table.py
@@ -366,6 +366,7 @@ class Table(JupyterMixin):
         footer: "RenderableType" = "",
         *,
         header_style: Optional[StyleType] = None,
+        highlight: Optional[bool] = None,
         footer_style: Optional[StyleType] = None,
         style: Optional[StyleType] = None,
         justify: "JustifyMethod" = "left",
@@ -385,6 +386,7 @@ class Table(JupyterMixin):
             footer (RenderableType, optional): Text or renderable for the footer.
                 Defaults to "".
             header_style (Union[str, Style], optional): Style for the header, or None for default. Defaults to None.
+            highlight (bool, optional): Whether to highlight the text. The default of None uses the value of the table (self) object.
             footer_style (Union[str, Style], optional): Style for the footer, or None for default. Defaults to None.
             style (Union[str, Style], optional): Style for the column cells, or None for default. Defaults to None.
             justify (JustifyMethod, optional): Alignment for cells. Defaults to "left".
@@ -402,6 +404,7 @@ class Table(JupyterMixin):
             header=header,
             footer=footer,
             header_style=header_style or "",
+            highlight=highlight if highlight is not None else self.highlight,
             footer_style=footer_style or "",
             style=style or "",
             justify=justify,


### PR DESCRIPTION
Defaults to the value of the self.table when the default value of None is unchanged.

It seems like the Column constructor didn't receive a `highlight` value, so I guess that it used to receive a highlight value at a later point. Someone who knows the project better could comment on that.

## Type of changes

-> New feature

## Checklist

This is more of a proof of concept than an actual pull request. 

