### PR TITLE
Do not wrap text at no-break spaces

### DIFF
--- a/rich/_wrap.py
+++ b/rich/_wrap.py
@@ -6,7 +6,7 @@ from typing import Iterable
 from ._loop import loop_last
 from .cells import cell_len, chop_cells
 
-re_word = re.compile(r"\s*\S+\s*")
+re_word = re.compile("\\s*[\\S\N{NO-BREAK SPACE}]+\\s*")
 
 
 def words(text: str) -> Iterable[tuple[int, int, str]]:


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes #3545.

I was unable to run tests locally (`tox p` showed a bunch of errors, most of them about Poetry.lock being out of date.  I've never used Poetry before.  I ran `sudo apt install python3-poetry; poetry lock` and it popped up some KDE wallet initial setup wizard, in a loop.  I don't use KDE!  What is even going on here.)