### PR TITLE
live: add "tail" vertical_overflow method

### DIFF
--- a/docs/source/live.rst
+++ b/docs/source/live.rst
@@ -3,7 +3,7 @@
 Live Display
 ============
 
-Progress bars and status indicators use a *live* display to animate parts of the terminal. You can build custom live displays with the :class:`~rich.live.Live` class. 
+Progress bars and status indicators use a *live* display to animate parts of the terminal. You can build custom live displays with the :class:`~rich.live.Live` class.
 
 For a demonstration of a live display, run the following command::
 
@@ -72,7 +72,7 @@ You can also change the renderable on-the-fly by calling the :meth:`~rich.live.L
 Alternate screen
 ~~~~~~~~~~~~~~~~
 
-You can opt to show a Live display in the "alternate screen" by setting ``screen=True`` on the constructor. This will allow your live display to go full screen and restore the command prompt on exit. 
+You can opt to show a Live display in the "alternate screen" by setting ``screen=True`` on the constructor. This will allow your live display to go full screen and restore the command prompt on exit.
 
 You can use this feature in combination with :ref:`Layout` to display sophisticated terminal "applications".
 
@@ -80,7 +80,7 @@ Transient display
 ~~~~~~~~~~~~~~~~~
 
 Normally when you exit live context manager (or call :meth:`~rich.live.Live.stop`) the last refreshed item remains in the terminal with the cursor on the following line.
-You can also make the live display disappear on exit by setting ``transient=True`` on the Live constructor. 
+You can also make the live display disappear on exit by setting ``transient=True`` on the Live constructor.
 
 Auto refresh
 ~~~~~~~~~~~~
@@ -100,6 +100,7 @@ By default, the live display will display ellipsis if the renderable is too larg
 - "crop" Show renderable up to the terminal height. The rest is hidden.
 - "ellipsis" Similar to crop except last line of the terminal is replaced with "...". This is the default behavior.
 - "visible" Will allow the whole renderable to be shown. Note that the display cannot be properly cleared in this mode.
+- "tail" Show the trailing lines of the renderable, up to the terminal height.
 
 .. note::
 

--- a/rich/live_render.py
+++ b/rich/live_render.py
@@ -14,7 +14,7 @@ from .segment import ControlType, Segment
 from .style import StyleType
 from .text import Text
 
-VerticalOverflowMethod = Literal["crop", "ellipsis", "visible"]
+VerticalOverflowMethod = Literal["crop", "ellipsis", "visible", "tail"]
 
 
 class LiveRender:
@@ -102,6 +102,17 @@ class LiveRender:
                     style="live.ellipsis",
                 )
                 lines.append(list(console.render(overflow_text)))
+                shape = Segment.get_shape(lines)
+            elif self.vertical_overflow == "tail":
+                overflow_text = Text(
+                    "...",
+                    overflow="tail",
+                    justify="center",
+                    end="",
+                    style="live.ellipsis",
+                )
+                lines = lines[-(options.size.height) : -1]
+                lines.insert(0, list(console.render(overflow_text)))
                 shape = Segment.get_shape(lines)
         self._shape = shape
 

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -113,6 +113,22 @@ def test_growing_display_overflow_visible() -> None:
     )
 
 
+def test_growing_display_overflow_tail() -> None:
+    console = create_capture_console(height=5)
+    console.begin_capture()
+    with Live(console=console, auto_refresh=False, vertical_overflow="tail") as live:
+        display = ""
+        for step in range(10):
+            display += f"Step {step}\n"
+            live.update(display, refresh=True)
+    output = console.end_capture()
+
+    assert (
+        output
+        == "\x1b[?25lStep 0\n\r\x1b[2K\x1b[1A\x1b[2KStep 0\nStep 1\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 0\nStep 1\nStep 2\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 0\nStep 1\nStep 2\nStep 3\n\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K                            ...                             \nStep 1\nStep 2\nStep 3\nStep 4\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K                            ...                             \nStep 2\nStep 3\nStep 4\nStep 5\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K                            ...                             \nStep 3\nStep 4\nStep 5\nStep 6\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K                            ...                             \nStep 4\nStep 5\nStep 6\nStep 7\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K                            ...                             \nStep 5\nStep 6\nStep 7\nStep 8\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K                            ...                             \nStep 6\nStep 7\nStep 8\nStep 9\r\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2K\x1b[1A\x1b[2KStep 0\nStep 1\nStep 2\nStep 3\nStep 4\nStep 5\nStep 6\nStep 7\nStep 8\nStep 9\n\n\x1b[?25h"
+    )
+
+
 def test_growing_display_autorefresh() -> None:
     """Test generating a table but using auto-refresh from threading"""
     console = create_capture_console(height=5)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [x] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This implements an alternative `vertical_overflow="tail"` mode for `Live`, behaving somehow like "crop" but only showing the trailing lines that fit the terminal height, adding an ellipsis at the top

[Here](https://asciinema.org/a/vkbg83LQ6u1PogViACbWodWpQ) is an example:

[![vertical_overflow_tail](https://github.com/Textualize/rich/assets/8560118/e585a5da-cd40-47d1-8f8a-690dd8d1e384)](https://asciinema.org/a/vkbg83LQ6u1PogViACbWodWpQ)