### PR TITLE
fix(table): highlight columns added by add_row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `Table` columns not highlighting when added by `add_row` https://github.com/Textualize/rich/issues/3517
+
 ## [13.9.1] - 2024-10-01
 
 ### Fixed

--- a/rich/table.py
+++ b/rich/table.py
@@ -451,7 +451,7 @@ class Table(JupyterMixin):
             ]
         for index, renderable in enumerate(cell_renderables):
             if index == len(columns):
-                column = Column(_index=index)
+                column = Column(_index=index, highlight=self.highlight)
                 for _ in self.rows:
                     add_cell(column, Text(""))
                 self.columns.append(column)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -363,6 +363,25 @@ def test_placement_table_box_elements(show_header, show_footer, expected):
     assert output == expected
 
 
+def test_columns_highlight_added_by_add_row() -> None:
+    """Regression test for https://github.com/Textualize/rich/issues/3517"""
+    table = Table(show_header=False, highlight=True)
+    table.add_row("1", repr("FOO"))
+
+    assert table.columns[0].highlight == table.highlight
+    assert table.columns[1].highlight == table.highlight
+
+    console = Console(record=True)
+    console.print(table)
+    output = console.export_text(styles=True)
+    print(repr(output))
+
+    expected = (
+        "┌───┬───────┐\n│ \x1b[1;36m1\x1b[0m │ \x1b[32m'FOO'\x1b[0m │\n└───┴───────┘\n"
+    )
+    assert output == expected
+
+
 if __name__ == "__main__":
     render = render_tables()
     print(render)


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes #3517. The default value for the `Column.highlight` is False, so where necessary columns are added by the `add_row` method this should default to the `Table.highlight` value.