### PR TITLE
Make the Console generic on the file type

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -29,6 +29,7 @@ from typing import (
     TextIO,
     Tuple,
     Type,
+    TypeVar,
     Union,
     cast,
 )
@@ -591,7 +592,10 @@ def detect_legacy_windows() -> bool:
     return WINDOWS and not get_windows_console_features().vt
 
 
-class Console:
+IOType = TypeVar("IOType", bound=IO[str])
+
+
+class Console(Generic[IOType]):
     """A high level console interface.
 
     Args:
@@ -641,7 +645,7 @@ class Console:
         soft_wrap: bool = False,
         theme: Optional[Theme] = None,
         stderr: bool = False,
-        file: Optional[IO[str]] = None,
+        file: Optional[IOType] = None,
         quiet: bool = False,
         width: Optional[int] = None,
         height: Optional[int] = None,
@@ -757,7 +761,7 @@ class Console:
         return f"<console width={self.width} {self._color_system!s}>"
 
     @property
-    def file(self) -> IO[str]:
+    def file(self) -> IOType:
         """Get the file object to write to."""
         file = self._file or (sys.stderr if self.stderr else sys.stdout)
         file = getattr(file, "rich_proxied_file", file)
@@ -766,7 +770,7 @@ class Console:
         return file
 
     @file.setter
-    def file(self, new_file: IO[str]) -> None:
+    def file(self, new_file: IOType) -> None:
         """Set a new file object."""
         self._file = new_file
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This would have saved me from having to assert on the type here: https://github.com/NeilGirdhar/tjax/commit/085a9e4ffb989b80ab236609f73e2599856138e5#diff-8d12e9756f49b99f6d43b0863bf279057e145f38b98db4c30522b1b14138bd5c