### PR TITLE
Update progress.py: doc: Progress.default_columns -> Progress.get_def…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -71,3 +71,4 @@ The following people have contributed to the development of Rich:
 - [Qiming Xu](https://github.com/xqm32)
 - [James Addison](https://github.com/jayaddison)
 - [Pierro](https://github.com/xpierroz)
+- [Bernhard Wagner](https://github.com/bwagner)

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -1113,7 +1113,7 @@ class Progress(JupyterMixin):
 
             progress = Progress(
                 SpinnerColumn(),
-                *Progress.default_columns(),
+                *Progress.get_default_columns(),
                 "Elapsed:",
                 TimeElapsedColumn(),
             )


### PR DESCRIPTION
Update `progress.py`: docstring: 
`Progress.default_columns()` -> `Progress.get_default_columns()`

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

It fixes the example in the docstring for `Progress.get_default_columns()`:
`Progress.default_columns()` is `Progress.get_default_columns()`