### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,9 +6,10 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - { os: ubuntu-latest, python-version: "3.7" }
           - { os: windows-latest, python-version: "3.7" }
@@ -22,6 +23,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install and configure Poetry
         # TODO: workaround for https://github.com/snok/install-poetry/issues/94
         uses: snok/install-poetry@v1.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Added support for Python 3.13 https://github.com/Textualize/rich/pull/3481
 - Fixed infinite loop when appending Text to same instance https://github.com/Textualize/rich/pull/3480
 
 ## [13.8.0] - 2024-08-26

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
 include = ["rich/py.typed"]

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -668,7 +668,10 @@ def test_attrs_broken_310() -> None:
     del foo.bar
     result = pretty_repr(foo)
     print(repr(result))
-    expected = "Foo(bar=AttributeError(\"'Foo' object has no attribute 'bar'\"))"
+    if sys.version_info >= (3, 13):
+        expected = "Foo(\n    bar=AttributeError(\"'tests.test_pretty.test_attrs_broken_310.<locals>.Foo' object has no attribute 'bar'\")\n)"
+    else:
+        expected = "Foo(bar=AttributeError(\"'Foo' object has no attribute 'bar'\"))"
     assert result == expected
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion = 4.0.0
 envlist =
     lint
     docs
-    py{37,38,39,310,311}
+    py{37,38,39,310,311,312,313}
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The final Python 3.13 release candidate is out now! :rocket:

The Release Manager has issued a [call to action](https://discuss.python.org/t/python-3-13-0rc2-3-12-6-3-11-10-3-10-15-3-9-20-and-3-8-20-are-now-available/63161?u=hugovk]):

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.13 compatibilities during this phase, and where necessary publish Python 3.13 wheels on PyPI to be ready for the final release of 3.13.0. Any binary wheels built against Python 3.13.0rc2 will work with future versions of Python 3.13. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).

This PR adds 3.13 to the CI and tox, and fixes a test that fails on 3.13.