### PR TITLE
Add support for continuation indent and optimize divide_line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Running tests in environment with `FORCE_COLOR` or `NO_COLOR` environment variables
 - ansi decoder will now strip problematic private escape sequences (like `\x1b7`) https://github.com/Textualize/rich/pull/3278/
 - Tree's ASCII_GUIDES and TREE_GUIDES constants promoted to class attributes
+- Optimizes `_wrap.divide_line` by removing several `list` instantiations and
+  string slices.
 
 ### Added
 
 - Adds a `case_sensitive` parameter to `prompt.Prompt`. This determines if the
   response is treated as case-sensitive. Defaults to `True`.
+- Adds a `continuation_indent` argument to `text.Text`, which prefixes subsequent
+  wrapped lines with the specified number of spaces.
 
 ## [13.7.1] - 2024-02-28
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,7 @@ The following people have contributed to the development of Rich:
 - [Hugo van Kemenade](https://github.com/hugovk)
 - [Andrew Kettmann](https://github.com/akettmann)
 - [Alexander Krasnikov](https://github.com/askras)
+- [Noah Kim](https://github.com/noahbkim)
 - [Martin Larralde](https://github.com/althonos)
 - [Hedy Li](https://github.com/hedythedev)
 - [Henry Mai](https://github.com/tanducmai)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -401,6 +401,34 @@ def test_right_crop():
     assert text._spans == [Span(0, 3, "red")]
 
 
+def test_wrap_2():
+    text = Text("foo bar baz")
+    lines = text.wrap(Console(), 2)
+    print(repr(lines))
+    assert len(lines) == 6
+    assert lines[0] == Text("fo")
+    assert lines[1] == Text("o ")
+    assert lines[2] == Text("ba")
+    assert lines[3] == Text("r ")
+    assert lines[4] == Text("ba")
+    assert lines[5] == Text("z")
+
+
+def test_wrap_2_continuation_indent():
+    text = Text("foo bar baz", continuation_indent=4)
+    lines = text.wrap(Console(), 2)
+    print(repr(lines))
+    assert len(lines) == 8
+    assert lines[0] == Text("fo")
+    assert lines[1] == Text(" o")
+    assert lines[2] == Text(" b")
+    assert lines[3] == Text(" a")
+    assert lines[4] == Text(" r")
+    assert lines[5] == Text(" b")
+    assert lines[6] == Text(" a")
+    assert lines[7] == Text(" z")
+
+
 def test_wrap_3():
     text = Text("foo bar baz")
     lines = text.wrap(Console(), 3)
@@ -411,6 +439,20 @@ def test_wrap_3():
     assert lines[2] == Text("baz")
 
 
+def test_wrap_3_continuation_indent():
+    text = Text("foo bar baz", continuation_indent=4)
+    lines = text.wrap(Console(), 3)
+    print(repr(lines))
+    assert len(lines) == 7
+    assert lines[0] == Text("foo")
+    assert lines[1] == Text("  b")
+    assert lines[2] == Text("  a")
+    assert lines[3] == Text("  r")
+    assert lines[4] == Text("  b")
+    assert lines[5] == Text("  a")
+    assert lines[6] == Text("  z")
+
+
 def test_wrap_4():
     text = Text("foo bar baz", justify="left")
     lines = text.wrap(Console(), 4)
@@ -418,6 +460,31 @@ def test_wrap_4():
     assert lines[0] == Text("foo ")
     assert lines[1] == Text("bar ")
     assert lines[2] == Text("baz ")
+
+
+def test_wrap_7():
+    text = Text("foo bar baz", justify="left")
+    lines = text.wrap(Console(), 7)
+    assert len(lines) == 2
+    assert lines[0] == Text("foo bar")
+    assert lines[1] == Text("baz    ")
+
+
+def test_wrap_7_continuation_indent():
+    text = Text("foo bar baz", justify="left", continuation_indent=4)
+    lines = text.wrap(Console(), 7)
+    assert len(lines) == 2
+    assert lines[0] == Text("foo bar")
+    assert lines[1] == Text("    baz")
+
+
+def test_wrap_sentence():
+    text = Text("Where there is a Will, there is a Way.")
+    lines = text.wrap(Console(), 15)
+    assert len(lines) == 3
+    assert lines[0] == Text("Where there is ")
+    assert lines[1] == Text("a Will, there ")
+    assert lines[2] == Text("is a Way.")
 
 
 def test_wrap_wrapped_word_length_greater_than_available_width():


### PR DESCRIPTION
## Type of changes

- [x] New feature
- [x] Documentation / docstrings
- [x] Tests

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This PR adds an attribute `continuation_indent: int` to `rich.text.Text` that prefixes wrapped lines with a corresponding number of spaces. A paragraph wrapped to 72 characters might look like:

```
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
commodo consequat.
```

With `continuation_indent=4`, it would look like:

```
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
    ea commodo consequat.
```

This is particularly useful for rendering multiline output that may become ambiguous without some indication of where text wrapping occurred. For example, printing a list of (very contrived) CLI commands:

```
echo reading file /path/to/file.txt
ssh user@host -- cat /path/to/file.txt
```

Might wrap to:

```
echo reading file
/path/to/file
ssh user@host --
cat /path/to/file
```

Which has a significantly different meaning. Using `continuation_indent=4`, we instead get:

```
echo reading file
    /path/to/file
ssh user@host --
    cat /path/to/file
```

In the process of implementing this I heavily refactored `divide_line` to no longer use `chop_cells`. Not only is this much faster (it no longer creates a temporary list of list of substrings), but it is more correct in the degenerate case of wrapping to a single column (though I'm happy to revert this if it's not preferred):

```
# Old behavior
>>> rich.text.Text("ab cd").wrap(rich.get_console(), 1)
Lines([<text 'a' []>, <text 'b' []>, <text ' ' []>, <text 'c' []>, <text 'd' []>])

# New behavior (no lines only containing whitespace)
>>> rich.text.Text("ab cd").wrap(rich.get_console(), 1)
Lines([<text 'a' []>, <text 'b' []>, <text 'c' []>, <text 'd' []>])
```
