### PR TITLE
Fix `leading` Parameter Type In Docstring

### DIFF
--- a/rich/table.py
+++ b/rich/table.py
@@ -54,7 +54,7 @@ class Column:
         show_footer (bool, optional): Show a footer row. Defaults to False.
         show_edge (bool, optional): Draw a box around the outside of the table. Defaults to True.
         show_lines (bool, optional): Draw lines between every row. Defaults to False.
-        leading (bool, optional): Number of blank lines between rows (precludes ``show_lines``). Defaults to 0.
+        leading (int, optional): Number of blank lines between rows (precludes ``show_lines``). Defaults to 0.
         style (Union[str, Style], optional): Default style for the table. Defaults to "none".
         row_styles (List[Union, str], optional): Optional list of row styles, if more than one style is given then the styles will alternate. Defaults to None.
         header_style (Union[str, Style], optional): Style of the header. Defaults to "table.header".
@@ -167,7 +167,7 @@ class Table(JupyterMixin):
         show_footer (bool, optional): Show a footer row. Defaults to False.
         show_edge (bool, optional): Draw a box around the outside of the table. Defaults to True.
         show_lines (bool, optional): Draw lines between every row. Defaults to False.
-        leading (bool, optional): Number of blank lines between rows (precludes ``show_lines``). Defaults to 0.
+        leading (int, optional): Number of blank lines between rows (precludes ``show_lines``). Defaults to 0.
         style (Union[str, Style], optional): Default style for the table. Defaults to "none".
         row_styles (List[Union, str], optional): Optional list of row styles, if more than one style is given then the styles will alternate. Defaults to None.
         header_style (Union[str, Style], optional): Style of the header. Defaults to "table.header".


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Noticed on [the docs](https://rich.readthedocs.io/en/stable/reference/table.html) that the `leading` parameter (available for the `Table` and `Column` objects), mention that this parameter is a `bool` type, although it appears to be an `int` type and has a default value of `0`.

This PR fixes the docstrings to annotate this parameter with the correct `int` type.
