### PR TITLE
Add option to pass a timezone into richhandler for log timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Allow a `log_time_zone` argument to be passed to `RichHandler`
+
 
 ## [13.9.4] - 2024-11-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -70,6 +70,7 @@ The following people have contributed to the development of Rich:
 - [Nicolas Simonds](https://github.com/0xDEC0DE)
 - [Aaron Stephens](https://github.com/aaronst)
 - [Karolina Surma](https://github.com/befeleme)
+- [Wei Jie Tan](https://github.com/PokkaKiyo)
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)
 - [Nils Vu](https://github.com/nilsvu)
 - [Arian Mollik Wasi](https://github.com/wasi-master)
@@ -91,4 +92,3 @@ The following people have contributed to the development of Rich:
 - [L. Yeung](https://github.com/lewis-yeung)
 - [chthollyphile](https://github.com/chthollyphile)
 - [Jonathan Helmus](https://github.com/jjhelmus)
-- [Tan Wei Jie](https://github.com/PokkaKiyo)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -91,3 +91,4 @@ The following people have contributed to the development of Rich:
 - [L. Yeung](https://github.com/lewis-yeung)
 - [chthollyphile](https://github.com/chthollyphile)
 - [Jonathan Helmus](https://github.com/jjhelmus)
+- [Tan Wei Jie](https://github.com/PokkaKiyo)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Add option to pass a timezone into RichHandler for log timestamps.

Currently, the timestamp produced by RichHandler ignores the "%z" field if it is passed into the dateformat, likely because the datetime object created in RichHandler.render is timezone-naive. We can make it timezone-aware by passing in the expected timezone when calling datetime.fromtimestamp on the log message's timestamp.

The current alternative to doing this would be something like
```python
import logging
from datetime import UTC, datetime

from rich.logging import RichHandler
from rich.text import Text

logging.basicConfig(
    level="NOTSET",
    format="%(message)s",
    handlers=[
        RichHandler(
            rich_tracebacks=True,
            tracebacks_show_locals=True,
            log_time_format=lambda dt: Text(
                datetime.fromtimestamp(dt.timestamp(), tz=UTC).strftime("%Y-%m-%dT%H:%M:%S%z")
            ),
        )
    ],
)
logging.debug("hello")  # 2024-11-24T08:53:00+0000 DEBUG    hello 
```
