### PR TITLE
Remove margin around output in jupyter notebooks

### DIFF
--- a/rich/jupyter.py
+++ b/rich/jupyter.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from rich.console import ConsoleRenderable
 
 JUPYTER_HTML_FORMAT = """\
-<pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace">{code}</pre>
+<pre style="white-space:pre;overflow-x:auto;line-height:normal;margin:0;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace">{code}</pre>
 """
 
 


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

The output in a jupyter notebook seems like there is too much space between (especially obvious when using the logging handler).
This removes the margin, I prefer it but understand if its not quite what you want. Here is a before and after:
![image](https://github.com/user-attachments/assets/d4e53321-fb42-4379-a02c-0b487455762b)
