### PR TITLE
Added customization to the  illegal_choice_message. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Adds missing parameters to Panel.fit https://github.com/Textualize/rich/issues/3142
+- Added a addtional parameter to prompt class (illegal_choice_message).
 
 ### Fixed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,6 +39,7 @@ The following people have contributed to the development of Rich:
 - [Paul McGuire](https://github.com/ptmcg)
 - [Antony Milne](https://github.com/AntonyMilneQB)
 - [Michael Milton](https://github.com/multimeric)
+- [Samuel Morris](https://github.com/SamuelMorrisProjects)
 - [Martina Oefelein](https://github.com/oefe)
 - [Nathan Page](https://github.com/nathanrpage97)
 - [Dave Pearson](https://github.com/davep/)
@@ -76,3 +77,4 @@ The following people have contributed to the development of Rich:
 - [Pierro](https://github.com/xpierroz)
 - [Bernhard Wagner](https://github.com/bwagner)
 - [Aaron Beaudoin](https://github.com/AaronBeaudoin)
+

--- a/docs/source/prompt.rst
+++ b/docs/source/prompt.rst
@@ -13,17 +13,17 @@ You can set a default value which will be returned if the user presses return wi
     >>> from rich.prompt import Prompt
     >>> name = Prompt.ask("Enter your name", default="Paul Atreides")
 
-If you supply a list of choices, the prompt will loop until the user enters one of the supplied choices.::
+If you supply a list of choices, the prompt will loop until the user enters one of the supplied choices::
 
     >>> from rich.prompt import Prompt
     >>> name = Prompt.ask("Enter your name", choices=["Paul", "Jessica", "Duncan"], default="Paul")
 
-Additionally, if the user does not choose one of the supplied names a error message will be outputted.::
+Additionally, if the user does not choose one of the supplied names a error message will be outputted::
 
     >>> from rich.prompt import Prompt
     >>> name = Prompt.ask("Pick a name please", choices=("Paul", "Jessica", "Duncan"), illegal_choice_message="[prompt.invalid.choice]That name is not available")
 
-As seen above, this error message can be changed using the illegal message parameter. The error message may be given as a string (which may contain :ref:`console_markup` and emoji code) or as a :class:`~rich.text.Text` instance.::
+As seen above, this error message can be changed using the illegal message parameter. The error message may be given as a string (which may contain :ref:`console_markup` and emoji code) or as a :class:`~rich.text.Text` instance.
 
 In addition to :class:`~rich.prompt.Prompt` which returns strings, you can also use :class:`~rich.prompt.IntPrompt` which asks the user for an integer, and :class:`~rich.prompt.FloatPrompt` for floats.
 

--- a/docs/source/prompt.rst
+++ b/docs/source/prompt.rst
@@ -13,10 +13,17 @@ You can set a default value which will be returned if the user presses return wi
     >>> from rich.prompt import Prompt
     >>> name = Prompt.ask("Enter your name", default="Paul Atreides")
 
-If you supply a list of choices, the prompt will loop until the user enters one of the choices::
+If you supply a list of choices, the prompt will loop until the user enters one of the supplied choices.::
 
     >>> from rich.prompt import Prompt
     >>> name = Prompt.ask("Enter your name", choices=["Paul", "Jessica", "Duncan"], default="Paul")
+
+Additionally, if the user does not choose one of the supplied names a error message will be outputted.::
+
+    >>> from rich.prompt import Prompt
+    >>> name = Prompt.ask("Pick a name please", choices=("Paul", "Jessica", "Duncan"), illegal_choice_message="[prompt.invalid.choice]That name is not available")
+
+As seen above, this error message can be changed using the illegal message parameter. The error message may be given as a string (which may contain :ref:`console_markup` and emoji code) or as a :class:`~rich.text.Text` instance.::
 
 In addition to :class:`~rich.prompt.Prompt` which returns strings, you can also use :class:`~rich.prompt.IntPrompt` which asks the user for an integer, and :class:`~rich.prompt.FloatPrompt` for floats.
 

--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -38,14 +38,13 @@ class PromptBase(Generic[PromptType]):
         choices (List[str], optional): A list of valid choices. Defaults to None.
         show_default (bool, optional): Show default in prompt. Defaults to True.
         show_choices (bool, optional): Show choices in prompt. Defaults to True.
+        illegal_choice_message (str, optional): The message on a illegal choice. Defaults to [prompt.invalid.choice]Please select one of the available options
+
     """
 
     response_type: type = str
 
     validate_error_message = "[prompt.invalid]Please enter a valid value"
-    illegal_choice_message = (
-        "[prompt.invalid.choice]Please select one of the available options"
-    )
     prompt_suffix = ": "
 
     choices: Optional[List[str]] = None
@@ -59,8 +58,16 @@ class PromptBase(Generic[PromptType]):
         choices: Optional[List[str]] = None,
         show_default: bool = True,
         show_choices: bool = True,
+        illegal_choice_message: Optional[TextType] = (
+            "[prompt.invalid.choice]Please select one of the available options"
+        )
     ) -> None:
         self.console = console or get_console()
+        self.illegal_choice_message = (
+            Text.from_markup((illegal_choice_message), style="prompt")
+            if isinstance(illegal_choice_message, str)
+            else illegal_choice_message
+        )
         self.prompt = (
             Text.from_markup(prompt, style="prompt")
             if isinstance(prompt, str)
@@ -85,6 +92,9 @@ class PromptBase(Generic[PromptType]):
         show_choices: bool = True,
         default: DefaultType,
         stream: Optional[TextIO] = None,
+        illegal_choice_message: Optional[TextType] = (
+            "[prompt.invalid.choice]Please select one of the available options"
+        )
     ) -> Union[DefaultType, PromptType]:
         ...
 
@@ -100,6 +110,9 @@ class PromptBase(Generic[PromptType]):
         show_default: bool = True,
         show_choices: bool = True,
         stream: Optional[TextIO] = None,
+        illegal_choice_message: Optional[TextType] = (
+            "[prompt.invalid.choice]Please select one of the available options"
+        )
     ) -> PromptType:
         ...
 
@@ -115,6 +128,9 @@ class PromptBase(Generic[PromptType]):
         show_choices: bool = True,
         default: Any = ...,
         stream: Optional[TextIO] = None,
+        illegal_choice_message: Optional[TextType] = (
+            "[prompt.invalid.choice]Please select one of the available options"
+        )
     ) -> Any:
         """Shortcut to construct and run a prompt loop and return the result.
 
@@ -137,6 +153,7 @@ class PromptBase(Generic[PromptType]):
             choices=choices,
             show_default=show_default,
             show_choices=show_choices,
+            illegal_choice_message=illegal_choice_message,
         )
         return _prompt(default=default, stream=stream)
 
@@ -164,7 +181,7 @@ class PromptBase(Generic[PromptType]):
         prompt.end = ""
 
         if self.show_choices and self.choices:
-            _choices = "/".join(self.choices)
+            _choices = "/".join((self.choices))
             choices = f"[{_choices}]"
             prompt.append(" ")
             prompt.append(choices, "prompt.choices")
@@ -307,7 +324,7 @@ class IntPrompt(PromptBase[int]):
     validate_error_message = "[prompt.invalid]Please enter a valid integer number"
 
 
-class FloatPrompt(PromptBase[float]):
+class FloatPrompt(PromptBase[int]):
     """A prompt that returns a float.
 
     Example:
@@ -346,6 +363,7 @@ class Confirm(PromptBase[bool]):
 
 
 if __name__ == "__main__":  # pragma: no cover
+
     from rich import print
 
     if Confirm.ask("Run [i]prompt[/i] tests?", default=True):

--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -181,7 +181,7 @@ class PromptBase(Generic[PromptType]):
         prompt.end = ""
 
         if self.show_choices and self.choices:
-            _choices = "/".join((self.choices))
+            _choices = "/".join(self.choices)
             choices = f"[{_choices}]"
             prompt.append(" ")
             prompt.append(choices, "prompt.choices")
@@ -324,7 +324,7 @@ class IntPrompt(PromptBase[int]):
     validate_error_message = "[prompt.invalid]Please enter a valid integer number"
 
 
-class FloatPrompt(PromptBase[int]):
+class FloatPrompt(PromptBase[float]):
     """A prompt that returns a float.
 
     Example:

--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -38,7 +38,7 @@ class PromptBase(Generic[PromptType]):
         choices (List[str], optional): A list of valid choices. Defaults to None.
         show_default (bool, optional): Show default in prompt. Defaults to True.
         show_choices (bool, optional): Show choices in prompt. Defaults to True.
-        illegal_choice_message (str, optional): The message on a illegal choice. Defaults to [prompt.invalid.choice]Please select one of the available options
+        illegal_choice_message (TextType, optional): The message on a illegal choice. Defaults to [prompt.invalid.choice]Please select one of the available options
 
     """
 
@@ -145,6 +145,7 @@ class PromptBase(Generic[PromptType]):
             show_default (bool, optional): Show default in prompt. Defaults to True.
             show_choices (bool, optional): Show choices in prompt. Defaults to True.
             stream (TextIO, optional): Optional text file open for reading to get input. Defaults to None.
+            illegal_choice_message (TextType, optional): The message on a illegal choice. Defaults to [prompt.invalid.choice]Please select one of the available options.
         """
         _prompt = cls(
             prompt,


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ x] New feature
- [ x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ x] I accept that @willmcgugan may be pedantic in the code review.

## Description
I made the illegal_choice_message an optional parameter of the both the class prompt and the method ask in prompt.py. The illegal choice parameter automatically defaults to the original Text Type("[prompt.invalid.choice]Please select one of the available options."). This will allow those using the library to customize the message that is outputted to the user. I also updated the documentation to reflect this change. 
## Why 
I added this feature because to my knowledge—please correct me if I am wrong in this assumption—there is no way to change the error message outputted when a user does not pick one of the choices. I am somewhat new to programming so I could have missed something. I also feel this change will produce overall more robust code.
## Examples
**Code:**
![image](https://github.com/Textualize/rich/assets/149737652/f884169f-4e6f-449c-9f55-34ff2995a070)
**Output:**
![image](https://github.com/Textualize/rich/assets/149737652/c81e12b3-89f7-4114-8993-dc1520fa2743)
