### PR TITLE
Make it possible to override the representation function from the outside

### DIFF
--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -594,7 +594,7 @@ def traverse(
             obj_repr = f"{obj[:max_string]!r}+{truncated}"
         else:
             try:
-                obj_repr = repr(obj)
+                obj_repr = get_repr(obj)
             except Exception as error:
                 obj_repr = f"<repr-error {str(error)!r}>"
         return obj_repr
@@ -933,6 +933,11 @@ def pprint(
         ),
         soft_wrap=True,
     )
+
+
+def get_repr(obj: Any) -> str:
+    # Allow overriding the representation function from the outside.
+    return repr(obj)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
A minimal change that makes it possible to override the representation function from the outside. This unblocks us now and could lay the basis for #3393 in the future.

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
