### PR TITLE
feat: enable color support in marimo notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Upcoming
+
+### Changed
+
+- Enabled color support in marimo notebooks. https://github.com/Textualize/rich/pull/3651
 
 ## [13.9.4] - 2024-11-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ The following people have contributed to the development of Rich:
 <!-- Add your name below, sort alphabetically by surname. Link to GitHub profile / your home page. -->
 
 - [Patrick Arminio](https://github.com/patrick91)
+- [banteg](https://github.com/banteg)
 - [Gregory Beauregard](https://github.com/GBeauregard/pyffstream)
 - [Artur Borecki](https://github.com/pufereq)
 - [Pedro Aaron](https://github.com/paaaron)

--- a/rich/console.py
+++ b/rich/console.py
@@ -534,6 +534,16 @@ def _is_jupyter() -> bool:  # pragma: no cover
         return False  # Other type (?)
 
 
+def _is_marimo() -> bool:  # pragma: no cover
+    """Check if we're running in a marimo notebook."""
+    try:
+        import marimo
+
+        return marimo.running_in_notebook() is True
+    except (ImportError, AttributeError):
+        return False
+
+
 COLOR_SYSTEMS = {
     "standard": ColorSystem.STANDARD,
     "256": ColorSystem.EIGHT_BIT,
@@ -790,7 +800,7 @@ class Console:
 
     def _detect_color_system(self) -> Optional[ColorSystem]:
         """Detect color system from env vars."""
-        if self.is_jupyter:
+        if self.is_jupyter or _is_marimo():
             return ColorSystem.TRUECOLOR
         if not self.is_terminal or self.is_dumb_terminal:
             return None


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I've added [marimo notebook](https://marimo.io/) detection to the Rich console. The implementation includes:

1. A new `_is_marimo()` function that:
- Attempts to import the marimo module
- Checks if [`marimo.running_in_notebook()`](https://docs.marimo.io/api/miscellaneous/) is True
- Handles both `ImportError` (if marimo isn't installed) and `AttributeError` (if the function doesn't exist)
- Returns False if any errors occur
2. Updated the `_detect_color_system()` method to:
- Check for marimo notebooks using the new function
- Set the color system to truecolor when running in a marimo notebook, just like with Jupyter

This implementation follows the same pattern as the existing Jupyter detection, ensuring consistent behavior across different notebook environments.
