### PR TITLE
Reference correct variable in IPython configuration

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -92,7 +92,7 @@ Rich also includes an IPython extension that will do this same pretty install + 
 
     In [1]: %load_ext rich
 
-You can also have it load by default by adding `"rich"` to the ``c.InteractiveShellApp.extension`` variable in
+You can also have it load by default by adding `"rich"` to the ``c.InteractiveShellApp.extensions`` variable in
 `IPython Configuration <https://ipython.readthedocs.io/en/stable/config/intro.html>`_.
 
 Rich Inspect


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

The documentation referenced a variable `c.InteractiveShellApp.extension` in the IPython configuration which does not exist, the actual variable name is `c.InteractiveShellApp.extensions`. This PR fixes the reference!
