### PR TITLE
docs(table): add column highlight option

### DIFF
--- a/docs/source/tables.rst
+++ b/docs/source/tables.rst
@@ -142,6 +142,7 @@ There are a number of options you can set on a column to modify how it will look
 - ``max_width`` When set to an integer will prevent the column from growing beyond this amount.
 - ``ratio`` Defines a ratio to set the column width. For instance, if there are 3 columns with a total of 6 ratio, and ``ratio=2`` then the column will be a third of the available size.
 - ``no_wrap`` Set to True to prevent this column from wrapping.
+- ``highlight`` Set to True to enable automatic highlighting of cell contents.
 
 Vertical Alignment
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

While investigating an issue with the table, I noticed that the column `highlight` option was missing in the documentation.
