### PR TITLE
Allow __rich_class_repr__ to render

### DIFF
--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -379,11 +379,14 @@ _MAPPING_CONTAINERS = (dict, os._Environ, MappingProxyType, UserDict)
 def is_expandable(obj: Any) -> bool:
     """Check if an object may be expanded by pretty print."""
     return (
-        _safe_isinstance(obj, _CONTAINERS)
-        or (is_dataclass(obj))
-        or (hasattr(obj, "__rich_repr__"))
-        or _is_attr_object(obj)
-    ) and not isclass(obj)
+        (
+            _safe_isinstance(obj, _CONTAINERS)
+            or (is_dataclass(obj))
+            or (hasattr(obj, "__rich_repr__"))
+            or _is_attr_object(obj)
+        )
+        and not isclass(obj)
+    ) or (isclass(obj) and hasattr(obj, "__rich_class_repr__"))
 
 
 @dataclass
@@ -639,6 +642,8 @@ def traverse(
             try:
                 if hasattr(obj, "__rich_repr__") and not isclass(obj):
                     rich_repr_result = obj.__rich_repr__()
+                elif hasattr(obj, "__rich_class_repr__") and isclass(obj):
+                    rich_repr_result = obj.__rich_class_repr__()
             except Exception:
                 pass
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Allow `__rich_class_repr__` to be rendered when printing class.