### PR TITLE
Documentation Update - Projects using Rich

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,8 +440,30 @@ See also Rich's sister project, [Textual](https://github.com/Textualize/textual)
 
 # Projects using Rich
 
-For some examples of projects using Rich, see the [Rich Gallery](https://www.textualize.io/rich/gallery) on [Textualize.io](https://www.textualize.io).
+For some examples of projects using Rich:
 
-Would you like to add your own project to the gallery? You can! Follow [these instructions](https://www.textualize.io/gallery-instructions).
+- [BrancoLab/BrainRender](https://github.com/BrancoLab/BrainRender)
+   A python package for the visualization of three dimensional neuro-anatomical data
+- [Ciphey/Ciphey](https://github.com/Ciphey/Ciphey)
+   Automated decryption tool
+- [emeryberger/scalene](https://github.com/emeryberger/scalene)
+   A high-performance, high-precision CPU and memory profiler for Python
+- [hedythedev/StarCli](https://github.com/hedythedev/starcli)
+   Browse GitHub trending projects from your command line
+- [intel/cve-bin-tool](https://github.com/intel/cve-bin-tool)
+   This tool scans for a number of common, vulnerable components (openssl, libpng, libxml2, expat and a few others) to let you know if your system includes common libraries with known vulnerabilities.
+- [nf-core/tools](https://github.com/nf)
+   Python package with helper tools for the nf-core community.
+- [cansarigol/pdbr](https://github.com/cansarigol/pdbr)
+   pdb + Rich library for enhanced debugging
+- [plant99/felicette](https://github.com/plant99/felicette)
+   Satellite imagery for dummies.
+- [seleniumbase/SeleniumBase](https://github.com/seleniumbase/SeleniumBase)
+   Automate & test 10x faster with Selenium & pytest.
+- [smacke/ffsubsync](https://github.com/smacke/ffsubsync)
+   Automagically synchronize subtitles with video.
+- [tryolabs/norfair](https://github.com/tryolabs/norfair)
+   Lightweight Python library for adding real-time 2D object tracking to any detector.
+- +[There are many more](https://github.com/textualize/rich/network/dependents)!
 
 <!-- This is a test, no need to translate -->


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [X] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description:

**Please describe your changes here. If this fixes a bug, please link to the issue, if possible:**

Removed the linked Textualize Rich Gallery as it produces a 404 error. This has been replaced with a list of Projects that use Rich as per other language readme markdown files. 

**Still to be updated:**
* README.tr.md
* README.fa.md

