### PR TITLE
fix pretty_repr for dataclasses in frozen bundles (e.g. pyinstaller)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed pretty_repr for dataclasses in frozen (e.g. pyinstaller) bundles https://github.com/Textualize/rich/pull/3592
 
 ## [13.9.4] - 2024-11-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,7 @@ The following people have contributed to the development of Rich:
 - [Hugo van Kemenade](https://github.com/hugovk)
 - [Andrew Kettmann](https://github.com/akettmann)
 - [Alexander Krasnikov](https://github.com/askras)
+- [Talley Lambert](https://github.com/tlambert03)
 - [Martin Larralde](https://github.com/althonos)
 - [Hedy Li](https://github.com/hedythedev)
 - [Henry Mai](https://github.com/tanducmai)

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -67,6 +67,9 @@ def _get_attr_fields(obj: Any) -> Sequence["_attr_module.Attribute[Any]"]:
     return _attr_module.fields(type(obj)) if _has_attrs else []
 
 
+IS_FROZEN = getattr(sys, "frozen", False)
+
+
 def _is_dataclass_repr(obj: object) -> bool:
     """Check if an instance of a dataclass contains the default repr.
 
@@ -79,10 +82,10 @@ def _is_dataclass_repr(obj: object) -> bool:
     # Digging in to a lot of internals here
     # Catching all exceptions in case something is missing on a non CPython implementation
     try:
-        return obj.__repr__.__code__.co_filename in (
-            dataclasses.__file__,
-            reprlib.__file__,
-        )
+        accepted = {dataclasses.__file__, reprlib.__file__}
+        if IS_FROZEN:
+            accepted.update({'dataclasses.py', 'reprlib.py'})
+        return obj.__repr__.__code__.co_filename in accepted
     except Exception:  # pragma: no coverage
         return False
 

--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -84,7 +84,7 @@ def _is_dataclass_repr(obj: object) -> bool:
     try:
         accepted = {dataclasses.__file__, reprlib.__file__}
         if IS_FROZEN:
-            accepted.update({'dataclasses.py', 'reprlib.py'})
+            accepted.update({"dataclasses.py", "reprlib.py"})
         return obj.__repr__.__code__.co_filename in accepted
     except Exception:  # pragma: no coverage
         return False


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.  :joy:

## Description

Probably a very fringe case here, but I bundled rich in a pyinstaller app (along with IPython), and noticed that dataclasses were not getting the standard rich pretty treatment (no newlines between attributes, etc...)

tracked it down to this check on `obj.__repr__.__code__.co_filename`, let me know if you'd prefer a different fix.