### PR TITLE
Fix right justification: conditionally preserve trailing space character

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -91,3 +91,4 @@ The following people have contributed to the development of Rich:
 - [L. Yeung](https://github.com/lewis-yeung)
 - [chthollyphile](https://github.com/chthollyphile)
 - [Jonathan Helmus](https://github.com/jjhelmus)
+- [Benjamin Ben Rachmiel](https://github.com/BenRachmiel)

--- a/rich/containers.py
+++ b/rich/containers.py
@@ -76,12 +76,10 @@ class Lines:
         return iter(self._lines)
 
     @overload
-    def __getitem__(self, index: int) -> "Text":
-        ...
+    def __getitem__(self, index: int) -> "Text": ...
 
     @overload
-    def __getitem__(self, index: slice) -> List["Text"]:
-        ...
+    def __getitem__(self, index: slice) -> List["Text"]: ...
 
     def __getitem__(self, index: Union[slice, int]) -> Union["Text", List["Text"]]:
         return self._lines[index]
@@ -137,7 +135,7 @@ class Lines:
                 line.pad_right(width - cell_len(line.plain))
         elif justify == "right":
             for line in self._lines:
-                line.rstrip()
+                line[:-1].rstrip() if line[-1] == Text(" ") else line.rstrip()
                 line.truncate(width, overflow=overflow)
                 line.pad_left(width - cell_len(line.plain))
         elif justify == "full":


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
#3641 details an issue with right justified titles of panels losing the trailing whitespace, and it being reassigned to the beginning of the segment. It appears that trailing whitespace is removed via rstrip, but titles have a singular space added after the text (I assume for visual clarity), which is inadvertently removed.

Seeing as this change might have knock-on effects, I attempted to mitigate that by using a ternary if, checking that the final character is a space and if so, leaving that space out of the rstrip. I have not added a test, since I do not know if the test mentioned in the issue is appropriate (seems very hardcoded), but could think up a regression test if necessary (don't know exactly how atm, but I could learn). 

First time contributing to open source, hope this isn't a dumb way to tackle the issue, but I do see how it could have some unintended consequences.