### PR TITLE
Traceback: Expose local rendering options in install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adds a `case_sensitive` parameter to `prompt.Prompt`. This determines if the
   response is treated as case-sensitive. Defaults to `True`.
+- Expose locals_max_depth and locals_overflow in traceback.install
 
 ## [13.7.1] - 2024-02-28
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,3 +85,4 @@ The following people have contributed to the development of Rich:
 - [Pierro](https://github.com/xpierroz)
 - [Bernhard Wagner](https://github.com/bwagner)
 - [Aaron Beaudoin](https://github.com/AaronBeaudoin)
+- [Ioannis Papamanoglou](https://github.com/IoannisP-ITENG)

--- a/rich/scope.py
+++ b/rich/scope.py
@@ -8,7 +8,7 @@ from .table import Table
 from .text import Text, TextType
 
 if TYPE_CHECKING:
-    from .console import ConsoleRenderable
+    from .console import ConsoleRenderable, OverflowMethod
 
 
 def render_scope(
@@ -19,6 +19,8 @@ def render_scope(
     indent_guides: bool = False,
     max_length: Optional[int] = None,
     max_string: Optional[int] = None,
+    max_depth: Optional[int] = None,
+    overflow: Optional["OverflowMethod"] = None,
 ) -> "ConsoleRenderable":
     """Render python variables in a given scope.
 
@@ -57,6 +59,8 @@ def render_scope(
                 indent_guides=indent_guides,
                 max_length=max_length,
                 max_string=max_string,
+                max_depth=max_depth,
+                overflow=overflow,
             ),
         )
     return Panel.fit(

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -26,7 +26,14 @@ from pygments.util import ClassNotFound
 from . import pretty
 from ._loop import loop_last
 from .columns import Columns
-from .console import Console, ConsoleOptions, ConsoleRenderable, RenderResult, group
+from .console import (
+    Console,
+    ConsoleOptions,
+    ConsoleRenderable,
+    OverflowMethod,
+    RenderResult,
+    group,
+)
 from .constrain import Constrain
 from .highlighter import RegexHighlighter, ReprHighlighter
 from .panel import Panel
@@ -53,8 +60,10 @@ def install(
     show_locals: bool = False,
     locals_max_length: int = LOCALS_MAX_LENGTH,
     locals_max_string: int = LOCALS_MAX_STRING,
+    locals_max_depth: Optional[int] = None,
     locals_hide_dunder: bool = True,
     locals_hide_sunder: Optional[bool] = None,
+    locals_overflow: Optional[OverflowMethod] = None,
     indent_guides: bool = True,
     suppress: Iterable[Union[str, ModuleType]] = (),
     max_frames: int = 100,
@@ -111,8 +120,10 @@ def install(
                 show_locals=show_locals,
                 locals_max_length=locals_max_length,
                 locals_max_string=locals_max_string,
+                locals_max_depth=locals_max_depth,
                 locals_hide_dunder=locals_hide_dunder,
                 locals_hide_sunder=bool(locals_hide_sunder),
+                locals_overflow=locals_overflow,
                 indent_guides=indent_guides,
                 suppress=suppress,
                 max_frames=max_frames,
@@ -251,8 +262,10 @@ class Traceback:
         show_locals: bool = False,
         locals_max_length: int = LOCALS_MAX_LENGTH,
         locals_max_string: int = LOCALS_MAX_STRING,
+        locals_max_depth: Optional[int] = None,
         locals_hide_dunder: bool = True,
         locals_hide_sunder: bool = False,
+        locals_overlow: Optional[OverflowMethod] = None,
         indent_guides: bool = True,
         suppress: Iterable[Union[str, ModuleType]] = (),
         max_frames: int = 100,
@@ -276,8 +289,10 @@ class Traceback:
         self.indent_guides = indent_guides
         self.locals_max_length = locals_max_length
         self.locals_max_string = locals_max_string
+        self.locals_max_depth = locals_max_depth
         self.locals_hide_dunder = locals_hide_dunder
         self.locals_hide_sunder = locals_hide_sunder
+        self.locals_overflow = locals_overlow
 
         self.suppress: Sequence[str] = []
         for suppress_entity in suppress:
@@ -307,8 +322,10 @@ class Traceback:
         show_locals: bool = False,
         locals_max_length: int = LOCALS_MAX_LENGTH,
         locals_max_string: int = LOCALS_MAX_STRING,
+        locals_max_depth: Optional[int] = None,
         locals_hide_dunder: bool = True,
         locals_hide_sunder: bool = False,
+        locals_overflow: Optional[OverflowMethod] = None,
         indent_guides: bool = True,
         suppress: Iterable[Union[str, ModuleType]] = (),
         max_frames: int = 100,
@@ -344,6 +361,7 @@ class Traceback:
             show_locals=show_locals,
             locals_max_length=locals_max_length,
             locals_max_string=locals_max_string,
+            locals_max_depth=locals_max_depth,
             locals_hide_dunder=locals_hide_dunder,
             locals_hide_sunder=locals_hide_sunder,
         )
@@ -359,8 +377,10 @@ class Traceback:
             indent_guides=indent_guides,
             locals_max_length=locals_max_length,
             locals_max_string=locals_max_string,
+            locals_max_depth=locals_max_depth,
             locals_hide_dunder=locals_hide_dunder,
             locals_hide_sunder=locals_hide_sunder,
+            locals_overlow=locals_overflow,
             suppress=suppress,
             max_frames=max_frames,
         )
@@ -375,6 +395,7 @@ class Traceback:
         show_locals: bool = False,
         locals_max_length: int = LOCALS_MAX_LENGTH,
         locals_max_string: int = LOCALS_MAX_STRING,
+        locals_max_depth: Optional[int] = None,
         locals_hide_dunder: bool = True,
         locals_hide_sunder: bool = False,
     ) -> Trace:
@@ -457,6 +478,7 @@ class Traceback:
                             value,
                             max_length=locals_max_length,
                             max_string=locals_max_string,
+                            max_depth=locals_max_depth,
                         )
                         for key, value in get_locals(frame_summary.f_locals.items())
                     }
@@ -631,6 +653,8 @@ class Traceback:
                     indent_guides=self.indent_guides,
                     max_length=self.locals_max_length,
                     max_string=self.locals_max_string,
+                    max_depth=self.locals_max_depth,
+                    overflow=self.locals_overflow,
                 )
 
         exclude_frames: Optional[range] = None


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Add locals_max_depth and locals_overflow to tracebacks to enable truncating deep objects or wrapping long strings.

```python
    install(
        width=500,
        extra_lines=3,
        theme=None,
        word_wrap=True,
        show_locals=True,
        locals_max_length=10,
        locals_max_string=1000,
        locals_max_depth=3,
        locals_hide_dunder=True,
        locals_hide_sunder=True,
        locals_overflow="fold",
        indent_guides=True,
        suppress=(),
        max_frames=10,
    )
```


![image](https://github.com/Textualize/rich/assets/94004258/87dd804c-6048-4160-99ef-f63b7505d140)
