### PR TITLE
Fix Read the Docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,8 +11,11 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
+build:
+  os: ubuntu-24.04
+  tools:
+    python: 3.8
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Part of fix #3575.

Fix .readthedocs.yml.

Refs:
- `build.os`: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os
- `python.install`: https://docs.readthedocs.io/en/stable/config-file/v2.html#python-install