### PR TITLE
Skip tests which are expected to fail with Python 3.14

### DIFF
--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -43,6 +43,11 @@ skip_py313 = pytest.mark.skipif(
     reason="rendered differently on py3.13",
 )
 
+skip_py314 = pytest.mark.skipif(
+    sys.version_info.minor == 14 and sys.version_info.major == 3,
+    reason="rendered differently on py3.14",
+)
+
 skip_pypy3 = pytest.mark.skipif(
     hasattr(sys, "pypy_version_info"),
     reason="rendered differently on pypy3",
@@ -139,6 +144,7 @@ def test_inspect_empty_dict():
     assert render({}).startswith(expected)
 
 
+@skip_py314
 @skip_py313
 @skip_py312
 @skip_py311
@@ -219,6 +225,7 @@ def test_inspect_integer_with_value():
 @skip_py311
 @skip_py312
 @skip_py313
+@skip_py314
 def test_inspect_integer_with_methods_python38_and_python39():
     expected = (
         "╭──────────────── <class 'int'> ─────────────────╮\n"
@@ -257,6 +264,7 @@ def test_inspect_integer_with_methods_python38_and_python39():
 @skip_py311
 @skip_py312
 @skip_py313
+@skip_py314
 def test_inspect_integer_with_methods_python310only():
     expected = (
         "╭──────────────── <class 'int'> ─────────────────╮\n"
@@ -299,6 +307,7 @@ def test_inspect_integer_with_methods_python310only():
 @skip_py310
 @skip_py312
 @skip_py313
+@skip_py314
 def test_inspect_integer_with_methods_python311():
     # to_bytes and from_bytes methods on int had minor signature change -
     # they now, as of 3.11, have default values for all of their parameters

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -38,6 +38,10 @@ skip_py313 = pytest.mark.skipif(
     sys.version_info.minor == 13 and sys.version_info.major == 3,
     reason="rendered differently on py3.13",
 )
+skip_py314 = pytest.mark.skipif(
+    sys.version_info.minor == 14 and sys.version_info.major == 3,
+    reason="rendered differently on py3.14",
+)
 
 
 def test_install() -> None:
@@ -639,6 +643,7 @@ def test_attrs_empty() -> None:
 @skip_py311
 @skip_py312
 @skip_py313
+@skip_py314
 def test_attrs_broken() -> None:
     @attr.define
     class Foo:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate. -- not sure this requires a changelog entry
- [-] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

In Fedora Linux, we've started testing packages with Python 3.14. When I deal with the (expected) failure of these 5 tests, rich builds just fine.
