### PR TITLE
Add enable_link_path option to tracebacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add enable_link_path for traceback.link and traceback.Traceback similar to logging.RichHandler
+
 ## [13.7.1] - 2024-02-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add enable_link_path for traceback.link and traceback.Traceback similar to logging.RichHandler
+- Add enable_link_path for traceback.link and traceback.Traceback similar to logging.RichHandler https://github.com/Textualize/rich/pull/3338
 
 ## [13.7.1] - 2024-02-28
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,3 +76,4 @@ The following people have contributed to the development of Rich:
 - [Pierro](https://github.com/xpierroz)
 - [Bernhard Wagner](https://github.com/bwagner)
 - [Aaron Beaudoin](https://github.com/AaronBeaudoin)
+- [Benedikt Volkmer](https://github.com/bvolkmer)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

I added linking of paths in tracebacks. I'm not sure if there is a more elegant way of combining the `Style(link=...)` with `'pygments.string'`.
