### PR TITLE
use larger width/height defaults for non-interactive consoles

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -76,6 +76,10 @@ if TYPE_CHECKING:
 
 JUPYTER_DEFAULT_COLUMNS = 115
 JUPYTER_DEFAULT_LINES = 100
+INTERACTIVE_DEFAULT_COLUMNS = 80
+INTERACTIVE_DEFAULT_LINES = 25
+NON_INTERACTIVE_DEFAULT_COLUMNS = 32767
+NON_INTERACTIVE_DEFAULT_LINES = 32767
 WINDOWS = platform.system() == "Windows"
 
 HighlighterType = Callable[[Union[str, "Text"]], "Text"]
@@ -1001,7 +1005,9 @@ class Console:
             return ConsoleDimensions(self._width - self.legacy_windows, self._height)
 
         if self.is_dumb_terminal:
-            return ConsoleDimensions(80, 25)
+            return ConsoleDimensions(
+                INTERACTIVE_DEFAULT_COLUMNS, INTERACTIVE_DEFAULT_LINES
+            )
 
         width: Optional[int] = None
         height: Optional[int] = None
@@ -1028,8 +1034,13 @@ class Console:
             height = int(lines)
 
         # get_terminal_size can report 0, 0 if run from pseudo-terminal
-        width = width or 80
-        height = height or 25
+        if self.is_interactive:
+            width = width or INTERACTIVE_DEFAULT_COLUMNS
+            height = height or INTERACTIVE_DEFAULT_LINES
+        else:
+            width = NON_INTERACTIVE_DEFAULT_COLUMNS
+            height = NON_INTERACTIVE_DEFAULT_LINES
+
         return ConsoleDimensions(
             width - self.legacy_windows if self._width is None else self._width,
             height if self._height is None else self._height,


### PR DESCRIPTION
When a user is redirecting output to a file, or perhaps running a job non-interactively (say, via cron), arguably, it is surprising when output (such as a rich.table) is truncated to a default size of (80, 25). This change preserves that default Console.size() -> width=80, height=25, but uses larger defaults when Console.is_interactive == False.

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I am not at all sure that I'm solving the right problem here or going about it correctly, but I prefer describing what I'm trying to accomplish, via code (pull request) rather than simply descriptively, via a project issue. The basic idea here is that I _personally_ find the following result surprising:

given the following table test (basically pulled directly from the example in the documentation, here: https://rich.readthedocs.io/en/stable/tables.html#tables):

```
#!/usr/bin/env python
from rich.console import Console
from rich.table import Table

table = Table(title="Star Wars Movies")

table.add_column("Released", justify="right", style="cyan", no_wrap=True)
table.add_column("Title", style="magenta")
table.add_column("Box Office", justify="right", style="green")

table.add_row("Dec 20, 2019", "Star Wars: The Rise of Skywalker", "$952,110,690")
table.add_row("May 25, 2018", "Solo: A Star Wars Story", "$393,151,347")
table.add_row("Dec 15, 2017", "Star Wars Ep. V111: The Last Jedi", "$1,332,539,889")
table.add_row("Dec 16, 2016", "Rogue One: A Star Wars Story", "$1,332,439,889")
table.add_row("May 22, 2026", "As Yet Unnamed Amazing Next Star Wars Movie With A Really Long Name", "$999,999,999,999")

console = Console()
console.print(table)
```

I like that it truncates the table to my terminal width/height when running it interactively (say, `./print_rich_table.py`), but would prefer that it doesn't truncate and/or wrap when non-interactive, for instance, when redirecting to a file (`./print_rich_table.py > star_wars.txt`), or perhaps running a job via cron or in some other way where the expectation is for the handling of display constraints to be handled by some later user who may not be the original script runner.

I've tested this change by shrinking/growing my terminal and making sure the old behavior is preserved, as well as by updating tests/test_console.py with some new cases.

I'm happy to try to take another approach here if this doesn't make sense. Also, of course, I picked the new defaults out of thin air (just trying to come up with some reasonably large numbers to prove out the strategy).
