### PR TITLE
REQUEST-3552: Added a choices separator to Prompt.ask. This argument …

### DIFF
--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -39,6 +39,7 @@ class PromptBase(Generic[PromptType]):
         case_sensitive (bool, optional): Matching of choices should be case-sensitive. Defaults to True.
         show_default (bool, optional): Show default in prompt. Defaults to True.
         show_choices (bool, optional): Show choices in prompt. Defaults to True.
+        choices_separator (str, optional): Separator for choices. Defaults to "/".
     """
 
     response_type: type = str
@@ -61,6 +62,7 @@ class PromptBase(Generic[PromptType]):
         case_sensitive: bool = True,
         show_default: bool = True,
         show_choices: bool = True,
+        choices_separator: str = "/",
     ) -> None:
         self.console = console or get_console()
         self.prompt = (
@@ -74,6 +76,7 @@ class PromptBase(Generic[PromptType]):
         self.case_sensitive = case_sensitive
         self.show_default = show_default
         self.show_choices = show_choices
+        self.choices_separator = choices_separator
 
     @classmethod
     @overload
@@ -87,6 +90,7 @@ class PromptBase(Generic[PromptType]):
         case_sensitive: bool = True,
         show_default: bool = True,
         show_choices: bool = True,
+        choices_separator: str = "/",
         default: DefaultType,
         stream: Optional[TextIO] = None,
     ) -> Union[DefaultType, PromptType]:
@@ -104,6 +108,7 @@ class PromptBase(Generic[PromptType]):
         case_sensitive: bool = True,
         show_default: bool = True,
         show_choices: bool = True,
+        choices_separator: str = "/",
         stream: Optional[TextIO] = None,
     ) -> PromptType:
         ...
@@ -119,6 +124,7 @@ class PromptBase(Generic[PromptType]):
         case_sensitive: bool = True,
         show_default: bool = True,
         show_choices: bool = True,
+        choices_separator: str = "/",
         default: Any = ...,
         stream: Optional[TextIO] = None,
     ) -> Any:
@@ -135,6 +141,7 @@ class PromptBase(Generic[PromptType]):
             case_sensitive (bool, optional): Matching of choices should be case-sensitive. Defaults to True.
             show_default (bool, optional): Show default in prompt. Defaults to True.
             show_choices (bool, optional): Show choices in prompt. Defaults to True.
+            choices_separator (str, optional): Separator for choices. Defaults to "/".
             stream (TextIO, optional): Optional text file open for reading to get input. Defaults to None.
         """
         _prompt = cls(
@@ -145,6 +152,7 @@ class PromptBase(Generic[PromptType]):
             case_sensitive=case_sensitive,
             show_default=show_default,
             show_choices=show_choices,
+            choices_separator=choices_separator,
         )
         return _prompt(default=default, stream=stream)
 
@@ -172,7 +180,7 @@ class PromptBase(Generic[PromptType]):
         prompt.end = ""
 
         if self.show_choices and self.choices:
-            _choices = "/".join(self.choices)
+            _choices = self.choices_separator.join(self.choices)
             choices = f"[{_choices}]"
             prompt.append(" ")
             prompt.append(choices, "prompt.choices")

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -21,6 +21,41 @@ def test_prompt_str():
     assert output == expected
 
 
+def test_prompt_str_choices_separator():
+    # Default separator is '/'
+    INPUT = "egg\nfoo"
+    console = Console(file=io.StringIO())
+    name = Prompt.ask(
+        "what is your name",
+        console=console,
+        choices=["foo", "bar"],
+        default="baz",
+        stream=io.StringIO(INPUT),
+    )
+    assert name == "foo"
+    expected = "what is your name [foo/bar] (baz): Please select one of the available options\nwhat is your name [foo/bar] (baz): "
+    output = console.file.getvalue()
+    print(repr(output))
+    assert output == expected
+
+    # Custom separator
+    INPUT = "egg\nfoo"
+    console = Console(file=io.StringIO())
+    name = Prompt.ask(
+        "what is your name",
+        console=console,
+        choices=["foo", "bar"],
+        default="baz",
+        choices_separator=" | ",
+        stream=io.StringIO(INPUT),
+    )
+    assert name == "foo"
+    expected = "what is your name [foo | bar] (baz): Please select one of the available options\nwhat is your name [foo | bar] (baz): "
+    output = console.file.getvalue()
+    print(repr(output))
+    assert output == expected
+
+
 def test_prompt_str_case_insensitive():
     INPUT = "egg\nFoO"
     console = Console(file=io.StringIO())


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [x] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Issue - https://github.com/Textualize/rich/issues/3552

Added a choices separator to Prompt.ask. This argument will allow the choices to be separated by anything other than the default "/" in the console.

Example


```sh
from rich.prompt import Prompt

predicate = Prompt.ask(
	f"[green]Enter the animal name[/green]",
	choices=["Lion", "Tiger", "Bear", "Giraffe", "Elephant"],
	case_sensitive=False,
	show_choices=True,
        choices_separator=" | " 
)
```

> Enter the animal name [Lion | Tiger | Bear | Giraffe | Elephant]:
