### PR TITLE
Add 'completed' parameter to 'track' function for resumable progress

### DIFF
--- a/rich/progress.py
+++ b/rich/progress.py
@@ -1206,7 +1206,7 @@ class Progress(JupyterMixin):
         if task_id is None:
             task_id = self.add_task(description, total=total, completed=completed)
         else:
-            self.update(task_id, total=total)
+            self.update(task_id, total=total, completed=completed)
 
         if self.live.auto_refresh:
             with _TrackThread(self, task_id, update_period) as track_thread:

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -104,6 +104,7 @@ def track(
     sequence: Union[Sequence[ProgressType], Iterable[ProgressType]],
     description: str = "Working...",
     total: Optional[float] = None,
+    completed: int = 0,
     auto_refresh: bool = True,
     console: Optional[Console] = None,
     transient: bool = False,
@@ -123,6 +124,7 @@ def track(
         sequence (Iterable[ProgressType]): A sequence (must support "len") you wish to iterate over.
         description (str, optional): Description of task show next to progress bar. Defaults to "Working".
         total: (float, optional): Total number of steps. Default is len(sequence).
+        completed (int, optional): Number of steps completed so far. Defaults to 0.
         auto_refresh (bool, optional): Automatic refresh, disable to force a refresh after each iteration. Default is True.
         transient: (bool, optional): Clear the progress on exit. Defaults to False.
         console (Console, optional): Console to write to. Default creates internal Console instance.
@@ -166,7 +168,7 @@ def track(
 
     with progress:
         yield from progress.track(
-            sequence, total=total, description=description, update_period=update_period
+            sequence, total=total, completed=completed, description=description, update_period=update_period
         )
 
 
@@ -1180,6 +1182,7 @@ class Progress(JupyterMixin):
         self,
         sequence: Union[Iterable[ProgressType], Sequence[ProgressType]],
         total: Optional[float] = None,
+        completed: int = 0,
         task_id: Optional[TaskID] = None,
         description: str = "Working...",
         update_period: float = 0.1,
@@ -1189,6 +1192,7 @@ class Progress(JupyterMixin):
         Args:
             sequence (Sequence[ProgressType]): A sequence of values you want to iterate over and track progress.
             total: (float, optional): Total number of steps. Default is len(sequence).
+            completed (int, optional): Number of steps completed so far. Defaults to 0.
             task_id: (TaskID): Task to track. Default is new task.
             description: (str, optional): Description of task, if new task is created.
             update_period (float, optional): Minimum time (in seconds) between calls to update(). Defaults to 0.1.
@@ -1200,7 +1204,7 @@ class Progress(JupyterMixin):
             total = float(length_hint(sequence)) or None
 
         if task_id is None:
-            task_id = self.add_task(description, total=total)
+            task_id = self.add_task(description, total=total, completed=completed)
         else:
             self.update(task_id, total=total)
 


### PR DESCRIPTION
This commit introduces a new 'completed' parameter to the 'track' function in order to support resumable progress. Now users can specify the starting point for progress, making it easier to implement progress resumption.

## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Add 'completed' parameter to 'track' function for resumable progress.