### PR TITLE
Add "crop_top" and "ellipsis_top" options for vertical overflow of live display

### DIFF
--- a/docs/source/live.rst
+++ b/docs/source/live.rst
@@ -3,7 +3,7 @@
 Live Display
 ============
 
-Progress bars and status indicators use a *live* display to animate parts of the terminal. You can build custom live displays with the :class:`~rich.live.Live` class. 
+Progress bars and status indicators use a *live* display to animate parts of the terminal. You can build custom live displays with the :class:`~rich.live.Live` class.
 
 For a demonstration of a live display, run the following command::
 
@@ -72,7 +72,7 @@ You can also change the renderable on-the-fly by calling the :meth:`~rich.live.L
 Alternate screen
 ~~~~~~~~~~~~~~~~
 
-You can opt to show a Live display in the "alternate screen" by setting ``screen=True`` on the constructor. This will allow your live display to go full screen and restore the command prompt on exit. 
+You can opt to show a Live display in the "alternate screen" by setting ``screen=True`` on the constructor. This will allow your live display to go full screen and restore the command prompt on exit.
 
 You can use this feature in combination with :ref:`Layout` to display sophisticated terminal "applications".
 
@@ -80,7 +80,7 @@ Transient display
 ~~~~~~~~~~~~~~~~~
 
 Normally when you exit live context manager (or call :meth:`~rich.live.Live.stop`) the last refreshed item remains in the terminal with the cursor on the following line.
-You can also make the live display disappear on exit by setting ``transient=True`` on the Live constructor. 
+You can also make the live display disappear on exit by setting ``transient=True`` on the Live constructor.
 
 Auto refresh
 ~~~~~~~~~~~~
@@ -98,7 +98,9 @@ By default, the live display will display ellipsis if the renderable is too larg
 ``vertical_overflow`` argument on the :class:`~rich.live.Live` constructor.
 
 - "crop" Show renderable up to the terminal height. The rest is hidden.
+- "crop_top" Same as above, but renderable is cropped at the top instead of the bottom.
 - "ellipsis" Similar to crop except last line of the terminal is replaced with "...". This is the default behavior.
+- "ellipsis_top" Same as above, but the first line of the terminal is replaced with "...".
 - "visible" Will allow the whole renderable to be shown. Note that the display cannot be properly cleared in this mode.
 
 .. note::

--- a/rich/live_render.py
+++ b/rich/live_render.py
@@ -14,7 +14,9 @@ from .segment import ControlType, Segment
 from .style import StyleType
 from .text import Text
 
-VerticalOverflowMethod = Literal["crop", "ellipsis", "visible"]
+VerticalOverflowMethod = Literal[
+    "crop", "crop_top", "ellipsis", "ellipsis_top", "visible"
+]
 
 
 class LiveRender:
@@ -92,6 +94,9 @@ class LiveRender:
             if self.vertical_overflow == "crop":
                 lines = lines[: options.size.height]
                 shape = Segment.get_shape(lines)
+            elif self.vertical_overflow == "crop_top":
+                lines = lines[height - options.size.height :]
+                shape = Segment.get_shape(lines)
             elif self.vertical_overflow == "ellipsis":
                 lines = lines[: (options.size.height - 1)]
                 overflow_text = Text(
@@ -102,6 +107,17 @@ class LiveRender:
                     style="live.ellipsis",
                 )
                 lines.append(list(console.render(overflow_text)))
+                shape = Segment.get_shape(lines)
+            elif self.vertical_overflow == "ellipsis_top":
+                lines = lines[height - options.size.height + 1 :]
+                overflow_text = Text(
+                    "...",
+                    overflow="crop",
+                    justify="center",
+                    end="",
+                    style="live.ellipsis",
+                )
+                lines.insert(0, list(console.render(overflow_text)))
                 shape = Segment.get_shape(lines)
         self._shape = shape
 

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -98,6 +98,40 @@ def test_growing_display_overflow_crop() -> None:
     )
 
 
+def test_growing_display_overflow_ellipsis_top() -> None:
+    console = create_capture_console(height=5)
+    console.begin_capture()
+    with Live(
+        console=console, auto_refresh=False, vertical_overflow="ellipsis_top"
+    ) as live:
+        display = ""
+        for step in range(10):
+            display += f"Step {step}\n"
+            live.update(display, refresh=True)
+    output = console.end_capture()
+    assert (
+        output
+        == "\x1b[?25lStep 0\n\r\x1b[2K\x1b[1A\x1b[2KStep 0\nStep 1\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 0\nStep 1\nStep 2\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 0\nStep 1\nStep 2\nStep 3\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K                            ...                             \nStep 2\nStep 3\nStep 4\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K                            ...                             \nStep 3\nStep 4\nStep 5\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K                            ...                             \nStep 4\nStep 5\nStep 6\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K                            ...                             \nStep 5\nStep 6\nStep 7\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K                            ...                             \nStep 6\nStep 7\nStep 8\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K                            ...                             \nStep 7\nStep 8\nStep 9\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 0\nStep 1\nStep 2\nStep 3\nStep 4\nStep 5\nStep 6\nStep 7\nStep 8\nStep 9\n\n\x1b[?25h"
+    )
+
+
+def test_growing_display_overflow_crop_top() -> None:
+    console = create_capture_console(height=5)
+    console.begin_capture()
+    with Live(
+        console=console, auto_refresh=False, vertical_overflow="crop_top"
+    ) as live:
+        display = ""
+        for step in range(10):
+            display += f"Step {step}\n"
+            live.update(display, refresh=True)
+    output = console.end_capture()
+    assert (
+        output
+        == "\x1b[?25lStep 0\n\r\x1b[2K\x1b[1A\x1b[2KStep 0\nStep 1\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 0\nStep 1\nStep 2\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 0\nStep 1\nStep 2\nStep 3\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 1\nStep 2\nStep 3\nStep 4\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 2\nStep 3\nStep 4\nStep 5\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 3\nStep 4\nStep 5\nStep 6\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 4\nStep 5\nStep 6\nStep 7\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 5\nStep 6\nStep 7\nStep 8\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 6\nStep 7\nStep 8\nStep 9\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 0\nStep 1\nStep 2\nStep 3\nStep 4\nStep 5\nStep 6\nStep 7\nStep 8\nStep 9\n\n\x1b[?25h"
+    )
+
+
 def test_growing_display_overflow_visible() -> None:
     console = create_capture_console(height=5)
     console.begin_capture()


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Hi!

I tried to use Live to display continuously updating stream of text and realized that existing vertical overflow options are pretty inconvenient. I'd like new lines to appear at the bottom of the console window so that only the latest information is displayed. So I added "crop_top" option for it, and also "ellipsis_top" for symmetry.