### PR TITLE
feat: speedup import time using sys.platform

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@ The following people have contributed to the development of Rich:
 - [Kenneth Hoste](https://github.com/boegel)
 - [Lanqing Huang](https://github.com/lqhuang)
 - [Finn Hughes](https://github.com/finnhughes)
+- [JP Hutchins](https://github.com/JPhutchins)
 - [Ionite](https://github.com/ionite34)
 - [Josh Karpel](https://github.com/JoshKarpel)
 - [Jan Katins](https://github.com/jankatins)

--- a/rich/color.py
+++ b/rich/color.py
@@ -1,5 +1,5 @@
-import platform
 import re
+import sys
 from colorsys import rgb_to_hls
 from enum import IntEnum
 from functools import lru_cache
@@ -15,7 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .text import Text
 
 
-WINDOWS = platform.system() == "Windows"
+WINDOWS = sys.platform == "win32"
 
 
 class ColorSystem(IntEnum):

--- a/rich/console.py
+++ b/rich/console.py
@@ -1,6 +1,5 @@
 import inspect
 import os
-import platform
 import sys
 import threading
 import zlib
@@ -76,7 +75,7 @@ if TYPE_CHECKING:
 
 JUPYTER_DEFAULT_COLUMNS = 115
 JUPYTER_DEFAULT_LINES = 100
-WINDOWS = platform.system() == "Windows"
+WINDOWS = sys.platform == "win32"
 
 HighlighterType = Callable[[Union[str, "Text"]], "Text"]
 JustifyMethod = Literal["default", "left", "center", "right", "full"]

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -1,5 +1,4 @@
 import os.path
-import platform
 import re
 import sys
 import textwrap
@@ -52,7 +51,7 @@ from .text import Text
 
 TokenType = Tuple[str, ...]
 
-WINDOWS = platform.system() == "Windows"
+WINDOWS = sys.platform == "win32"
 DEFAULT_THEME = "monokai"
 
 # The following styles are based on https://github.com/pygments/pygments/blob/master/pygments/formatters/terminal.py

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import linecache
 import os
-import platform
 import sys
 from dataclasses import dataclass, field
 from traceback import walk_tb
@@ -39,7 +38,7 @@ from .syntax import Syntax
 from .text import Text
 from .theme import Theme
 
-WINDOWS = platform.system() == "Windows"
+WINDOWS = sys.platform == "win32"
 
 LOCALS_MAX_LENGTH = 10
 LOCALS_MAX_STRING = 80


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

We're investigating slow CLIs over at Typer: https://github.com/tiangolo/typer/discussions/744.  More generally, I am interested in improving Python import performance.

This PR cuts rich import time from ~230ms -> ~130ms on my machine.  Here's the test process.

Create a simple test script that mimics the dependencies used by Typer:

```python
from rich import box
from rich.align import Align
from rich.columns import Columns
from rich.console import Console, RenderableType, group
from rich.emoji import Emoji
from rich.highlighter import RegexHighlighter
from rich.markdown import Markdown
from rich.padding import Padding
from rich.panel import Panel
from rich.table import Table
from rich.text import Text
from rich.theme import Theme
```

Refer to:
https://github.com/tiangolo/typer/blob/04eba6b70203287176d2823753513226bf778872/typer/rich_utils.py#L11-L22

Run 1x to compile, then test times.

My shell records execution times ranging from 282ms -> 380ms (let's call it 300ms).

```
python test.py 
```

Check import times

```
python -X importtime test.py
```

```
import time: self [us] | cumulative | imported package
import time:       205 |        205 | winreg
import time:       407 |        407 |   _io
import time:        78 |         78 |   marshal
import time:       135 |        135 |   nt
import time:       483 |       1102 | _frozen_importlib_external
import time:       403 |        403 |   time
import time:       183 |        585 | zipimport
import time:        46 |         46 |     _codecs
import time:       289 |        335 |   codecs
import time:       862 |        862 |   encodings.aliases
import time:      1265 |       2461 | encodings
import time:       826 |        826 | encodings.utf_8
import time:       803 |        803 | encodings.cp1252
import time:        95 |         95 | _signal
import time:        31 |         31 |     _abc
import time:       195 |        226 |   abc
import time:       191 |        417 | io
import time:       102 |        102 |       _stat
import time:       164 |        265 |     stat
import time:      1163 |       1163 |     _collections_abc
import time:       114 |        114 |       genericpath
import time:       404 |        404 |       _winapi
import time:       372 |        889 |     ntpath
import time:       741 |       3056 |   os
import time:        74 |         74 |   _sitebuiltins
import time:       600 |        600 |   encodings.utf_8_sig
import time:       501 |        501 |     __future__
import time:      1862 |       2362 |   _virtualenv
import time:       914 |        914 |   _distutils_hack
import time:       459 |        459 |   sitecustomize
import time:      3130 |      10593 | site
import time:       127 |        127 |       itertools
import time:      1034 |       1034 |       keyword
import time:       120 |        120 |         _operator
import time:      1474 |       1593 |       operator
import time:      1074 |       1074 |       reprlib
import time:       169 |        169 |       _collections
import time:      1562 |       5557 |     collections
import time:       687 |        687 |     collections.abc
import time:       496 |        496 |     copyreg
import time:       545 |        545 |         types
import time:        65 |         65 |         _functools
import time:      1193 |       1802 |       functools
import time:      1278 |       3079 |     contextlib
import time:      2519 |       2519 |       enum
import time:        63 |         63 |         _sre
import time:       461 |        461 |           re._constants
import time:       786 |       1246 |         re._parser
import time:       843 |        843 |         re._casefix
import time:       979 |       3130 |       re._compiler
import time:      1499 |       7148 |     re
import time:       575 |        575 |     warnings
import time:        40 |         40 |     _typing
import time:      2939 |      20518 |   typing
import time:       937 |        937 |   rich._extension
import time:      1892 |      23347 | rich
import time:       265 |        265 |   rich._loop
import time:       679 |        943 | rich.box
import time:       620 |        620 |                 token
import time:       105 |        105 |                 _tokenize
import time:      1639 |       2363 |               tokenize
import time:       629 |       2991 |             linecache
import time:      2066 |       2066 |             textwrap
import time:      1311 |       6367 |           traceback
import time:       545 |        545 |             _weakrefset
import time:       974 |       1519 |           weakref
import time:        50 |         50 |             _string
import time:       938 |        988 |           string
import time:       895 |        895 |           threading
import time:        38 |         38 |           atexit
import time:      2675 |      12479 |         logging
import time:       313 |        313 |           rich._cell_widths
import time:       795 |       1108 |         rich.cells
import time:        65 |         65 |               _ast
import time:      2069 |       2133 |             ast
import time:        38 |         38 |                 _opcode
import time:      1472 |       1510 |               opcode
import time:      2609 |       4119 |             dis
import time:       651 |        651 |               importlib
import time:       277 |        928 |             importlib.machinery
import time:      3074 |      10253 |           inspect
import time:       759 |      11011 |         rich.repr
import time:        65 |         65 |             math
import time:        35 |         35 |               _bisect
import time:       496 |        531 |             bisect
import time:       113 |        113 |             _random
import time:       129 |        129 |             _sha2
import time:       971 |       1807 |           random
import time:       437 |        437 |           rich.errors
import time:      2840 |       2840 |               _wmi
import time:      1065 |       3905 |             platform
import time:       977 |        977 |             colorsys
import time:       655 |        655 |                 rich.color_triplet
import time:       786 |       1441 |               rich.palette
import time:       833 |       2274 |             rich._palettes
import time:       831 |        831 |             rich.terminal_theme
import time:      2363 |       2363 |               _socket
import time:       949 |        949 |                 select
import time:       953 |       1902 |               selectors
import time:        77 |         77 |               errno
import time:      2156 |       6497 |             socket
import time:    100090 |     114572 |           rich.color
import time:      1579 |     118393 |         rich.style
import time:      1513 |     144502 |       rich.segment
import time:       373 |     144874 |     rich.jupyter
import time:       218 |        218 |       rich.protocol
import time:      1762 |       1979 |     rich.measure
import time:       840 |     147692 |   rich.constrain
import time:       955 |     148646 | rich.align
import time:       109 |        109 |     zlib
import time:       664 |        664 |       copy
import time:      2021 |       2684 |     dataclasses
import time:       108 |        108 |       _datetime
import time:       623 |        731 |     datetime
import time:       453 |        453 |       termios
import time:       113 |        113 |       msvcrt
import time:       653 |       1218 |     getpass
import time:      1350 |       1350 |       html.entities
import time:      1065 |       2415 |     html
import time:       373 |        373 |     rich._null_file
import time:       872 |        872 |       rich.default_styles
import time:      1833 |       1833 |         configparser
import time:       656 |       2488 |       rich.theme
import time:       431 |       3790 |     rich.themes
import time:      1755 |       1755 |       rich._emoji_codes
import time:      1005 |       2760 |     rich._emoji_replace
import time:       573 |        573 |     rich._export_format
import time:       578 |        578 |     rich._fileno
import time:       219 |        219 |         rich._pick
import time:       319 |        319 |         rich._wrap
import time:      1137 |       1137 |         rich.containers
import time:      1257 |       1257 |         rich.control
import time:       959 |        959 |         rich.emoji
import time:      1457 |       5345 |       rich.text
import time:       696 |       6040 |     rich._log_render
import time:       402 |        402 |     rich.highlighter
import time:      1029 |       1029 |     rich.markup
import time:       605 |        605 |     rich.pager
import time:       322 |        322 |       array
import time:       460 |        460 |           attr._compat
import time:       261 |        261 |             attr._config
import time:       523 |        523 |               attr.exceptions
import time:       852 |       1374 |             attr.setters
import time:      3188 |       4823 |           attr._make
import time:       583 |       5864 |         attr.converters
import time:       438 |        438 |         attr.filters
import time:      3604 |       3604 |         attr.validators
import time:       282 |        282 |         attr._cmp
import time:       280 |        280 |         attr._funcs
import time:      1068 |       1068 |         attr._version_info
import time:       277 |        277 |         attr._next_gen
import time:      1323 |      13134 |       attr
import time:       258 |        258 |       rich.abc
import time:      2896 |      16609 |     rich.pretty
import time:       787 |        787 |     rich.region
import time:       278 |        278 |         rich.padding
import time:       690 |        967 |       rich.panel
import time:       712 |        712 |                 numbers
import time:      1762 |       2474 |               _decimal
import time:       533 |       3007 |             decimal
import time:      2306 |       5312 |           fractions
import time:       587 |       5899 |         rich._ratio
import time:      3225 |       9124 |       rich.table
import time:       954 |      11044 |     rich.scope
import time:       760 |        760 |     rich.screen
import time:       520 |        520 |     rich.styled
import time:      5693 |      58712 |   rich.console
import time:      1333 |      60044 | rich.columns
import time:       229 |        229 |             markdown_it.common
import time:       649 |        649 |             markdown_it.common.entities
import time:      3175 |       4053 |           markdown_it.common.utils
import time:       374 |       4426 |         markdown_it.helpers.parse_link_destination
import time:       221 |        221 |                 markdown_it._compat
import time:      1677 |       1677 |                 markdown_it.ruler
import time:      3963 |       3963 |                 markdown_it.token
import time:      1072 |       6931 |               markdown_it.rules_inline.state_inline
import time:       411 |       7342 |             markdown_it.rules_inline.emphasis
import time:       323 |        323 |             markdown_it.rules_inline.strikethrough
import time:      1060 |       1060 |             markdown_it.rules_inline.autolink
import time:       313 |        313 |             markdown_it.rules_inline.backticks
import time:       255 |        255 |             markdown_it.rules_inline.balance_pairs
import time:       506 |        506 |             markdown_it.rules_inline.entity
import time:       250 |        250 |             markdown_it.rules_inline.escape
import time:       677 |        677 |               markdown_it.common.html_re
import time:       287 |        963 |             markdown_it.rules_inline.html_inline
import time:       256 |        256 |             markdown_it.rules_inline.image
import time:       262 |        262 |             markdown_it.rules_inline.link
import time:       664 |        664 |             markdown_it.rules_inline.newline
import time:       542 |        542 |             markdown_it.rules_inline.text
import time:       264 |        264 |             markdown_it.rules_inline.text_collapse
import time:      1202 |      14196 |           markdown_it.rules_inline
import time:       371 |      14567 |         markdown_it.helpers.parse_link_label
import time:       282 |        282 |         markdown_it.helpers.parse_link_title
import time:       492 |      19765 |       markdown_it.helpers
import time:       825 |        825 |         markdown_it.presets.commonmark
import time:       273 |        273 |         markdown_it.presets.default
import time:       598 |        598 |         markdown_it.presets.zero
import time:      1141 |       2835 |       markdown_it.presets
import time:       434 |        434 |           urllib
import time:      1189 |       1189 |           ipaddress
import time:      2523 |       4146 |         urllib.parse
import time:       377 |        377 |           mdurl._decode
import time:       628 |        628 |           mdurl._encode
import time:       327 |        327 |           mdurl._format
import time:       453 |        453 |             mdurl._url
import time:       696 |       1148 |           mdurl._parse
import time:      1362 |       3841 |         mdurl
import time:       685 |        685 |         markdown_it._punycode
import time:       892 |       9562 |       markdown_it.common.normalize_url
import time:       276 |        276 |             markdown_it.rules_block.state_block
import time:       449 |        725 |           markdown_it.rules_block.blockquote
import time:       390 |        390 |           markdown_it.rules_block.code
import time:       520 |        520 |           markdown_it.rules_block.fence
import time:       374 |        374 |           markdown_it.rules_block.heading
import time:       602 |        602 |           markdown_it.rules_block.hr
import time:       267 |        267 |             markdown_it.common.html_blocks
import time:      1526 |       1792 |           markdown_it.rules_block.html_block
import time:       677 |        677 |           markdown_it.rules_block.lheading
import time:       750 |        750 |           markdown_it.rules_block.list
import time:       579 |        579 |           markdown_it.rules_block.paragraph
import time:       720 |        720 |           markdown_it.rules_block.reference
import time:       873 |        873 |           markdown_it.rules_block.table
import time:      1240 |       9237 |         markdown_it.rules_block
import time:       739 |       9975 |       markdown_it.parser_block
import time:       260 |        260 |             markdown_it.rules_core.state_core
import time:       886 |       1145 |           markdown_it.rules_core.block
import time:       262 |        262 |           markdown_it.rules_core.inline
import time:       391 |        391 |           markdown_it.rules_core.linkify
import time:       305 |        305 |           markdown_it.rules_core.normalize
import time:       581 |        581 |           markdown_it.rules_core.replacements
import time:       293 |        293 |           markdown_it.rules_core.smartquotes
import time:      1026 |       3999 |         markdown_it.rules_core
import time:       553 |       4552 |       markdown_it.parser_core
import time:       285 |        285 |       markdown_it.parser_inline
import time:       322 |        322 |                 posix
import time:       190 |        511 |               posixpath
import time:       556 |       1067 |             fnmatch
import time:      1396 |       2463 |           pathlib
import time:       390 |       2853 |         markdown_it.utils
import time:       527 |       3379 |       markdown_it.renderer
import time:       360 |        360 |       linkify_it
import time:      1085 |      51795 |     markdown_it.main
import time:       533 |      52328 |   markdown_it
import time:       294 |        294 |   rich._stack
import time:       300 |        300 |   rich.rule
import time:       550 |        550 |       pygments
import time:       291 |        291 |       pygments.filter
import time:       506 |        506 |         pygments.token
import time:       781 |        781 |         pygments.util
import time:       621 |        621 |         pygments.plugin
import time:      1258 |       3165 |       pygments.filters
import time:       422 |        422 |       pygments.regexopt
import time:      1458 |       5885 |     pygments.lexer
import time:      1650 |       1650 |       pygments.lexers._mapping
import time:       921 |        921 |       pygments.modeline
import time:      1351 |       3921 |     pygments.lexers
import time:       793 |        793 |     pygments.style
import time:       319 |        319 |     pygments.styles
import time:      1327 |      12243 |   rich.syntax
import time:       894 |      66058 | rich.markdown
```

`rich.color` stands out a bit!

Results after this PR - run at least 1x to compile.

```
python test.py
```

Centering around 200ms.  Considering that the shell records 75ms with NOTHING in test.py,
that's around a 2x import time speedup.

Check import times

```
python -X importtime test.py
```

```
import time: self [us] | cumulative | imported package
import time:       197 |        197 | winreg
import time:       255 |        255 |   _io
import time:        83 |         83 |   marshal
import time:       283 |        283 |   nt
import time:       487 |       1106 | _frozen_importlib_external
import time:       355 |        355 |   time
import time:       119 |        474 | zipimport
import time:        46 |         46 |     _codecs
import time:       528 |        573 |   codecs
import time:      1455 |       1455 |   encodings.aliases
import time:      1537 |       3565 | encodings
import time:       845 |        845 | encodings.utf_8
import time:       977 |        977 | encodings.cp1252
import time:        43 |         43 | _signal
import time:        71 |         71 |     _abc
import time:       233 |        304 |   abc
import time:       211 |        514 | io
import time:        56 |         56 |       _stat
import time:       129 |        185 |     stat
import time:       942 |        942 |     _collections_abc
import time:        34 |         34 |       genericpath
import time:        81 |         81 |       _winapi
import time:       133 |        248 |     ntpath
import time:       310 |       1683 |   os
import time:        65 |         65 |   _sitebuiltins
import time:       471 |        471 |   encodings.utf_8_sig
import time:       411 |        411 |     __future__
import time:      1704 |       2115 |   _virtualenv
import time:      1118 |       1118 |   _distutils_hack
import time:       438 |        438 |   sitecustomize
import time:      3705 |       9592 | site
import time:       152 |        152 |       itertools
import time:      1212 |       1212 |       keyword
import time:       126 |        126 |         _operator
import time:      1537 |       1663 |       operator
import time:       851 |        851 |       reprlib
import time:        80 |         80 |       _collections
import time:      1872 |       5828 |     collections
import time:      1279 |       1279 |     collections.abc
import time:      1123 |       1123 |     copyreg
import time:       603 |        603 |         types
import time:        64 |         64 |         _functools
import time:      1082 |       1749 |       functools
import time:      1609 |       3357 |     contextlib
import time:      1390 |       1390 |       enum
import time:        63 |         63 |         _sre
import time:       473 |        473 |           re._constants
import time:       639 |       1111 |         re._parser
import time:       352 |        352 |         re._casefix
import time:       796 |       2321 |       re._compiler
import time:       968 |       4678 |     re
import time:       555 |        555 |     warnings
import time:        40 |         40 |     _typing
import time:      2594 |      19451 |   typing
import time:       898 |        898 |   rich._extension
import time:      2143 |      22491 | rich
import time:       259 |        259 |   rich._loop
import time:       587 |        845 | rich.box
import time:       424 |        424 |                 token
import time:       107 |        107 |                 _tokenize
import time:      1195 |       1725 |               tokenize
import time:       449 |       2174 |             linecache
import time:      1230 |       1230 |             textwrap
import time:      1070 |       4474 |           traceback
import time:       508 |        508 |             _weakrefset
import time:      1569 |       2077 |           weakref
import time:        35 |         35 |             _string
import time:       961 |        996 |           string
import time:       904 |        904 |           threading
import time:        43 |         43 |           atexit
import time:      2368 |      10860 |         logging
import time:       391 |        391 |           rich._cell_widths
import time:       485 |        875 |         rich.cells
import time:       214 |        214 |               _ast
import time:      2801 |       3015 |             ast
import time:        60 |         60 |                 _opcode
import time:      1331 |       1390 |               opcode
import time:      2037 |       3427 |             dis
import time:       504 |        504 |               importlib
import time:        90 |        594 |             importlib.machinery
import time:      2344 |       9379 |           inspect
import time:       516 |       9894 |         rich.repr
import time:        55 |         55 |             math
import time:        65 |         65 |               _bisect
import time:       993 |       1058 |             bisect
import time:        94 |         94 |             _random
import time:       103 |        103 |             _sha2
import time:       970 |       2277 |           random
import time:       375 |        375 |           rich.errors
import time:       590 |        590 |             colorsys
import time:       361 |        361 |                 rich.color_triplet
import time:       351 |        711 |               rich.palette
import time:       358 |       1069 |             rich._palettes
import time:       344 |        344 |             rich.terminal_theme
import time:      1802 |       3803 |           rich.color
import time:       890 |       7345 |         rich.style
import time:      1019 |      29991 |       rich.segment
import time:       341 |      30332 |     rich.jupyter
import time:       264 |        264 |       rich.protocol
import time:       435 |        698 |     rich.measure
import time:       630 |      31659 |   rich.constrain
import time:       991 |      32650 | rich.align
import time:        70 |         70 |     zlib
import time:       688 |        688 |       copy
import time:      1781 |       2469 |     dataclasses
import time:        88 |         88 |       _datetime
import time:       631 |        718 |     datetime
import time:       612 |        612 |       termios
import time:        54 |         54 |       msvcrt
import time:      1252 |       1917 |     getpass
import time:      1132 |       1132 |       html.entities
import time:       798 |       1929 |     html
import time:       444 |        444 |     rich._null_file
import time:      1891 |       1891 |       rich.default_styles
import time:      1906 |       1906 |         configparser
import time:      1013 |       2919 |       rich.theme
import time:       821 |       5630 |     rich.themes
import time:      2475 |       2475 |       rich._emoji_codes
import time:       878 |       3352 |     rich._emoji_replace
import time:       285 |        285 |     rich._export_format
import time:       551 |        551 |     rich._fileno
import time:       198 |        198 |         rich._pick
import time:       285 |        285 |         rich._wrap
import time:       476 |        476 |         rich.containers
import time:       400 |        400 |         rich.control
import time:       379 |        379 |         rich.emoji
import time:      1109 |       2844 |       rich.text
import time:       631 |       3474 |     rich._log_render
import time:       369 |        369 |     rich.highlighter
import time:       605 |        605 |     rich.markup
import time:       628 |        628 |     rich.pager
import time:       128 |        128 |       array
import time:      2501 |       2501 |               _wmi
import time:       967 |       3467 |             platform
import time:       884 |       4350 |           attr._compat
import time:       268 |        268 |             attr._config
import time:       356 |        356 |               attr.exceptions
import time:       399 |        755 |             attr.setters
import time:      3259 |       4281 |           attr._make
import time:       536 |       9166 |         attr.converters
import time:       263 |        263 |         attr.filters
import time:      2720 |       2720 |         attr.validators
import time:       284 |        284 |         attr._cmp
import time:       285 |        285 |         attr._funcs
import time:       676 |        676 |         attr._version_info
import time:       285 |        285 |         attr._next_gen
import time:       975 |      14650 |       attr
import time:       253 |        253 |       rich.abc
import time:      1764 |      16793 |     rich.pretty
import time:       342 |        342 |     rich.region
import time:       613 |        613 |         rich.padding
import time:       855 |       1467 |       rich.panel
import time:       702 |        702 |                 numbers
import time:      1799 |       2500 |               _decimal
import time:       516 |       3015 |             decimal
import time:      2040 |       5055 |           fractions
import time:       705 |       5760 |         rich._ratio
import time:      2599 |       8359 |       rich.table
import time:       774 |      10599 |     rich.scope
import time:       820 |        820 |     rich.screen
import time:       713 |        713 |     rich.styled
import time:      3759 |      55460 |   rich.console
import time:       988 |      56447 | rich.columns
import time:       230 |        230 |             markdown_it.common
import time:       445 |        445 |             markdown_it.common.entities
import time:      3091 |       3765 |           markdown_it.common.utils
import time:       518 |       4282 |         markdown_it.helpers.parse_link_destination
import time:       207 |        207 |                 markdown_it._compat
import time:      1503 |       1503 |                 markdown_it.ruler
import time:      1586 |       1586 |                 markdown_it.token
import time:      1543 |       4837 |               markdown_it.rules_inline.state_inline
import time:       693 |       5530 |             markdown_it.rules_inline.emphasis
import time:       649 |        649 |             markdown_it.rules_inline.strikethrough
import time:      1200 |       1200 |             markdown_it.rules_inline.autolink
import time:       317 |        317 |             markdown_it.rules_inline.backticks
import time:       290 |        290 |             markdown_it.rules_inline.balance_pairs
import time:      1248 |       1248 |             markdown_it.rules_inline.entity
import time:       624 |        624 |             markdown_it.rules_inline.escape
import time:       792 |        792 |               markdown_it.common.html_re
import time:       621 |       1413 |             markdown_it.rules_inline.html_inline
import time:       286 |        286 |             markdown_it.rules_inline.image
import time:       417 |        417 |             markdown_it.rules_inline.link
import time:       542 |        542 |             markdown_it.rules_inline.newline
import time:       357 |        357 |             markdown_it.rules_inline.text
import time:       250 |        250 |             markdown_it.rules_inline.text_collapse
import time:      1608 |      14726 |           markdown_it.rules_inline
import time:       379 |      15104 |         markdown_it.helpers.parse_link_label
import time:       272 |        272 |         markdown_it.helpers.parse_link_title
import time:       488 |      20145 |       markdown_it.helpers
import time:       624 |        624 |         markdown_it.presets.commonmark
import time:       826 |        826 |         markdown_it.presets.default
import time:       346 |        346 |         markdown_it.presets.zero
import time:      1055 |       2849 |       markdown_it.presets
import time:      1055 |       1055 |           urllib
import time:      2192 |       2192 |           ipaddress
import time:      2413 |       5660 |         urllib.parse
import time:       347 |        347 |           mdurl._decode
import time:       631 |        631 |           mdurl._encode
import time:       594 |        594 |           mdurl._format
import time:       921 |        921 |             mdurl._url
import time:      1119 |       2039 |           mdurl._parse
import time:       906 |       4514 |         mdurl
import time:       751 |        751 |         markdown_it._punycode
import time:       927 |      11851 |       markdown_it.common.normalize_url
import time:       250 |        250 |             markdown_it.rules_block.state_block
import time:       422 |        671 |           markdown_it.rules_block.blockquote
import time:       319 |        319 |           markdown_it.rules_block.code
import time:       627 |        627 |           markdown_it.rules_block.fence
import time:       268 |        268 |           markdown_it.rules_block.heading
import time:       249 |        249 |           markdown_it.rules_block.hr
import time:       293 |        293 |             markdown_it.common.html_blocks
import time:      2305 |       2597 |           markdown_it.rules_block.html_block
import time:       733 |        733 |           markdown_it.rules_block.lheading
import time:       443 |        443 |           markdown_it.rules_block.list
import time:       379 |        379 |           markdown_it.rules_block.paragraph
import time:       647 |        647 |           markdown_it.rules_block.reference
import time:       350 |        350 |           markdown_it.rules_block.table
import time:      1057 |       8337 |         markdown_it.rules_block
import time:       385 |       8721 |       markdown_it.parser_block
import time:       235 |        235 |             markdown_it.rules_core.state_core
import time:       404 |        638 |           markdown_it.rules_core.block
import time:       235 |        235 |           markdown_it.rules_core.inline
import time:       397 |        397 |           markdown_it.rules_core.linkify
import time:       304 |        304 |           markdown_it.rules_core.normalize
import time:       580 |        580 |           markdown_it.rules_core.replacements
import time:       294 |        294 |           markdown_it.rules_core.smartquotes
import time:       516 |       2962 |         markdown_it.rules_core
import time:       346 |       3308 |       markdown_it.parser_core
import time:       279 |        279 |       markdown_it.parser_inline
import time:       288 |        288 |                 posix
import time:        92 |        379 |               posixpath
import time:       492 |        871 |             fnmatch
import time:        67 |         67 |             errno
import time:      1026 |       1963 |           pathlib
import time:       369 |       2332 |         markdown_it.utils
import time:       437 |       2769 |       markdown_it.renderer
import time:       747 |        747 |       linkify_it
import time:      1172 |      51837 |     markdown_it.main
import time:       571 |      52407 |   markdown_it
import time:       589 |        589 |   rich._stack
import time:       295 |        295 |   rich.rule
import time:       498 |        498 |       pygments
import time:       248 |        248 |       pygments.filter
import time:       538 |        538 |         pygments.token
import time:       740 |        740 |         pygments.util
import time:       615 |        615 |         pygments.plugin
import time:      1336 |       3227 |       pygments.filters
import time:       490 |        490 |       pygments.regexopt
import time:      1111 |       5572 |     pygments.lexer
import time:      1602 |       1602 |       pygments.lexers._mapping
import time:       434 |        434 |       pygments.modeline
import time:      1082 |       3118 |     pygments.lexers
import time:       522 |        522 |     pygments.style
import time:       330 |        330 |     pygments.styles
import time:      1957 |      11496 |   rich.syntax
import time:      1656 |      66442 | rich.markdown
```

rich.color goes from ~100ms -> ~1.8ms

I suspect that that reason is that `sys.platform` can be evaluated at compile time,
allowing for further optimizations down the line, where as the runtime
`platform.system()` call in module scope was preventing this.

Cheers,
JP



