### PR TITLE
refactor(test_traceback): delete unused test helper `get_exception`

### DIFF
--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -73,23 +73,6 @@ def test_no_exception():
         tb = Traceback()
 
 
-def get_exception() -> Traceback:
-    def bar(a):
-        print(1 / a)
-
-    def foo(a):
-        bar(a)
-
-    try:
-        try:
-            foo(0)
-        except:
-            foobarbaz
-    except:
-        tb = Traceback()
-        return tb
-
-
 def test_print_exception():
     console = Console(width=100, file=io.StringIO())
     try:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pydantic in the code review.

## Description

This is just a tiny cleanup PR.

While working on #3630, I checked the tests in [`test_traceback.py`](https://github.com/Textualize/rich/blob/43d3b04725ab9731727fb1126e35980c62f32377/tests/test_traceback.py) and noticed that [`get_exception`](https://github.com/Textualize/rich/blob/43d3b04725ab9731727fb1126e35980c62f32377/tests/test_traceback.py#L76-L90) was not used anywhere.