### PR TITLE
fix for null tb_offset

### DIFF
--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -177,7 +177,9 @@ def install(
 
             # determine correct tb_offset
             compiled = tb_data.get("running_compiled_code", False)
-            tb_offset = tb_data.get("tb_offset", 1 if compiled else 0)
+            tb_offset = tb_data.get("tb_offset")
+            if tb_offset is None:
+                tb_offset = 1 if compiled else 0
             # remove ipython internal frames from trace with tb_offset
             for _ in range(tb_offset):
                 if tb is None:


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

tb_offset can be passed explicitly as `None` in ipython when calling `shell.showtraceback(...)`. this can happen for example in the case of shell subclasses that override showtraceback and then just propagate the kwarg default. to fix, add an explicit null check, and make sure we set rich's defaults if it's null.
