### PR TITLE
Fix a few typos in the repository that were resulting in the codespel…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -984,7 +984,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added rich.live https://github.com/textualize/rich/pull/382
-- Added algin parameter to Rule and Console.rule
+- Added align parameter to Rule and Console.rule
 - Added rich.Status class and Console.status
 - Added getitem to Text
 - Added style parameter to Console.log

--- a/docs/source/style.rst
+++ b/docs/source/style.rst
@@ -106,7 +106,7 @@ You can parse a style definition explicitly with the :meth:`~rich.style.Style.pa
 Style Themes
 ------------
 
-If you re-use styles it can be a maintenance headache if you ever want to modify an attribute or color -- you would have to change every line where the style is used. Rich provides a :class:`~rich.theme.Theme` class which you can use to define custom styles that you can refer to by name. That way you only need to update your styles in one place.
+If you reuse styles it can be a maintenance headache if you ever want to modify an attribute or color -- you would have to change every line where the style is used. Rich provides a :class:`~rich.theme.Theme` class which you can use to define custom styles that you can refer to by name. That way you only need to update your styles in one place.
 
 Style themes can make your code more semantic, for instance a style called ``"warning"`` better expresses intent that ``"italic magenta underline"``.
 

--- a/rich/align.py
+++ b/rich/align.py
@@ -27,7 +27,7 @@ class Align(JupyterMixin):
         renderable (RenderableType): A console renderable.
         align (AlignMethod): One of "left", "center", or "right""
         style (StyleType, optional): An optional style to apply to the background.
-        vertical (Optional[VerticalAlginMethod], optional): Optional vertical align, one of "top", "middle", or "bottom". Defaults to None.
+        vertical (Optional[VerticalAlignMethod], optional): Optional vertical align, one of "top", "middle", or "bottom". Defaults to None.
         pad (bool, optional): Pad the right with spaces. Defaults to True.
         width (int, optional): Restrict contents to given width, or None to use default width. Defaults to None.
         height (int, optional): Set height of align renderable, or None to fit to contents. Defaults to None.


### PR DESCRIPTION
The codespell action is failing on `master`.

This PR fixes the typos that are resulting in this failure.