### PR TITLE
2286 pep657 error code ranges in traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Highlight error code ranges in traceback similar to [PEP657](https://peps.python.org/pep-0657/) https://github.com/Textualize/rich/issues/2286
+
 ## [13.7.1] - 2024-02-28
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,3 +76,4 @@ The following people have contributed to the development of Rich:
 - [Pierro](https://github.com/xpierroz)
 - [Bernhard Wagner](https://github.com/bwagner)
 - [Aaron Beaudoin](https://github.com/AaronBeaudoin)
+- [Jacob Thompson](https://github.com/Gothingbop)

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import linecache
 import os
 import platform
+import sys
 import itertools
 from dataclasses import dataclass, field
 from types import ModuleType, TracebackType

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -178,8 +178,8 @@ class Frame:
     name: str
     line: str = ""
     locals: Optional[Dict[str, pretty.Node]] = None
-    colno: Optional[int] = 0
-    end_colno: Optional[int] = 0
+    colno: Optional[int] = None
+    end_colno: Optional[int] = None
 
 
 @dataclass


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Pull request for https://github.com/Textualize/rich/issues/2286

Replicates some of the functionality in [PEP 657](https://peps.python.org/pep-0657) by extracting the col range of the exception and adds the style to the Syntax using `Syntax.stylize_range()`.

Effectively repurposes code found in some private functions in the base `traceback` module: `_get_code_position()` and `_walk_tb_with_full_positions()`. The code would be cleaner if those functions were not private or we were OK with using private functions (raises an error when running the mypy type checking).

I can also abstract the loop into a generator to more closely replicate the `_walk_tb_with_full_positions()` functionality, but I'm unsure where the best spot for that would be.

### Base Python traceback
![image](https://github.com/Textualize/rich/assets/51204390/b871eda0-6a26-4a0c-b4ed-12d73c8d260f)

### Rich traceback before
![image](https://github.com/Textualize/rich/assets/51204390/ca478f59-0b21-4766-ba01-be581f51e401)

### Rich traceback with highlighing
![image](https://github.com/Textualize/rich/assets/51204390/a6cfcc04-a92a-44e8-8ba5-22491585cf46)