### PR TITLE
Add the ability to disable the display of object attributes, or to only display selected attributes in the inspect function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add the ability to display selected attributes using rich.inspect
+
 ## [13.7.1] - 2023-02-28
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -75,4 +75,5 @@ The following people have contributed to the development of Rich:
 - [James Addison](https://github.com/jayaddison)
 - [Pierro](https://github.com/xpierroz)
 - [Bernhard Wagner](https://github.com/bwagner)
+- [Mateusz Wozny](https://github.com/mateusz-wozny)
 - [Aaron Beaudoin](https://github.com/AaronBeaudoin)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "rich"
 homepage = "https://github.com/Textualize/rich"
 documentation = "https://rich.readthedocs.io/en/latest/"
-version = "13.7.1"
+version = "13.7.2"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 authors = ["Will McGugan <willmcgugan@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "rich"
 homepage = "https://github.com/Textualize/rich"
 documentation = "https://rich.readthedocs.io/en/latest/"
-version = "13.7.2"
+version = "13.7.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 authors = ["Will McGugan <willmcgugan@gmail.com>"]
 license = "MIT"

--- a/rich/__init__.py
+++ b/rich/__init__.py
@@ -1,7 +1,7 @@
 """Rich text and beautiful formatting in the terminal."""
 
 import os
-from typing import IO, TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import IO, TYPE_CHECKING, Any, Callable, Optional, Union, Collection
 
 from ._extension import load_ipython_extension  # noqa: F401
 
@@ -130,11 +130,15 @@ def inspect(
     sort: bool = True,
     all: bool = False,
     value: bool = True,
+    attributes: bool = True,
+    attributes_to_display: Collection[str] = (),
 ) -> None:
     """Inspect any Python object.
 
     * inspect(<OBJECT>) to see summarized info.
     * inspect(<OBJECT>, methods=True) to see methods.
+    * inspect(<OBJECT>, attributes=True) to see attributes.
+    * inspect(<OBJECT>, attributes=True, attributes_to_display=["attr1", "attr2"]) to see only specified attributes.
     * inspect(<OBJECT>, help=True) to see full (non-abbreviated) help.
     * inspect(<OBJECT>, private=True) to see private attributes (single underscore).
     * inspect(<OBJECT>, dunder=True) to see attributes beginning with double underscore.
@@ -151,6 +155,8 @@ def inspect(
         sort (bool, optional): Sort attributes alphabetically. Defaults to True.
         all (bool, optional): Show all attributes. Defaults to False.
         value (bool, optional): Pretty print value. Defaults to True.
+        attributes (bool, optional): Show object attributes. Defaults to True.
+        attributes_to_display (Collection[str], optional): List of attributes to display. Defaults to (). If empty, all attributes are displayed.
     """
     _console = console or get_console()
     from rich._inspect import Inspect
@@ -169,6 +175,8 @@ def inspect(
         sort=sort,
         all=all,
         value=value,
+        attributes=attributes,
+        attributes_to_display=attributes_to_display,
     )
     _console.print(_inspect)
 

--- a/rich/_inspect.py
+++ b/rich/_inspect.py
@@ -34,6 +34,8 @@ class Inspect(JupyterMixin):
         sort (bool, optional): Sort attributes alphabetically. Defaults to True.
         all (bool, optional): Show all attributes. Defaults to False.
         value (bool, optional): Pretty print value of object. Defaults to True.
+        attributes (bool, optional): Show object attributes. Defaults to True.
+        attributes_to_display (Collection[str], optional): List of attributes to display. Defaults to (). If empty, all attributes are displayed.
     """
 
     def __init__(
@@ -49,14 +51,18 @@ class Inspect(JupyterMixin):
         sort: bool = True,
         all: bool = True,
         value: bool = True,
+        attributes: bool = True,
+        attributes_to_display: Collection[str] = (),
     ) -> None:
         self.highlighter = ReprHighlighter()
         self.obj = obj
         self.title = title or self._make_title(obj)
         if all:
-            methods = private = dunder = True
+            methods = private = dunder = attributes = True
         self.help = help
         self.methods = methods
+        self.attributes = attributes
+        self.attributes_to_display = attributes_to_display
         self.docs = docs or help
         self.private = private or dunder
         self.dunder = dunder
@@ -204,6 +210,10 @@ class Inspect(JupyterMixin):
 
                     add_row(key_text, _signature_text)
             else:
+                if not self.attributes:
+                    continue
+                if self.attributes_to_display and key not in self.attributes_to_display:
+                    continue
                 add_row(key_text, Pretty(value, highlighter=highlighter))
         if items_table.row_count:
             yield items_table

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -49,9 +49,18 @@ skip_pypy3 = pytest.mark.skipif(
 )
 
 
-def render(obj, methods=False, value=False, width=50) -> str:
+def render(
+    obj, methods=False, value=False, width=50, attributes=True, attributes_to_display=()
+) -> str:
     console = Console(file=io.StringIO(), width=width, legacy_windows=False)
-    inspect(obj, console=console, methods=methods, value=value)
+    inspect(
+        obj,
+        console=console,
+        methods=methods,
+        value=value,
+        attributes=attributes,
+        attributes_to_display=attributes_to_display,
+    )
     return console.file.getvalue()
 
 
@@ -207,6 +216,25 @@ def test_inspect_integer():
     )
     assert expected == render(1)
 
+
+def test_inspect_integer_without_attributes():
+    expected = ("╭──────────────── <class 'int'> ─────────────────╮\n"
+                "│ int([x]) -> integer                            │\n"
+                "│ int(x, base=10) -> integer                     │\n"
+                "│                                                │\n"
+                "│ 62 attribute(s) not shown. Run                 │\n"
+                "│ inspect(inspect) for options.                  │\n"
+                "╰────────────────────────────────────────────────╯\n")
+    assert expected == render(1, attributes=False)
+
+def test_inspect_integer_with_denominator():
+    expected = ("╭────── <class 'int'> ───────╮\n"
+                "│ int([x]) -> integer        │\n"
+                "│ int(x, base=10) -> integer │\n"
+                "│                            │\n"
+                "│ denominator = 1            │\n"
+                "╰────────────────────────────╯\n")
+    assert expected == render(1, attributes=True, attributes_to_display=["denominator"])
 
 def test_inspect_integer_with_value():
     expected = "╭────── <class 'int'> ───────╮\n│ int([x]) -> integer        │\n│ int(x, base=10) -> integer │\n│                            │\n│ ╭────────────────────────╮ │\n│ │ 1                      │ │\n│ ╰────────────────────────╯ │\n│                            │\n│ denominator = 1            │\n│        imag = 0            │\n│   numerator = 1            │\n│        real = 1            │\n╰────────────────────────────╯\n"


### PR DESCRIPTION
## Type of changes

- [x] New feature
- [x] Documentation / docstrings
- [x] Tests

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description
I want to use inspect method for object which have some attributes very large (for example list of 1000 items) and currently all attributes are displayed. The output is quite unreadable so I want to disable displaying object attributes or display only selected. I added parameter to enable/disable displaying object attributes and parameter to pass names of attributes I want to display (if not specified all attributes will be displayed).
