### PR TITLE
Updating the example link used in downloader.py

### DIFF
--- a/examples/downloader.py
+++ b/examples/downloader.py
@@ -73,7 +73,7 @@ def download(urls: Iterable[str], dest_dir: str):
 
 
 if __name__ == "__main__":
-    # Try with https://releases.ubuntu.com/20.04/ubuntu-20.04.3-desktop-amd64.iso
+    # Try with https://releases.ubuntu.com/22.04/ubuntu-22.04.3-desktop-amd64.iso
     if sys.argv[1:]:
         download(sys.argv[1:], "./")
     else:


### PR DESCRIPTION
The original file link (ubuntu-20.04.3-desktop-amd64.iso) is now unavailable, now replaced with a link to the latest lts version of Ubuntu desktop (ubuntu-22.04.3-desktop-amd64.iso).

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description
Original link now is 404 Not Found, replaced with the link of latest lts version of Ubuntu desktop.

original link
```plain
$ curl --HEAD https://releases.ubuntu.com/20.04/ubuntu-20.04.3-desktop-amd64.iso
HTTP/1.1 200 Connection established

HTTP/1.1 404 Not Found
Date: Tue, 28 Nov 2023 05:58:37 GMT
Server: Apache/2.4.29 (Ubuntu)
Content-Type: text/html; charset=iso-8859-1
```
new link
```plain
$ curl --HEAD https://releases.ubuntu.com/22.04/ubuntu-22.04.3-desktop-amd64.iso
HTTP/1.1 200 Connection established

HTTP/1.1 200 OK
Date: Tue, 28 Nov 2023 06:00:32 GMT
Server: Apache/2.4.29 (Ubuntu)
Last-Modified: Tue, 08 Aug 2023 01:19:36 GMT
ETag: "12c44a000-6025f27ffd9c2"
Accept-Ranges: bytes
Content-Length: 5037662208
Content-Type: application/x-iso9660-image
```

