### PR TITLE
Fix(prompt.py): #2994

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.9.4]
+
+### Fixed
+
+- Fixed importing readline breaks rich prompt alignement [#2994](https://github.com/Textualize/rich/issues/2994)
 
 ## [13.9.4] - 2024-11-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -75,6 +75,7 @@ The following people have contributed to the development of Rich:
 - [Arian Mollik Wasi](https://github.com/wasi-master)
 - [Jan van Wijk](https://github.com/jdvanwijk)
 - [Handhika Yanuar Pratama](https://github.com/theDreamer911)
+- [Tianyu Yuan](https://github.com/paperplane110)
 - [za](https://github.com/za)
 - [Motahhar Mokfi](https://github.com/motahhar)
 - [Tomer Shalev](https://github.com/tomers)

--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -292,7 +292,6 @@ class PromptBase(Generic[PromptType]):
             prompt = self.make_prompt(default)
             value = self.get_input(self.console, prompt, self.password, stream=stream)
             if ("readline" in sys.modules) and (value == ""):
-
                 print("")
             if value == "" and default != ...:
                 return default

--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Any, Generic, List, Optional, TextIO, TypeVar, Union, overload
 
 from . import get_console
@@ -290,6 +291,9 @@ class PromptBase(Generic[PromptType]):
             self.pre_prompt()
             prompt = self.make_prompt(default)
             value = self.get_input(self.console, prompt, self.password, stream=stream)
+            if ("readline" in sys.modules) and (value == ""):
+
+                print("")
             if value == "" and default != ...:
                 return default
             try:


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fix #2994 

When using `readline` and `Prompt.ask()`, then just pressing enter, prompt won't break line. Questions will all be printed in one line.

So, if `readline` is imported and user just enter nothing, use `print()` to break line.