### PR TITLE
Add scripts configuration for markdown, syntax, and json modules to be called directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [13.9.0]
+
+### Added
+
+- Added script entry points for `rich.markdown`, `rich.syntax`, and `rich.json` to allow for direct execution with uvx or pipx.
+
 ## [13.8.0] - 2024-08-26
 
 ### Fixed
@@ -2060,6 +2066,7 @@ Major version bump for a breaking change to `Text.stylize signature`, which corr
 
 - First official release, API still to be stabilized
 
+[13.9.0]: https://github.com/textualize/rich/compare/v13.8.0...v13.9.0
 [13.8.0]: https://github.com/textualize/rich/compare/v13.7.1...v13.8.0
 [13.7.1]: https://github.com/textualize/rich/compare/v13.7.0...v13.7.1
 [13.7.0]: https://github.com/textualize/rich/compare/v13.6.0...v13.7.0

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ The following people have contributed to the development of Rich:
 - [Robin Bowes](https://github.com/yo61)
 - [Dennis Brakhane](https://github.com/brakhane)
 - [Darren Burns](https://github.com/darrenburns)
+- [Nathan Cain](https://github.com/nathanscain)
 - [Ceyda Cinarel](https://github.com/cceyda)
 - [Jim Crist-Harif](https://github.com/jcrist)
 - [Ed Davis](https://github.com/davised)

--- a/docs/source/console.rst
+++ b/docs/source/console.rst
@@ -90,6 +90,16 @@ You can also pretty print JSON via the command line with the following::
 
     python -m rich.json cats.json
 
+Rich additionally adds the ``rich.json`` command into your environment when installed. The following behaves identically to the above example::
+
+    rich.json cats.json
+
+This functionality can also be run directly with pipx or uvx using the following commands::
+
+    uvx --from rich rich.json FILE
+
+    pipx run --spec rich rich.json FILE
+
 
 Low level output
 ----------------

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -26,9 +26,15 @@ You can install Rich from PyPI with `pip` or your favorite package manager::
 
 Add the ``-U`` switch to update to the current version, if Rich is already installed.
 
-If you intend to use Rich with Jupyter then there are some additional dependencies which you can install with the following command::
+If you intend to use Rich with Jupyter, then there are some additional dependencies which you can install with the following command::
 
     pip install "rich[jupyter]"
+
+If you only wish to use rich's exported commands for displaying markdown, json, and syntax highlighting in your terminal, then you may instead install rich as an isolated tool with ``uv`` or ``pipx``::
+
+    uv tool install rich
+
+    pipx install rich
 
 
 Quick Start

--- a/docs/source/markdown.rst
+++ b/docs/source/markdown.rst
@@ -24,6 +24,16 @@ You can also use the Markdown class from the command line. The following example
 
     python -m rich.markdown README.md
 
+Rich additionally adds the ``rich.markdown`` command into your environment when installed. The following behaves identically to the above example::
+
+    rich.markdown README.md
+
 Run the following to see the full list of arguments for the markdown command::
 
-    python -m rich.markdown -h
+    rich.markdown -h
+
+This functionality can also be run directly with uvx or pipx using the following commands respectively::
+
+    uvx --from rich rich.markdown FILE
+
+    pipx run --spec rich rich.markdown FILE

--- a/docs/source/syntax.rst
+++ b/docs/source/syntax.rst
@@ -51,7 +51,17 @@ You can use this class from the command line. Here's how you would syntax highli
 
     python -m rich.syntax syntax.py
 
+Rich additionally adds the ``rich.syntax`` command into your environment when installed. The following behaves identically to the above example::
+
+    rich.syntax syntax.py
+
 For the full list of arguments, run the following::
 
-    python -m rich.syntax -h
-    
+    rich.syntax -h
+
+This functionality can also be run directly with uvx or pipx using the following commands respectively::
+
+    uvx --from rich rich.syntax FILE
+
+    pipx run --spec rich rich.syntax FILE
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ pre-commit = "^2.17.0"
 asv = "^0.5.1"
 importlib-metadata = { version = "*", python = "<3.8" }
 
+[tool.poetry.scripts]
+"rich.markdown" = "rich.markdown:_main"
+"rich.syntax" = "rich.syntax:_main"
+"rich.json" = "rich.json:_main"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/rich/json.py
+++ b/rich/json.py
@@ -102,7 +102,8 @@ class JSON:
         return self.text
 
 
-if __name__ == "__main__":
+def _main() -> None:  # pragma: no cover
+    """Provide CLI interface for JSON rendering."""
     import argparse
     import sys
 
@@ -137,3 +138,7 @@ if __name__ == "__main__":
         sys.exit(-1)
 
     console.print(JSON(json_data, indent=args.indent), soft_wrap=True)
+
+
+if __name__ == "__main__":
+    _main()

--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -686,7 +686,8 @@ class Markdown(JupyterMixin):
                     new_line = element.new_line
 
 
-if __name__ == "__main__":  # pragma: no cover
+def _main() -> None:  # pragma: no cover
+    """Provide CLI interface for markdown rendering."""
     import argparse
     import sys
 
@@ -782,3 +783,7 @@ if __name__ == "__main__":  # pragma: no cover
             force_terminal=args.force_color, width=args.width, record=True
         )
         console.print(markdown)
+
+
+if __name__ == "__main__":
+    _main()

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -835,7 +835,8 @@ def _get_code_index_for_syntax_position(
     return newlines_offsets[line_index] + column_index
 
 
-if __name__ == "__main__":  # pragma: no cover
+def _main() -> None:  # pragma: no cover
+    """Provide CLI interface for syntax rendering."""
     import argparse
     import sys
 
@@ -953,3 +954,7 @@ if __name__ == "__main__":  # pragma: no cover
             highlight_lines={args.highlight_line},
         )
     console.print(syntax, soft_wrap=args.soft_wrap)
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [~] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I was trying to use rich's terminal rendering of markdown files earlier today, but the project wasn't using rich so `python -m rich.markdown` wouldn't work without me editing my virtual environment to include items that weren't listed in my `pyproject.toml` configuration. Typically I'd solve this by installing the package as a tool that has globally callable commands, but rich doesn't currently export any commands.

This PR adds `tool.poetry.scripts` entries for each of the 3 directly usable commands (markdown, syntax, and json). This required moving the content currently under `if __name__ == "__main__":` sections to be under a protected `_main` method so that both the scripts and module (`python -m`) entrypoints would execute the same code.

Now users can use `uv` or `pipx` to install rich as a tool so that these commands are always available:

```
uv tool install rich
rich.markdown README.md
```

I'm open to whatever naming convention you'd prefer. Currently the commands are `rich.markdown`, `rich.syntax`, and `rich.json` to mirror the module entrypoints, but these could also be `rich-markdown`, `rich-syntax`, and `rich-json` (or anything else — the only limiting factors are that they shouldn't have spaces and should be clearly tied to rich since the goal is for them to be installed globally without conflicts.)

The change is documented based on the surrounding style. I wasn't able to test building the documentation due a resolution error within the provided `requirements.txt`:

```
ERROR: Cannot install -r requirements.txt (line 2) and alabaster==0.7.12 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested alabaster==0.7.12
    sphinx 7.3.7 depends on alabaster~=0.7.14

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict
```
