### PR TITLE
Require typing_extensions in Python 3.9 and 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.9.1]
+
+### Fixed
+
+- Fixed missing dependency on typing_extensions library in Python 3.9 and 3.10.
+
 ## [13.9.0] - 2024-10-01
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -91,3 +91,4 @@ The following people have contributed to the development of Rich:
 - [L. Yeung](https://github.com/lewis-yeung)
 - [chthollyphile](https://github.com/chthollyphile)
 - [Jonathan Helmus](https://github.com/jjhelmus)
+- [Takashi Kajinami](https://github.com/kajinamit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ include = ["rich/py.typed"]
 
 [tool.poetry.dependencies]
 python = ">=3.8.0"
-typing-extensions = { version = ">=4.0.0, <5.0", python = "<3.9" }
+typing-extensions = { version = ">=4.0.0, <5.0", python = "<3.11" }
 pygments = "^2.13.0"
 ipywidgets = { version = ">=7.5.1,<9", optional = true }
 markdown-it-py = ">=2.2.0"


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Since 67e68f372 was merged, the rich.progress module requires the external typing_extensions library in Python 3.9 and 3.10. Bump the upper version to meet that requirement.

Fixes #3511
