### PR TITLE
Handle dataclasses with unitialized fields in pretty printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Progress track thread is now a daemon thread https://github.com/Textualize/rich/pull/3402
 - Fixed cached hash preservation upon clearing meta and links https://github.com/Textualize/rich/issues/2942
 - Fixed overriding the `background_color` of `Syntax` not including padding https://github.com/Textualize/rich/issues/3295
+- Fixed pretty printing of dataclasses with uninitialized fields https://github.com/Textualize/rich/issues/3417
 
 ### Changed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,3 +85,4 @@ The following people have contributed to the development of Rich:
 - [Pierro](https://github.com/xpierroz)
 - [Bernhard Wagner](https://github.com/bwagner)
 - [Aaron Beaudoin](https://github.com/AaronBeaudoin)
+- [Collin Heist](https://github.com/CollinHeist/)

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -779,7 +779,7 @@ def traverse(
                 for last, field in loop_last(
                     field for field in fields(obj) if field.repr
                 ):
-                    child_node = _traverse(getattr(obj, field.name), depth=depth + 1)
+                    child_node = _traverse(getattr(obj, field.name, field.default), depth=depth + 1)
                     child_node.key_repr = field.name
                     child_node.last = last
                     child_node.key_separator = "="

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -779,7 +779,11 @@ def traverse(
                 for last, field in loop_last(
                     field for field in fields(obj) if field.repr
                 ):
-                    child_node = _traverse(getattr(obj, field.name, field.default), depth=depth + 1)
+                    try:
+                        child_node = _traverse(getattr(obj, field.name), depth=depth + 1)
+                    except AttributeError:
+                        continue
+
                     child_node.key_repr = field.name
                     child_node.last = last
                     child_node.key_separator = "="


### PR DESCRIPTION
Fixes https://github.com/Textualize/rich/issues/3417

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This is a fix for #3417. If the field has no defined attribute, then the default value should be printed instead, rather than raising an uncaught `AttributeError`.
