### PR TITLE
Fix incorrectly converting relative to absolute of files and always show paths in traceback in case file cannot be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `Frame.filename` no longer incorrectly set to an incorrect absolute path if the original path cannot be found.
+
+### Changed
+
+- Traceback filename/path is always shown, even if the file cannot be found.
+
 ## [13.9.2] - 2024-10-04
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ The following people have contributed to the development of Rich:
 <!-- Add your name below, sort alphabetically by surname. Link to GitHub profile / your home page. -->
 
 - [Patrick Arminio](https://github.com/patrick91)
+- [Andreas Backx](https://github.com/AndreasBackx)
 - [Gregory Beauregard](https://github.com/GBeauregard/pyffstream)
 - [Artur Borecki](https://github.com/pufereq)
 - [Pedro Aaron](https://github.com/paaaron)

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -474,9 +474,13 @@ class Traceback:
                             (end_line, end_column),
                         )
 
-                if filename and not filename.startswith("<"):
-                    if not os.path.isabs(filename):
-                        filename = os.path.join(_IMPORT_CWD, filename)
+                if (
+                    filename
+                    and not filename.startswith("<")
+                    and not os.path.isabs(filename)
+                    and os.path.exists(filename)
+                ):
+                    filename = os.path.join(_IMPORT_CWD, filename)
                 if frame_summary.f_locals.get("_rich_traceback_omit", False):
                     continue
 
@@ -695,23 +699,14 @@ class Traceback:
             frame_filename = frame.filename
             suppressed = any(frame_filename.startswith(path) for path in self.suppress)
 
-            if os.path.exists(frame.filename):
-                text = Text.assemble(
-                    path_highlighter(Text(frame.filename, style="pygments.string")),
-                    (":", "pygments.text"),
-                    (str(frame.lineno), "pygments.number"),
-                    " in ",
-                    (frame.name, "pygments.function"),
-                    style="pygments.text",
-                )
-            else:
-                text = Text.assemble(
-                    "in ",
-                    (frame.name, "pygments.function"),
-                    (":", "pygments.text"),
-                    (str(frame.lineno), "pygments.number"),
-                    style="pygments.text",
-                )
+            text = Text.assemble(
+                path_highlighter(Text(frame.filename, style="pygments.string")),
+                (":", "pygments.text"),
+                (str(frame.lineno), "pygments.number"),
+                " in ",
+                (frame.name, "pygments.function"),
+                style="pygments.text",
+            )
             if not frame.filename.startswith("<") and not first:
                 yield ""
             yield text

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -1,7 +1,14 @@
+from __future__ import annotations
+
 import io
+import os
 import re
 import sys
-from typing import List
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import CodeType, FrameType, TracebackType
+from typing import Any, Iterable, List
 
 import pytest
 
@@ -298,7 +305,16 @@ def test_suppress():
     (
         # fmt: off
         [True, 3, ["test_rich_traceback_omit_optional_local_flag", "level1", "level3"]],
-        [False, 4, ["test_rich_traceback_omit_optional_local_flag", "level1", "level2", "level3"]],
+        [
+            False,
+            4,
+            [
+                "test_rich_traceback_omit_optional_local_flag",
+                "level1",
+                "level2",
+                "level3",
+            ],
+        ],
         # fmt: on
     ),
 )
@@ -358,3 +374,72 @@ def test_traceback_finely_grained() -> None:
         start, end = last_instruction
         print(start, end)
         assert start[0] == end[0]
+
+
+@dataclass(frozen=True)
+class FakeTraceback:
+    tb_frame: FakeFrameType
+    tb_lineno: int = 0
+    tb_next: FakeTraceback | None = None
+
+
+@dataclass(frozen=True)
+class FakeFrameType:
+    f_code: FakeCodeType
+    f_lasti: int = 0
+    f_locals: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FakeCodeType:
+    co_filename: str
+    co_name: str = "co_name"
+
+    def co_positions(
+        self,
+    ) -> Iterable[tuple[int | None, int | None, int | None, int | None]]:
+        return [(None, None, None, None)]
+
+
+def test_traceback_non_existent_paths() -> None:
+    existing_absolute_file = tempfile.NamedTemporaryFile()
+    existing_relative_file = tempfile.NamedTemporaryFile(dir=".")
+    nonexisting_absolute_filename = "/absolute_nonexisting_file"
+    nonexisting_relative_filename = "relative_nonexisting_file"
+    traceback_filenames = [
+        # Existing absolute path should be unchanged.
+        existing_absolute_file.name,
+        # The relative path should be converted into an absolute path below.
+        os.path.basename(existing_relative_file.name),
+        # Nonexisting absolute path should be unchanged.
+        nonexisting_absolute_filename,
+        # Nonexisting relative path should be unchanged.
+        nonexisting_relative_filename,
+    ]
+    expected_traceback_filenames = [
+        existing_absolute_file.name,
+        # This is the absolute path, not the relative path as above.
+        existing_relative_file.name,
+        nonexisting_absolute_filename,
+        nonexisting_relative_filename,
+    ]
+    for traceback_filename, expected_traceback_filename in zip(
+        traceback_filenames, expected_traceback_filenames
+    ):
+        fake_traceback = FakeTraceback(
+            tb_frame=FakeFrameType(
+                f_code=FakeCodeType(
+                    co_filename=traceback_filename,
+                )
+            ),
+        )
+        rich_traceback = Traceback.extract(
+            exc_type=Exception,
+            exc_value=Exception(),
+            traceback=fake_traceback,
+        )
+        assert len(rich_traceback.stacks) == 1
+        stack = rich_traceback.stacks[0]
+        assert len(stack.frames) == 1
+        frame = stack.frames[0]
+        assert frame.filename == expected_traceback_filename

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -7,7 +7,6 @@ import sys
 import tempfile
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from types import CodeType, FrameType, TracebackType
 from typing import Any, Iterable, List
 
 import pytest

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -304,16 +304,7 @@ def test_suppress():
     (
         # fmt: off
         [True, 3, ["test_rich_traceback_omit_optional_local_flag", "level1", "level3"]],
-        [
-            False,
-            4,
-            [
-                "test_rich_traceback_omit_optional_local_flag",
-                "level1",
-                "level2",
-                "level3",
-            ],
-        ],
+        [False, 4, ["test_rich_traceback_omit_optional_local_flag", "level1", "level2", "level3"]],
         # fmt: on
     ),
 )


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Currently Rich assumes that if a path in a traceback frame is relative, that it's relative to the current working directory. This is not the case when the Python application is running from a packaged bundle like a [PAR](https://google.github.io/subpar/subpar.html). In these cases the traceback loses the path information or the incorrect absolute path is used. This PR makes it so:
- `Frame.filename` is not absolute if the original filename does not exist in the first place. That would indicate that it's not relative to the current working directory.
- The path/filename is always shown in the traceback, not only if it exists.

I was considering replacing `rich.__init__._IMPORT_CWD`'s value to one that is reflective of `__file__` though that resulted in filenames relative to `/proc`. Those are not readable and this might change other expectations.

The `linecache` module understands the relative paths and even sometimes can give the lines inside of the PAR. (Though sometimes it cannot and I'm not sure when it can and cannot.) Regardless, this means we at least see some lines and also always see the location.
