### PR TITLE
Fix [BUG] @ breaks highlighting in hyperlink #3327

### DIFF
--- a/rich/highlighter.py
+++ b/rich/highlighter.py
@@ -98,7 +98,7 @@ class ReprHighlighter(RegexHighlighter):
             r"(?P<number>(?<!\w)\-?[0-9]+\.?[0-9]*(e[-+]?\d+?)?\b|0x[0-9a-fA-F]*)",
             r"(?P<path>\B(/[-\w._+]+)*\/)(?P<filename>[-\w._+]*)?",
             r"(?<![\\\w])(?P<str>b?'''.*?(?<!\\)'''|b?'.*?(?<!\\)'|b?\"\"\".*?(?<!\\)\"\"\"|b?\".*?(?<!\\)\")",
-            r"(?P<url>(file|https|http|ws|wss)://[-0-9a-zA-Z$_+!`(),.?/;:&=%#~]*)",
+            r"(?P<url>(file|https|http|ws|wss)://[-0-9a-zA-Z$_+!`(),.?/;:&=%#~@]*)",
         ),
     ]
 

--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -134,6 +134,7 @@ highlight_tests = [
     (" http://example.org ", [Span(1, 19, "repr.url")]),
     (" http://example.org/index.html ", [Span(1, 30, "repr.url")]),
     (" http://example.org/index.html#anchor ", [Span(1, 37, "repr.url")]),
+    ("https://www.youtube.com/@LinusTechTips", [Span(0, 38, "repr.url")]),
     (
         " http://example.org/index.html?param1=value1 ",
         [


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description
Fixed the bug [#3327](https://github.com/Textualize/rich/issues/3327).

Changes -
1. Added '@' in rich.highlighter:ReprHighlighter url regex pattern.
2. Added a test case in test_highlighter for the url with '@'.

## Note
Poetry installed black v22.12.0 and its formatting differs a bit from the latest version v24.8.0. Hence I've formatted with the prior to keep it consistent.