### PR TITLE
REQUEST-3385 add timeout to prompt.ask

### DIFF
--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,4 +1,7 @@
 import io
+from time import sleep
+
+import pytest
 
 from rich.console import Console
 from rich.prompt import Confirm, IntPrompt, Prompt
@@ -111,3 +114,27 @@ def test_prompt_confirm_default():
     output = console.file.getvalue()
     print(repr(output))
     assert output == expected
+
+
+def test_prompt_timeout_handling():
+    """Test that a timeout prints the correct message and returns default."""
+    console = Console(file=io.StringIO())
+    default_value = "Default"
+    result = Prompt.ask(
+        "Enter a value",
+        console=console,
+        timeout=0.1,
+        default=default_value
+    )
+    assert result == default_value
+
+
+def test_prompt_timeout_no_default():
+    """Test that a timeout with no default does not raise but returns an empty string."""
+    console = Console(file=io.StringIO())
+    result = Prompt.ask(
+        "Enter a value",
+        console=console,
+        timeout=0.1
+    )
+    assert result == ""


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [x] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Add optional argument timeout to the ask method in Prompt class.

After timeout message Prompt timed out! will be printed, and default value will be used or empty string 

Issue: #3385 