### PR TITLE
Add a `vertical_overflow='crop_above'` as an option to `Live()`

### DIFF
--- a/rich/live_render.py
+++ b/rich/live_render.py
@@ -14,7 +14,7 @@ from .segment import ControlType, Segment
 from .style import StyleType
 from .text import Text
 
-VerticalOverflowMethod = Literal["crop", "ellipsis", "visible"]
+VerticalOverflowMethod = Literal["crop", "crop_above", "ellipsis", "visible"]
 
 
 class LiveRender:
@@ -91,6 +91,9 @@ class LiveRender:
         if height > options.size.height:
             if self.vertical_overflow == "crop":
                 lines = lines[: options.size.height]
+                shape = Segment.get_shape(lines)
+            elif self.vertical_overflow == "crop_above":
+                lines = lines[-(options.size.height) :]
                 shape = Segment.get_shape(lines)
             elif self.vertical_overflow == "ellipsis":
                 lines = lines[: (options.size.height - 1)]


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

As described in #3263, `Live(vertical_overflow="visible")` has the unfortunate behavior of duplicating content when the content update exceeds the height of the console. This is especially unfortunate for a few reasons:

* It seems there is no way to get rid of the duplicated content (i.e., `transient=True` doesn't help to avoid this).
* There are no other `vertical_overflow` options that allows for the "newest" content to be visible.
* In today's Gen AI world where markdown often is received in chunks, it's really useful to have a live display where a (possibly long) markdown string accumulates over time.

This PR proposes a new option `vertical_overflow="crop_above"` which does the reverse of `vertical_overflow="crop"` (it displays only the bottom portion of the content instead of the top). It has the nice behavior of always making the "newest" content visible, but without the downside of duplicated content. Here's a demo:


```python
import requests
import time

from rich.live import Live
from rich.markdown import Markdown

readme = requests.get(
    "https://raw.githubusercontent.com/posit-dev/py-shiny/refs/heads/main/README.md"
)
readme_chunks = readme.text.replace("\n", " \n ").split(" ")[: 200]

content = ""
with Live(auto_refresh=False, vertical_overflow="crop_above") as live:
    for chunk in readme_chunks:
        content += chunk + " "
        time.sleep(0.01)
        live.update(Markdown(content), refresh=True)
```


https://github.com/user-attachments/assets/6425a645-2658-46a5-9b49-12c63a154063

And note that if you change `vertical_overflow="crop_above"` to `vertical_overflow="visible"`, this is the behavior:


https://github.com/user-attachments/assets/35f95d37-f1f3-4afb-a0ac-9d360fdac3d6


I'm happy to write tests or anything else you need if you like this overall direction

