### PR TITLE
Remove unnecessary import that confuses type checkers

### DIFF
--- a/rich/table.py
+++ b/rich/table.py
@@ -929,7 +929,6 @@ class Table(JupyterMixin):
 if __name__ == "__main__":  # pragma: no cover
     from rich.console import Console
     from rich.highlighter import ReprHighlighter
-    from rich.table import Table as Table
 
     from ._timer import timer
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

in `rich.table`, when executed as a main script, it imports `Table` from itself.

this seems unnecessary, considering the `Table` class is implemented in the same module.
this isn't only cosmetic though - at least one type checker (Pyre) gets confused because of this, and treats `Table` as a symbol that isn't exported by `rich.table`.

please let me know if this change is acceptable, and if so, whether it needs a CHANGELOG entry and/or additional tests.