### PR TITLE
fix checking Windows console features

### DIFF
--- a/rich/_win32_console.py
+++ b/rich/_win32_console.py
@@ -21,6 +21,7 @@ from rich.color import ColorSystem
 from rich.style import Style
 
 STDOUT = -11
+STDERR = -12
 ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4
 
 COORD = wintypes._COORD


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

On Windows, there is a use case where the standard output is redirected to a non-console object (e.g., a file), while the standard error is still connected to a console. So, similar to the fix in #3413, we should check console handles of both.
