### PR TITLE
Fix: When using inline HTML styles, directly apply rules to anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [13.9.5] - 2024-12-03
+
+### Fixed
+
+- When using inline HTML styles, directly apply rules to anchors https://github.com/Textualize/rich/pull/3580
+
 ## [13.9.4] - 2024-11-01
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@ The following people have contributed to the development of Rich:
 - [Jim Crist-Harif](https://github.com/jcrist)
 - [Ed Davis](https://github.com/davised)
 - [Pete Davison](https://github.com/pd93)
+- [Christophe Dufaza](https://github.com/dottspina)
 - [James Estevez](https://github.com/jstvz)
 - [Jonathan Eunice](https://github.com/jonathan-3play)
 - [Aryaz Eghbali](https://github.com/AryazE)

--- a/rich/console.py
+++ b/rich/console.py
@@ -2238,8 +2238,14 @@ class Console:
                     if style:
                         rule = style.get_html_style(_theme)
                         if style.link:
-                            text = f'<a href="{style.link}">{text}</a>'
-                        text = f'<span style="{rule}">{text}</span>' if rule else text
+                            if rule:
+                                text = (
+                                    f'<a style="{rule}" href="{style.link}">{text}</a>'
+                                )
+                            else:
+                                text = f'<a href="{style.link}">{text}</a>'
+                        elif rule:
+                            text = f'<span style="{rule}">{text}</span>'
                     append(text)
             else:
                 styles: Dict[str, int] = {}


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

When exporting captured output to HTML, using inline CSS styles, linked text is formatted as:
``` html
<span style="{rule}"><a href="{link}">text</a></span>
```

It seems that Web browsers will then render the linked text with the default style for unvisited links (typically blue).

The CSS rules are, however, correctly applied if put directly on the anchor element:
``` html
<a style="{rule}" href="{link}">text</a>
```

Tested with Firefox 128.4 and Google Chrome 131.

Thanks.

[Edit: I can squash the commits if preferred.]