### PR TITLE
Don't underline indentation

### DIFF
--- a/rich/default_styles.py
+++ b/rich/default_styles.py
@@ -120,7 +120,7 @@ DEFAULT_STYLES: Dict[str, Style] = {
     "traceback.exc_type": Style(color="bright_red", bold=True),
     "traceback.exc_value": Style.null(),
     "traceback.offset": Style(color="bright_red", bold=True),
-    "traceback.error_range": Style(underline=True, bold=True, dim=False),
+    "traceback.error_range": Style(underline=True, bold=True),
     "traceback.note": Style(color="green", bold=True),
     "bar.back": Style(color="grey23"),
     "bar.complete": Style(color="rgb(249,38,114)"),

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -686,17 +686,6 @@ class Traceback:
         path_highlighter = PathHighlighter()
         theme = self.theme
 
-        def read_code(filename: str) -> str:
-            """Read files, and cache results on filename.
-
-            Args:
-                filename (str): Filename to read
-
-            Returns:
-                str: Contents of file
-            """
-            return "".join(linecache.getlines(filename))
-
         def render_locals(frame: Frame) -> Iterable[ConsoleRenderable]:
             if frame.locals:
                 yield render_scope(
@@ -758,7 +747,8 @@ class Traceback:
                 continue
             if not suppressed:
                 try:
-                    code = read_code(frame.filename)
+                    code_lines = linecache.getlines(frame.filename)
+                    code = "".join(code_lines)
                     if not code:
                         # code may be an empty string if the file doesn't exist, OR
                         # if the traceback filename is generated dynamically

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -786,10 +786,10 @@ class Traceback:
                         ):
                             try:
                                 if column1 == 0:
-                                    line = lines[line1 - 1]
+                                    line = code_lines[line1 - 1]
                                     column1 = len(line) - len(line.lstrip())
                                 if column2 == -1:
-                                    column2 = len(lines[line1 - 1])
+                                    column2 = len(code_lines[line1 - 1])
                             except IndexError:
                                 # Being defensive here
                                 # If last_instruction reports a line out-of-bounds, we don't want to crash

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -46,30 +46,30 @@ LOCALS_MAX_STRING = 80
 
 def _iter_syntax_lines(
     start: SyntaxPosition, end: SyntaxPosition
-) -> Iterable[Tuple[SyntaxPosition, SyntaxPosition]]:
-    """Yield start and end syntax positions per line.
+) -> Iterable[Tuple[int, int, int]]:
+    """Yield start and end positions per line.
 
     Args:
         start: Start position.
         end: End position.
 
     Returns:
-        Iterable of pairs of syntax positions.
+        Iterable of (LINE, COLUMN1, COLUMN2).
     """
 
     line1, column1 = start
     line2, column2 = end
 
     if line1 == line2:
-        yield start, end
+        yield line1, column1, column2
     else:
         for first, last, line_no in loop_first_last(range(line1, line2 + 1)):
             if first:
-                yield (line_no, column1), (line_no, -1)
+                yield line_no, column1, -1
             elif last:
-                yield (line_no, 0), (line_no, column2)
+                yield line_no, 0, column2
             else:
-                yield (line_no, 0), (line_no, -1)
+                yield line_no, 0, -1
 
 
 def install(
@@ -777,13 +777,10 @@ class Traceback:
                 else:
                     if frame.last_instruction is not None:
                         start, end = frame.last_instruction
-                        lines = code.splitlines()
 
                         # Stylize a line at a time
                         # So that indentation isn't underlined (which looks bad)
-                        for (line1, column1), (_, column2) in _iter_syntax_lines(
-                            start, end
-                        ):
+                        for line1, column1, column2 in _iter_syntax_lines(start, end):
                             try:
                                 if column1 == 0:
                                     line = code_lines[line1 - 1]


### PR DESCRIPTION
Prevent code highlights in exceptions from highlighting indentation. Previously indentation was underline, which didn't look good.
<img width="1400" alt="Screenshot 2025-03-29 at 15 55 15" src="https://github.com/user-attachments/assets/67147fa5-25f4-4d34-a08d-97cea8996e32" />
<img width="1400" alt="Screenshot 2025-03-29 at 15 55 24" src="https://github.com/user-attachments/assets/8df26ccb-8444-4049-a023-3b609797fbce" />
