### PR TITLE
Mxp support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.7.1] - 2023-12-3
+
+### Added
+
+- Preliminary MXP support to Styles and Console.
+
 ## [13.7.0] - 2023-11-15
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ The following people have contributed to the development of Rich:
 <!-- Add your name below, sort alphabetically by surname. Link to GitHub profile / your home page. -->
 
 - [Patrick Arminio](https://github.com/patrick91)
+- [Andrew Bastien](https://github.com/volundmush)
 - [Gregory Beauregard](https://github.com/GBeauregard/pyffstream)
 - [Artur Borecki](https://github.com/pufereq)
 - [Pedro Aaron](https://github.com/paaaron)

--- a/rich/text.py
+++ b/rich/text.py
@@ -1,4 +1,5 @@
 import re
+import random
 from functools import partial, reduce
 from math import gcd
 from operator import itemgetter
@@ -34,6 +35,8 @@ if TYPE_CHECKING:  # pragma: no cover
 DEFAULT_JUSTIFY: "JustifyMethod" = "default"
 DEFAULT_OVERFLOW: "OverflowMethod" = "fold"
 
+_RE_SQUISH = re.compile("\S+")
+_RE_NOTSPACE = re.compile("[^ ]+")
 
 _re_whitespace = re.compile(r"\s+$")
 
@@ -182,6 +185,36 @@ class Text(JupyterMixin):
             return result
         return NotImplemented
 
+    def __radd__(self, other):
+        if isinstance(other, str):
+            other = self.__class__(text=other)
+            return other + self
+        return NotImplemented
+
+    def __iadd__(self, other: Any) -> "Text":
+        if isinstance(other, (str, Text)):
+            self.append(other)
+            return self
+        return NotImplemented
+
+    def __mul__(self, other):
+        if not isinstance(other, int):
+            return self
+        if other <= 0:
+            return self.__class__()
+        if other == 1:
+            return self.copy()
+        if other > 1:
+            out = self.copy()
+            for i in range(other - 1):
+                out.append(self)
+            return out
+
+    def __rmul__(self, other):
+        if not isinstance(other, int):
+            return self
+        return self * other
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Text):
             return NotImplemented
@@ -219,6 +252,12 @@ class Text(JupyterMixin):
                 # This would be a bit of work to implement efficiently
                 # For now, its not required
                 raise TypeError("slices with step!=1 are not supported")
+
+    def __format__(self, format_spec):
+        """
+        Allows use of f-strings, although styling is not preserved.
+        """
+        return self.plain.__format__(format_spec)
 
     @property
     def cell_len(self) -> int:
@@ -1327,6 +1366,256 @@ class Text(JupyterMixin):
 
         new_text = text.blank_copy("\n").join(new_lines)
         return new_text
+
+    # Begin implementing Python String Api below...
+
+    def capitalize(self):
+        return self.__class__(text=self.plain.capitalize(), style=self.style, spans=list(self.spans))
+
+    def count(self, *args, **kwargs):
+        return self.plain.count(*args, **kwargs)
+
+    def startswith(self, *args, **kwargs):
+        return self.plain.startswith(*args, **kwargs)
+
+    def endswith(self, *args, **kwargs):
+        return self.plain.endswith(*args, **kwargs)
+
+    def find(self, *args, **kwargs):
+        return self.plain.find(*args, **kwargs)
+
+    def index(self, *args, **kwargs):
+        return self.plain.index(*args, **kwargs)
+
+    def isalnum(self):
+        return self.plain.isalnum()
+
+    def isalpha(self):
+        return self.plain.isalpha()
+
+    def isdecimal(self):
+        return self.plain.isdecimal()
+
+    def isdigit(self):
+        return self.plain.isdigit()
+
+    def isidentifier(self):
+        return self.plain.isidentifier()
+
+    def islower(self):
+        return self.plain.islower()
+
+    def isnumeric(self):
+        return self.plain.isnumeric()
+
+    def isprintable(self):
+        return self.plain.isprintable()
+
+    def isspace(self):
+        return self.plain.isspace()
+
+    def istitle(self):
+        return self.plain.istitle()
+
+    def isupper(self):
+        return self.plain.isupper()
+
+    def center(self, width, fillchar=" "):
+        changed = self.plain.center(width, fillchar)
+        start = changed.find(self.plain)
+        lside = changed[:start]
+        rside = changed[len(lside) + len(self.plain) :]
+        idx = self.disassemble_bits()
+        new_idx = list()
+        for c in lside:
+            new_idx.append((None, c))
+        new_idx.extend(idx)
+        for c in rside:
+            new_idx.append((None, c))
+        return self.__class__.assemble_bits(new_idx)
+
+    def ljust(self, width: int, fillchar: Union[str, "MudText"] = " "):
+        diff = width - len(self)
+        out = self.copy()
+        if diff <= 0:
+            return out
+        else:
+            if isinstance(fillchar, str):
+                fillchar = self.__class__(fillchar)
+            out.append(fillchar * diff)
+            return out
+
+    def rjust(self, width: int, fillchar: Union[str, "MudText"] = " "):
+        diff = width - len(self)
+        if diff <= 0:
+            return self.copy()
+        else:
+            if isinstance(fillchar, str):
+                fillchar = self.__class__(fillchar)
+            out = fillchar * diff
+            out.append(self)
+            return out
+
+    def lstrip(self, chars: str = None):
+        lstripped = self.plain.lstrip(chars)
+        strip_count = len(self.plain) - len(lstripped)
+        return self[strip_count:]
+
+    def strip(self, chars: str = " "):
+        out_map = self.disassemble_bits()
+        for i, e in enumerate(out_map):
+            if e[1] != chars:
+                out_map = out_map[i:]
+                break
+        out_map.reverse()
+        for i, e in enumerate(out_map):
+            if e[1] != chars:
+                out_map = out_map[i:]
+                break
+        out_map.reverse()
+        return self.__class__.assemble_bits(out_map)
+
+    def replace(self, old: str, new: Union[str, "Text"], count=None) -> "Text":
+        if not (indexes := self.find_all(old)):
+            return self.clone()
+        if count and count > 0:
+            indexes = indexes[:count]
+        old_len = len(old)
+        new_len = len(new)
+        other = self.clone()
+        markup_idx_map = self.disassemble_bits()
+        other_map = other.disassemble_bits()
+
+        for idx in reversed(indexes):
+            final_markup = markup_idx_map[idx + old_len][0]
+            diff = abs(old_len - new_len)
+            replace_chars = min(new_len, old_len)
+            # First, replace any characters that overlap.
+            for i in range(replace_chars):
+                other_map[idx + i] = (markup_idx_map[idx + i][0], new[i])
+            if old_len == new_len:
+                pass  # the nicest case. nothing else needs doing.
+            elif old_len > new_len:
+                # slightly complex. pop off remaining characters.
+                for i in range(diff):
+                    deleted = other_map.pop(idx + new_len)
+            elif new_len > old_len:
+                # slightly complex. insert new characters.
+                for i in range(diff):
+                    other_map.insert(
+                        idx + old_len + i, (final_markup, new[old_len + i])
+                    )
+
+        return self.__class__.assemble_bits(other_map)
+
+    def find_all(self, sub: str):
+        indexes = list()
+        start = 0
+        while True:
+            start = self.plain.find(sub, start)
+            if start == -1:
+                return indexes
+            indexes.append(start)
+            start += len(sub)
+
+    def scramble(self):
+        idx = self.disassemble_bits()
+        random.shuffle(idx)
+        return self.__class__.assemble_bits(idx)
+
+    def reverse(self):
+        idx = self.disassemble_bits()
+        idx.reverse()
+        return self.__class__.assemble_bits(idx)
+
+    @classmethod
+    def assemble_bits(cls, idx: List[Tuple[Optional[Union[str, Style, None]], str]]):
+        out = cls()
+        for i, t in enumerate(idx):
+            s = [Span(0, 1, t[0])]
+            out.append_text(cls(text=t[1], spans=s))
+        return out
+
+    def style_at_index(self, offset: int) -> Style:
+        if offset < 0:
+            offset = len(self) + offset
+        style = Style.null()
+        for start, end, span_style in self._spans:
+            if end > offset >= start:
+                style = style + span_style
+        return style
+
+    def disassemble_bits(self) -> List[Tuple[Optional[Union[str, Style, None]], str]]:
+        idx = list()
+        for i, c in enumerate(self.plain):
+            idx.append((self.style_at_index(i), c))
+        return idx
+
+    def serialize(self) -> dict:
+        def ser_style(style):
+            if isinstance(style, str):
+                style = Style.parse(style)
+            if not isinstance(style, Style):
+                style = Style.upgrade(style)
+            return style.serialize()
+
+        def ser_span(span):
+            if not span.style:
+                return None
+            return {
+                "start": span.start,
+                "end": span.end,
+                "style": ser_style(span.style),
+            }
+
+        out = {"text": self.plain}
+
+        if self.style:
+            out["style"] = ser_style(self.style)
+
+        out_spans = [s for span in self.spans if (s := ser_span(span))]
+
+        if out_spans:
+            out["spans"] = out_spans
+
+        return out
+
+    @classmethod
+    def deserialize(cls, data) -> "Text":
+        text = data.get("text", None)
+        if text is None:
+            return cls("")
+        style = data.get("style", None)
+        if style:
+            style = Style(**style)
+
+        spans = data.get("spans", None)
+
+        if spans:
+            spans = [Span(s["start"], s["end"], Style(**s["style"])) for s in spans]
+
+        return cls(text=text, style=style, spans=spans)
+
+    def squish(self) -> "MudText":
+        """
+        Removes leading and trailing whitespace, and coerces all internal whitespace sequences
+        into at most a single space. Returns the results.
+        """
+        out = list()
+        matches = _RE_SQUISH.finditer(self.plain)
+        for match in matches:
+            out.append(self[match.start() : match.end()])
+        return self.__class__(" ").join(out)
+
+    def squish_spaces(self) -> "MudText":
+        """
+        Like squish, but retains newlines and tabs. Just squishes spaces.
+        """
+        out = list()
+        matches = _RE_NOTSPACE.finditer(self.plain)
+        for match in matches:
+            out.append(self[match.start() : match.end()])
+        return self.__class__(" ").join(out)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -2,7 +2,7 @@ import pytest
 
 from rich import errors
 from rich.color import Color, ColorSystem, ColorType
-from rich.style import Style, StyleStack
+from rich.style import Style, StyleStack, MXP
 
 
 def test_str():
@@ -251,3 +251,13 @@ def test_clear_meta_and_links():
     assert clear_style.bgcolor == Color.parse("black")
     assert clear_style.bold
     assert not clear_style.italic
+
+
+def test_mxp():
+    m = MXP("send", "command1|command2", {"hint": "First Command|Second Command"})
+    rendered = m.render("This text is MXP.")
+
+    assert (
+        rendered
+        == '\x1b[4z<send "command1|command2" hint="First Command|Second Command">This text is MXP.\x1b[4z</send>'
+    )


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [X ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description
This is a second attempt to add official MXP support to Rich to make it more suitable for use with MUDs as a side-use.

Rich is the absolute best Python ANSI library, and, thus far, the only one I've been able to get to work with my Python MU* projects. So, it would be amazing to me if we could get official support for MXP in.

MXP, or Mud eXtension Protocol, is a feature used in MUDs which turns the outgoing ANSI text into a XML stream (although MXP elements aren't always proper XML, all other rules of XML/HTML escaping apply). Its specification can be found here:
https://www.zuggsoft.com/zmud/mxp.htm

The current way I've figured out to make this work is to add an `_mxp` property on Styles which can take a `rich.style.MXP` object. Unfortunately, I have no idea how this could ever be accessible to bbcode.