### PR TITLE
Don't display() spurious newlines in jupyter

### DIFF
--- a/rich/jupyter.py
+++ b/rich/jupyter.py
@@ -83,6 +83,12 @@ def _render_segments(segments: Iterable[Segment]) -> str:
 
 def display(segments: Iterable[Segment], text: str) -> None:
     """Render segments to Jupyter."""
+    segments = list(segments)
+    if not segments and not text:
+        # display() always prints a newline, so if there is no content then
+        # we don't want a single newline appearing.
+        # See https://github.com/Textualize/rich/issues/3274
+        return None
     html = _render_segments(segments)
     jupyter_renderable = JupyterRenderable(html, text)
     try:

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -30,3 +30,22 @@ def test_jupyter_lines_env():
     console = Console(
         width=40, _environ={"JUPYTER_LINES": "broken"}, force_jupyter=True
     )
+
+
+def test_jupyter_capture(monkeypatch):
+    # If inside a capture, ipython's display shouldn't be called,
+    # or we would get spurious newlines.
+    # See https://github.com/Textualize/rich/issues/3274
+    called = False
+
+    def mock_display(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("IPython.display.display", mock_display)
+    console = Console(force_jupyter=True)
+    with console.capture():
+        console.print("foo")
+    assert not called
+    console.print("foo")
+    assert called


### PR DESCRIPTION
Fixes #3274

I couldn't think of a way to test the "real" behavior that we are looking for, which is "are random newlines appearing in jupyter's output?", so I had to settle for the proxy of "is ipython's display() ever called?".

I materialized the Iterable[Segment]s into a list, IDK if there are some performance concerns with this (we're about to materialize them all to strings anyway???). If so then I could come up with a less-clean way of checking for "did we get passed nothing")

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.
