### PR TITLE
Fixed legacy_windows is auto-detected as True incorrectly, when not in terminal environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+### Fixed
+
+- Fixed `legacy_windows` is auto-detected as `True` incorrectly, when not in terminal environment.
+
 ## [13.9.4] - 2024-11-01
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -91,3 +91,4 @@ The following people have contributed to the development of Rich:
 - [L. Yeung](https://github.com/lewis-yeung)
 - [chthollyphile](https://github.com/chthollyphile)
 - [Jonathan Helmus](https://github.com/jjhelmus)
+- [xymy](https://github.com/xymy)

--- a/rich/console.py
+++ b/rich/console.py
@@ -683,6 +683,18 @@ class Console:
         self._emoji_variant: Optional[EmojiVariant] = emoji_variant
         self._highlight = highlight
 
+        self._force_terminal = None
+        if force_terminal is not None:
+            self._force_terminal = force_terminal
+
+        self._file = file
+        self.quiet = quiet
+        self.stderr = stderr
+
+        self.legacy_windows = (
+            self._detect_legacy_windows() if legacy_windows is None else legacy_windows
+        )
+
         if width is None:
             columns = self._environ.get("COLUMNS")
             if columns is not None and columns.isdigit():
@@ -697,19 +709,6 @@ class Console:
         self._height = height
 
         self._color_system: Optional[ColorSystem]
-
-        self._force_terminal = None
-        if force_terminal is not None:
-            self._force_terminal = force_terminal
-
-        self._file = file
-        self.quiet = quiet
-        self.stderr = stderr
-
-        self.legacy_windows = (
-            self._detect_legacy_windows() if legacy_windows is None else legacy_windows
-        )
-
         if color_system is None:
             self._color_system = None
         elif color_system == "auto":

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -45,6 +45,12 @@ def test_dumb_terminal():
     assert height == 25
 
 
+def test_legacy_windows():
+    output = io.StringIO()
+    console = Console(file=output)
+    assert console.legacy_windows is False
+
+
 def test_soft_wrap():
     console = Console(file=io.StringIO(), width=20, soft_wrap=True)
     console.print("foo " * 10)


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fix #3647 
