### PR TITLE
Corrected Typo in Portuguese README

### DIFF
--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -354,7 +354,7 @@ O screenshot a seguir é do resultado do [exemplo de colunas](https://github.com
 
 O Rich pode renderizar [markdown](https://rich.readthedocs.io/en/latest/markdown.html) e faz um bom trabalho de conversão do formato para o terminal.
 
-Para renderizar markdowm, importe a classe `Markdown` e instancie com a string que contém o código markdown. Depois, imprima o objeto no console. Por exemplo:
+Para renderizar markdown, importe a classe `Markdown` e instancie com a string que contém o código markdown. Depois, imprima o objeto no console. Por exemplo:
 
 ```python
 from rich.console import Console


### PR DESCRIPTION
I fixed a minor typo in the Portuguese version of the README file. The word "Markdowm" should be "Markdown". This improves the clarity of the document. I am searching for another typo, but i can't find other typo, this is good 😃.   I have a issue asking for fix the typo [here](https://github.com/Textualize/rich/issues/3172).

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [X] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

I fixed a minor typo in the Portuguese version of the README file. The word "Markdowm" should be "Markdown". This improves the clarity of the document. I am searching for another typo, but i can't find another typo, this is good 😃.  
I have a issue asking for fix the typo [here](https://github.com/Textualize/rich/issues/3172).
