### PR TITLE
Drop Python 3.7 leftovers

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ sphinx:
 formats: all
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See what [people are saying about Rich](https://www.willmcgugan.com/blog/pages/p
 
 ## Compatibility
 
-Rich works with Linux, macOS and Windows. True color / emoji works with new Windows Terminal, classic terminal is limited to 16 colors. Rich requires Python 3.7 or later.
+Rich works with Linux, macOS and Windows. True color / emoji works with new Windows Terminal, classic terminal is limited to 16 colors. Rich requires Python 3.8 or later.
 
 Rich works with [Jupyter notebooks](https://jupyter.org/) with no additional configuration required.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -45,7 +44,6 @@ pytest-cov = "^3.0.0"
 attrs = "^21.4.0"
 pre-commit = "^2.17.0"
 asv = "^0.5.1"
-importlib-metadata = { version = "*", python = "<3.8" }
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -13,11 +13,6 @@ from rich._inspect import (
 )
 from rich.console import Console
 
-skip_py37 = pytest.mark.skipif(
-    sys.version_info.minor == 7 and sys.version_info.major == 3,
-    reason="rendered differently on py3.7",
-)
-
 skip_py38 = pytest.mark.skipif(
     sys.version_info.minor == 8 and sys.version_info.major == 3,
     reason="rendered differently on py3.8",
@@ -122,7 +117,6 @@ def test_inspect_text():
     assert render("Hello") == expected
 
 
-@skip_py37
 @skip_pypy3
 def test_inspect_empty_dict():
     expected = (
@@ -221,7 +215,6 @@ def test_inspect_integer_with_value():
     assert value == expected
 
 
-@skip_py37
 @skip_py310
 @skip_py311
 @skip_py312
@@ -259,7 +252,6 @@ def test_inspect_integer_with_methods_python38_and_python39():
     assert render(1, methods=True) == expected
 
 
-@skip_py37
 @skip_py38
 @skip_py39
 @skip_py311
@@ -302,7 +294,6 @@ def test_inspect_integer_with_methods_python310only():
     assert render(1, methods=True) == expected
 
 
-@skip_py37
 @skip_py38
 @skip_py39
 @skip_py310
@@ -347,7 +338,6 @@ def test_inspect_integer_with_methods_python311():
     assert render(1, methods=True) == expected
 
 
-@skip_py37
 @skip_pypy3
 def test_broken_call_attr():
     class NotCallable:

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -14,10 +14,6 @@ from rich.measure import Measurement
 from rich.pretty import Node, Pretty, _ipy_display_hook, install, pprint, pretty_repr
 from rich.text import Text
 
-skip_py37 = pytest.mark.skipif(
-    sys.version_info.minor == 7 and sys.version_info.major == 3,
-    reason="rendered differently on py3.7",
-)
 skip_py38 = pytest.mark.skipif(
     sys.version_info.minor == 8 and sys.version_info.major == 3,
     reason="rendered differently on py3.8",
@@ -656,7 +652,6 @@ def test_attrs_broken() -> None:
     assert result == expected
 
 
-@skip_py37
 @skip_py38
 @skip_py39
 def test_attrs_broken_310() -> None:

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Optional
 
 import pytest
@@ -7,11 +6,6 @@ import rich.repr
 from rich.console import Console
 
 from inspect import Parameter
-
-skip_py37 = pytest.mark.skipif(
-    sys.version_info.minor == 7 and sys.version_info.major == 3,
-    reason="rendered differently on py3.7",
-)
 
 
 @rich.repr.auto
@@ -100,7 +94,6 @@ def test_rich_repr() -> None:
     assert (repr(Foo("hello", bar=3))) == "Foo('hello', 'hello', bar=3, egg=1)"
 
 
-@skip_py37
 def test_rich_repr_positional_only() -> None:
     _locals = locals().copy()
     exec(

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ minversion = 4.0.0
 envlist =
     lint
     docs
-    py{37,38,39,310,311,312,313}
+    py{38,39,310,311,312,313}
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
## Type of changes

- [X] Documentation / docstrings
- [X] Tests
- [X] Other

## Description

Some Python 3.7 leftovers remained when support for Python 3.7 was dropped in https://github.com/Textualize/rich/releases/tag/v13.9.0.

This completes the drop. Eg. PyPI still shows support for `3.7`.

<img width="385" alt="Screenshot" src="https://github.com/user-attachments/assets/99bfa9f8-c0b7-42ad-a286-be20e7487eac">
