### PR TITLE
ISSUE-3062: Updated the code to optionally pass custom validate_error…

### DIFF
--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -39,11 +39,11 @@ class PromptBase(Generic[PromptType]):
         case_sensitive (bool, optional): Matching of choices should be case-sensitive. Defaults to True.
         show_default (bool, optional): Show default in prompt. Defaults to True.
         show_choices (bool, optional): Show choices in prompt. Defaults to True.
+        validate_error_message (str, optional): Customised error message to display when input is invalid.
     """
 
     response_type: type = str
 
-    validate_error_message = "[prompt.invalid]Please enter a valid value"
     illegal_choice_message = (
         "[prompt.invalid.choice]Please select one of the available options"
     )
@@ -61,6 +61,7 @@ class PromptBase(Generic[PromptType]):
         case_sensitive: bool = True,
         show_default: bool = True,
         show_choices: bool = True,
+        validate_error_message: str = "[prompt.invalid]Please enter a valid value"
     ) -> None:
         self.console = console or get_console()
         self.prompt = (
@@ -74,6 +75,7 @@ class PromptBase(Generic[PromptType]):
         self.case_sensitive = case_sensitive
         self.show_default = show_default
         self.show_choices = show_choices
+        self.validate_error_message = validate_error_message
 
     @classmethod
     @overload
@@ -89,6 +91,7 @@ class PromptBase(Generic[PromptType]):
         show_choices: bool = True,
         default: DefaultType,
         stream: Optional[TextIO] = None,
+        validate_error_message: str = "",
     ) -> Union[DefaultType, PromptType]:
         ...
 
@@ -105,6 +108,7 @@ class PromptBase(Generic[PromptType]):
         show_default: bool = True,
         show_choices: bool = True,
         stream: Optional[TextIO] = None,
+        validate_error_message: str = "",
     ) -> PromptType:
         ...
 
@@ -121,6 +125,7 @@ class PromptBase(Generic[PromptType]):
         show_choices: bool = True,
         default: Any = ...,
         stream: Optional[TextIO] = None,
+        validate_error_message: str = "",
     ) -> Any:
         """Shortcut to construct and run a prompt loop and return the result.
 
@@ -136,6 +141,7 @@ class PromptBase(Generic[PromptType]):
             show_default (bool, optional): Show default in prompt. Defaults to True.
             show_choices (bool, optional): Show choices in prompt. Defaults to True.
             stream (TextIO, optional): Optional text file open for reading to get input. Defaults to None.
+            validate_error_message (str, optional): Customised error message to display when input is invalid.
         """
         _prompt = cls(
             prompt,
@@ -145,6 +151,7 @@ class PromptBase(Generic[PromptType]):
             case_sensitive=case_sensitive,
             show_default=show_default,
             show_choices=show_choices,
+            validate_error_message=validate_error_message,
         )
         return _prompt(default=default, stream=stream)
 
@@ -322,7 +329,11 @@ class IntPrompt(PromptBase[int]):
     """
 
     response_type = int
-    validate_error_message = "[prompt.invalid]Please enter a valid integer number"
+    def __init__(self, *args, **kwargs):
+        if not kwargs.get("validate_error_message"):
+            kwargs["validate_error_message"] = "[prompt.invalid]Please enter a valid integer number"
+
+        super().__init__(*args, **kwargs)
 
 
 class FloatPrompt(PromptBase[float]):
@@ -334,7 +345,11 @@ class FloatPrompt(PromptBase[float]):
     """
 
     response_type = float
-    validate_error_message = "[prompt.invalid]Please enter a number"
+    def __init__(self, *args, **kwargs):
+        if not kwargs.get("validate_error_message"):
+            kwargs["validate_error_message"] = "[prompt.invalid]Please enter a valid number"
+
+        super().__init__(*args, **kwargs)
 
 
 class Confirm(PromptBase[bool]):
@@ -347,8 +362,13 @@ class Confirm(PromptBase[bool]):
     """
 
     response_type = bool
-    validate_error_message = "[prompt.invalid]Please enter Y or N"
     choices: List[str] = ["y", "n"]
+
+    def __init__(self, *args, **kwargs):
+        if not kwargs.get("validate_error_message"):
+            kwargs["validate_error_message"] = "[prompt.invalid]Please enter Y or N"
+
+        super().__init__(*args, **kwargs)
 
     def render_default(self, default: DefaultType) -> Text:
         """Render the default as (y) or (n) rather than True/False."""

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,4 +1,5 @@
 import io
+from unittest.mock import patch
 
 from rich.console import Console
 from rich.prompt import Confirm, IntPrompt, Prompt
@@ -55,6 +56,30 @@ def test_prompt_str_default():
     assert output == expected
 
 
+def test_prompt_str_custom_error_message():
+    def side_effect_once(*args, **kwargs):
+        if not hasattr(side_effect_once, "called"):
+            side_effect_once.called = True
+            raise ValueError("Mocked error")
+        return args[0]
+
+    INPUT = "foo\nWill"
+    console = Console(file=io.StringIO())
+    validate_error_message = "Please enter a valid name"
+    with patch.object(Prompt, "response_type", side_effect=side_effect_once):
+        name = Prompt.ask(
+            "what is your name",
+            console=console,
+            stream=io.StringIO(INPUT),
+            validate_error_message="Please enter a valid name",
+        )
+        expected = f"what is your name: {validate_error_message}\nwhat is your name: "
+        assert name == "Will"
+        output = console.file.getvalue()
+        print(repr(output))
+        assert output == expected
+
+
 def test_prompt_int():
     INPUT = "foo\n100"
     console = Console(file=io.StringIO())
@@ -65,6 +90,23 @@ def test_prompt_int():
     )
     assert number == 100
     expected = "Enter a number: Please enter a valid integer number\nEnter a number: "
+    output = console.file.getvalue()
+    print(repr(output))
+    assert output == expected
+
+
+def test_prompt_int_custom_error_message():
+    INPUT = "foo\n100"
+    console = Console(file=io.StringIO())
+    validate_error_message = "Invalid Integer. Enter a valid integer"
+    number = IntPrompt.ask(
+        "Enter a number",
+        console=console,
+        stream=io.StringIO(INPUT),
+        validate_error_message=validate_error_message,
+    )
+    assert number == 100
+    expected = f"Enter a number: {validate_error_message}\nEnter a number: "
     output = console.file.getvalue()
     print(repr(output))
     assert output == expected
@@ -85,6 +127,23 @@ def test_prompt_confirm_no():
     assert output == expected
 
 
+def test_prompt_confirm_no_custom_error_message():
+    INPUT = "foo\nNO\nn"
+    console = Console(file=io.StringIO())
+    validate_error_message = "Invalid input. Enter only Y or N"
+    answer = Confirm.ask(
+        "continue",
+        console=console,
+        stream=io.StringIO(INPUT),
+        validate_error_message=validate_error_message,
+    )
+    assert answer is False
+    expected = f"continue [y/n]: {validate_error_message}\ncontinue [y/n]: {validate_error_message}\ncontinue [y/n]: "
+    output = console.file.getvalue()
+    print(repr(output))
+    assert output == expected
+
+
 def test_prompt_confirm_yes():
     INPUT = "foo\nNO\ny"
     console = Console(file=io.StringIO())
@@ -100,14 +159,52 @@ def test_prompt_confirm_yes():
     assert output == expected
 
 
+def test_prompt_confirm_yes_custom_error_message():
+    INPUT = "foo\nNO\ny"
+    console = Console(file=io.StringIO())
+    validate_error_message = "Invalid input. Enter only Y or N"
+    answer = Confirm.ask(
+        "continue",
+        console=console,
+        stream=io.StringIO(INPUT),
+        validate_error_message=validate_error_message,
+    )
+    assert answer is True
+    expected = f"continue [y/n]: {validate_error_message}\ncontinue [y/n]: {validate_error_message}\ncontinue [y/n]: "
+    output = console.file.getvalue()
+    print(repr(output))
+    assert output == expected
+
+
 def test_prompt_confirm_default():
     INPUT = "foo\nNO\ny"
     console = Console(file=io.StringIO())
     answer = Confirm.ask(
-        "continue", console=console, stream=io.StringIO(INPUT), default=True
+        "continue",
+        console=console,
+        stream=io.StringIO(INPUT),
+        default=True,
     )
     assert answer is True
     expected = "continue [y/n] (y): Please enter Y or N\ncontinue [y/n] (y): Please enter Y or N\ncontinue [y/n] (y): "
+    output = console.file.getvalue()
+    print(repr(output))
+    assert output == expected
+
+
+def test_prompt_confirm_default_custom_error_message():
+    INPUT = "foo\nNO\ny"
+    console = Console(file=io.StringIO())
+    validate_error_message = "Invalid input. Enter only Y or N"
+    answer = Confirm.ask(
+        "continue",
+        console=console,
+        stream=io.StringIO(INPUT),
+        default=True,
+        validate_error_message=validate_error_message,
+    )
+    assert answer is True
+    expected = f"continue [y/n] (y): {validate_error_message}\ncontinue [y/n] (y): {validate_error_message}\ncontinue [y/n] (y): "
     output = console.file.getvalue()
     print(repr(output))
     assert output == expected


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [x] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Issue - https://github.com/Textualize/rich/issues/3062

Updated the code to optionally pass custom validate_error_message while making Prompt, IntPrompt, FloatPrompt and Confirm ask method.

Example

```python
    answer = Confirm.ask(
        "continue",
        console=console,
        stream=io.StringIO(INPUT),
        default=True,
        validate_error_message="[prompt.invalid]Per favore digita S o N",
    )
```
```python
    validate_error_message = "Invalid Integer. Enter a valid integer"
    number = IntPrompt.ask(
        "Enter a number",
        console=console,
        stream=io.StringIO(INPUT),
        validate_error_message=validate_error_message,
    )
```

