### PR TITLE
Anti flicker on legacy windows terminal

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -646,6 +646,7 @@ class Console:
         height: Optional[int] = None,
         style: Optional[StyleType] = None,
         no_color: Optional[bool] = None,
+        no_clear: bool = True,
         tab_size: int = 8,
         record: bool = False,
         markup: bool = True,
@@ -753,6 +754,7 @@ class Console:
         self._render_hooks: List[RenderHook] = []
         self._live: Optional["Live"] = None
         self._is_alt_screen = False
+        self._no_clear = no_clear
 
     def __repr__(self) -> str:
         return f"<console width={self.width} {self._color_system!s}>"

--- a/rich/live.py
+++ b/rich/live.py
@@ -256,7 +256,7 @@ class Live(JupyterMixin, RenderHook):
             with self._lock:
                 reset = (
                     Control.home()
-                ) if self.console.is_dumb_terminal else (
+                ) if self.console._no_clear else (
                     Control.home()
                     if self._alt_screen
                     else self._live_render.position_cursor()

--- a/rich/live.py
+++ b/rich/live.py
@@ -256,6 +256,8 @@ class Live(JupyterMixin, RenderHook):
             with self._lock:
                 reset = (
                     Control.home()
+                ) if self.console.is_dumb_terminal else (
+                    Control.home()
                     if self._alt_screen
                     else self._live_render.position_cursor()
                 )


### PR DESCRIPTION
## Type of changes

- [x ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ x] I accept that @willmcgugan may be pedantic in the code review.

## Description
Solving issues #3264 and many similar issues running rich on Windows Legacy Terminal.

To reduce flickering on Windows Legacy Terminal, it is best not to erase old screen content as suggested on this stackoverflow [python curses tty screen blink](https://stackoverflow.com/questions/24964940/python-curses-tty-screen-blink)](https://stackoverflow.com/questions/24964940/python-curses-tty-screen-blink)

Since I couldn't find a reliable way to detect Windows Legacy Terminal, I opt for "no_clear" flag instead.
Feel free to modify this patch.

