### PR TITLE
BUG-3536 - fix RichHandler not handling exception

### DIFF
--- a/rich/logging.py
+++ b/rich/logging.py
@@ -131,7 +131,11 @@ class RichHandler(Handler):
 
     def emit(self, record: LogRecord) -> None:
         """Invoked by logging."""
-        message = self.format(record)
+        try:
+            message = self.format(record)
+        except Exception:
+            self.handleError(record)
+
         traceback = None
         if (
             self.rich_tracebacks

--- a/rich/logging.py
+++ b/rich/logging.py
@@ -129,13 +129,9 @@ class RichHandler(Handler):
         )
         return level_text
 
-    def emit(self, record: LogRecord) -> None:
+    def _emit(self, record: LogRecord) -> None:
         """Invoked by logging."""
-        try:
-            message = self.format(record)
-        except Exception:
-            self.handleError(record)
-
+        message = self.format(record)
         traceback = None
         if (
             self.rich_tracebacks
@@ -182,6 +178,12 @@ class RichHandler(Handler):
                 self.console.print(log_renderable)
             except Exception:
                 self.handleError(record)
+
+    def emit(self, record: LogRecord) -> None:
+        try: 
+            return self._emit(record) 
+        except Exception: 
+            self.handleError(record)
 
     def render_message(self, record: LogRecord, message: str) -> "ConsoleRenderable":
         """Render message text in to Text.


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

RichHandler does not handle exceptions raised while formatting the log message, unlike default builtin Python handlers. The issue lies in emit method implementation.

Fixes #3536 

