### PR TITLE
Mention rich.get_console() in Console API docs

### DIFF
--- a/docs/source/console.rst
+++ b/docs/source/console.rst
@@ -10,6 +10,11 @@ Then you can import the console from anywhere in your project like this::
 
     from my_project.console import console
 
+You can also get a global console instance from the package-level API::
+
+    import rich
+    console = rich.get_console()
+
 The console object handles the mechanics of generating ANSI escape sequences for color and style. It will auto-detect the capabilities of the terminal and convert colors if necessary.
 
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [X] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

The get_console() access method is mentioned elsewhere in the API docs, but not at the console level - just adding a mention of it in case someone is going to that page as their sole entry point.
