### PR TITLE
Add numerical choices to prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added possibility to have numerical choices in prompt
+
 ### Changed
 
 - Rich will display tracebacks with finely grained error locations on python 3.11+ https://github.com/Textualize/rich/pull/3486

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -87,3 +87,4 @@ The following people have contributed to the development of Rich:
 - [Bernhard Wagner](https://github.com/bwagner)
 - [Aaron Beaudoin](https://github.com/AaronBeaudoin)
 - [Jonathan Helmus](https://github.com/jjhelmus)
+- [Marco Cattani](https://github.com/cattanimarco)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [x] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I have added the option to prompt to have a numerical choice. This avoid the user to type long options. Suggestion how to better implement the feature are welcome 😄 