### PR TITLE
feat(live): add support for using asyncio.Task as an alternative to threading.Thread to handle live updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds support for using `asyncio.Task` as an alternative to `threading.Thread` to handle live updates
 - Adds a `case_sensitive` parameter to `prompt.Prompt`. This determines if the
   response is treated as case-sensitive. Defaults to `True`.
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -64,6 +64,7 @@ The following people have contributed to the development of Rich:
 - [Luca Salvarani](https://github.com/LukeSavefrogs)
 - [Paul Sanders](https://github.com/sanders41)
 - [Tim Savage](https://github.com/timsavage)
+- [Dominik Schwabe](https://github.com/dominik-schwabe)
 - [Anthony Shaw](https://github.com/tonybaloney)
 - [Nicolas Simonds](https://github.com/0xDEC0DE)
 - [Aaron Stephens](https://github.com/aaronst)

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,11 +1,31 @@
 # encoding=utf-8
+import asyncio
 import time
-from typing import Optional
+from typing import Literal, Optional
 
 # import pytest
 from rich.console import Console
-from rich.live import Live
+from rich.live import Live, _AsyncioTaskRefresher, _ThreadRefresher
 from rich.text import Text
+
+
+def test_refresher() -> None:
+    def get_refresher(refresh_method: Literal["thread", "asyncio_task", "auto"]):
+        with Live("", refresh_method=refresh_method) as live:
+            return live._refresher
+
+    async def async_get_refresher(
+        refresh_method: Literal["thread", "asyncio_task", "auto"],
+    ):
+        return get_refresher(refresh_method)
+
+    assert isinstance(get_refresher("thread"), _ThreadRefresher)
+    assert isinstance(asyncio.run(async_get_refresher("thread")), _ThreadRefresher)
+    assert isinstance(
+        asyncio.run(async_get_refresher("asyncio_task")), _AsyncioTaskRefresher
+    )
+    assert isinstance(get_refresher("auto"), _ThreadRefresher)
+    assert isinstance(asyncio.run(async_get_refresher("auto")), _AsyncioTaskRefresher)
 
 
 def create_capture_console(


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This pull request adds support for using asyncio.Task as an alternative to threading.Thread to handle live updates.
The main reason for implementing this is that when using `__import__('pdb').set_trace()` or something similar, the screen keeps getting updated making it impossible to debug. Since `__import__('pdb').set_trace()` interrupts the event loop, this problem wont happen when using async code to handle the updates. Additionally it seams natural to use the event loop to handle the updates when one is available.
I set the default to determining the refresh method to `"auto"`, which determines the method based on if there is a running event loop.