### PR TITLE
Enable rendering of rich exception objects in traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Exception objects that are `RichRenderable` are rendered, instead of using the class name and string representation https://github.com/Textualize/rich/pull/3325
+
 ## [13.7.1] - 2023-02-28
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,6 +17,7 @@ The following people have contributed to the development of Rich:
 - [James Estevez](https://github.com/jstvz)
 - [Aryaz Eghbali](https://github.com/AryazE)
 - [Oleksis Fraga](https://github.com/oleksis)
+- [Pradyun Gedam](https://github.com/pradyunsg)
 - [Andy Gimblett](https://github.com/gimbo)
 - [Michał Górny](https://github.com/mgorny)
 - [Nok Lam Chan](https://github.com/noklam)

--- a/docs/source/traceback.rst
+++ b/docs/source/traceback.rst
@@ -22,7 +22,7 @@ The :meth:`~rich.console.Console.print_exception` method will print a traceback 
         console.print_exception(show_locals=True)
 
 The ``show_locals=True`` parameter causes Rich to display the value of local variables for each frame of the traceback.
- 
+
 See `exception.py <https://github.com/willmcgugan/rich/blob/master/examples/exception.py>`_ for a larger example.
 
 
@@ -63,7 +63,7 @@ Suppressing Frames
 
 If you are working with a framework (click, django etc), you may only be interested in seeing the code from your own application within the traceback. You can exclude framework code by setting the `suppress` argument on `Traceback`, `install`, `Console.print_exception`, and `RichHandler`, which should be a list of modules or str paths.
 
-Here's how you would exclude `click <https://click.palletsprojects.com/en/8.0.x/>`_ from Rich exceptions:: 
+Here's how you would exclude `click <https://click.palletsprojects.com/en/8.0.x/>`_ from Rich exceptions::
 
     import click
     from rich.traceback import install
@@ -96,3 +96,32 @@ Here's an example of printing a recursive error::
     except Exception:
         console.print_exception(max_frames=20)
 
+Rendering Rich Exceptions
+-------------------------
+
+You can create exceptions that implement :ref:`protocol`, which would be rendered when presented in a traceback.
+
+Here's an example that renders the exception's message in a :ref:`~rich.panel.Panel` with an ASCII box::
+
+    from rich.box import ASCII
+    from rich.console import Console
+    from rich.panel import Panel
+
+
+    class MyAwesomeException(Exception):
+        def __init__(self, message: str):
+            super().__init__(message)
+            self.message = message
+
+        def __rich__(self):
+            return Panel(self.message, title="My Awesome Exception", box=ASCII)
+
+
+    def do_something():
+        raise MyAwesomeException("Something went wrong")
+
+    console = Console()
+    try:
+        do_something()
+    except Exception:
+        console.print_exception()


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

See https://github.com/Textualize/rich/discussions/2717 for discussion. This enables exceptions to be rich objects and be rendered via the rich rendering pipeline, in tracebacks. This can be tested manually by running `python -m rich.traceback` whose example now uses a rich object instead of the `NameError`.
