### PR TITLE
Progress: Added an option to TimeRemainingColumn to estimate the speed using an exponential moving average

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 exclude: benchmarks/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -26,17 +26,17 @@ repos:
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.2.2
+    rev: v2.4.0
     hooks:
       - id: pycln
         args: [--all]
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.4.2
     hooks:
       - id: black
         exclude: ^benchmarks/
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added option to TimeRemainingColumn to estimate the remaining time using an Exponential Moving Average instead of averaging the recent past.
+
 ## [13.7.1] - 2024-02-28
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,6 +52,7 @@ The following people have contributed to the development of Rich:
 - [Felipe Guedes](https://github.com/guedesfelipe)
 - [Min RK](https://github.com/minrk)
 - [Clément Robert](https://github.com/neutrinoceros)
+- [Tomas Rigaux](https://github.com/akulen)
 - [Brian Rutledge](https://github.com/bhrutledge)
 - [Tushar Sadhwani](https://github.com/tusharsadhwani)
 - [Luca Salvarani](https://github.com/LukeSavefrogs)

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -1074,13 +1074,16 @@ class Task:
             return None
         estimate = remaining / speed
         current_step_progress = 0.0
-        with self._lock:
-            progress = self._progress
-            if progress:
-                current_step_progress = self.get_time() - progress[-1].timestamp
-            elif self.start_time is not None:
-                current_step_progress = self.get_time() - self.start_time
-        current_step_progress = 1 / speed * (1 - e ** (-current_step_progress * speed))
+        if self.stop_time is None:
+            with self._lock:
+                progress = self._progress
+                if progress:
+                    current_step_progress = self.get_time() - progress[-1].timestamp
+                elif self.start_time is not None:
+                    current_step_progress = self.get_time() - self.start_time
+            current_step_progress = (
+                1 / speed * (1 - e ** (-current_step_progress * speed))
+            )
         return ceil(estimate - current_step_progress)
 
     def _reset(self) -> None:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [x] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I added a new attribute `speed_ema` to the `Task` class that stores a speed estimate using an Exponential Moving Average (EMA). It is updated whenever `progress.update` or `progress.advance` are called with new completed steps.

In addition, a parameter `speed_estimate_alpha` was added to Progress to control the EMA. The base formula used was:
$$S_{i+1}=\left(\frac{\alpha}{s} + \frac{1-\alpha}{S_{i}}\right)^{-1}$$
where we do an harmonic weighted average of the speed, or a weighted average of the estimated remaining time. By interpolating this formula extension to $k$ consecutive speed updates with the same speed, we get the general formula
$$S_{i+x} = \left(\frac{1 - (1 - \alpha)^x}{s} + \frac{(1-\alpha)^x}{S_{i}}\right)^{-1}$$
for an arbitrary $x>0$

At the start, as we have no previous estimate, so $S_0 = s_0$, and for the first few updates, we use a larger $\alpha$ so that the first few speed estimates do not get a disproportionate weight. In practice, we use $\alpha=max(\frac{1}{i+1}, \text{speed\\_estimate\\_alpha})$

## Extra

The variable names are not ideal, being: `speed_estimate_alpha`, `speed_ema`, and `time_remaining_ema`, with `ema` abbreviating `exponential_moving_average`

I also updated pycvn in the pre-commit hooks to work in python 3.12