### PR TITLE
BF: don't force override terminal foreground color for Pygments themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Pygments styles without color now use terminal's foreground color rather than hardcode black https://github.com/Textualize/rich/pull/3582
 
 ## [13.9.4] - 2024-11-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -72,6 +72,7 @@ The following people have contributed to the development of Rich:
 - [Karolina Surma](https://github.com/befeleme)
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)
 - [Nils Vu](https://github.com/nilsvu)
+- [Alex Waite](https://github.com/aqw)
 - [Arian Mollik Wasi](https://github.com/wasi-master)
 - [Jan van Wijk](https://github.com/jdvanwijk)
 - [Handhika Yanuar Pratama](https://github.com/theDreamer911)

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -162,7 +162,7 @@ class PygmentsSyntaxTheme(SyntaxTheme):
                 color = pygments_style["color"]
                 bgcolor = pygments_style["bgcolor"]
                 style = Style(
-                    color="#" + color if color else "#000000",
+                    color="#" + color if color else None,
                     bgcolor="#" + bgcolor if bgcolor else self._background_color,
                     bold=pygments_style["bold"],
                     italic=pygments_style["italic"],


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This changes the behavior of Pygments Styles without a color to use `None` (meaning use the terminal's configured foreground color) rather than hardcoded to black.

This shows up, for example, with the `bw` theme. Despite its name, the theme does not specify any colors (foreground or background), and is instead exclusively bold, italics, etc. This is especially useful for providing a default syntax highlighting that will work across all terminal color schemes and possible user color blindness.

IMO, the fix in this PR is the appropriate behavior. However, it is a change in behavior, which I can understand a maintainer not being thrilled about. A less invasive solution would be to add something like the following to `PygmentsSyntaxTheme.__init__()`:
```python
self._foreground_color = getattr(self._pygments_style_class, 'foreground_color', "#000000")
```

And then use `self._foreground_color` as the fallback rather than `None`. Then themes could be defined with an explicit `foreground_color = None`. This would be similar to what `bgcolor` does.

I don't like that solution as much, as it means that existing pygments themes without a foreground color are still overridden. But at least new themes can be specified with an explicit `None` foreground. But I'm willing to change this PR to that approach if you prefer.