### PR TITLE
docs: fix search not working

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosectionlabel",
     "sphinx_copybutton",
+    "sphinx_rtd_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Fix the documentation search not working after a recent Read the Docs upgrade.

This adds `sphinx_rtd_theme` to the extensions as recommended in the install guide: https://sphinx-rtd-theme.readthedocs.io/en/stable/installing.html

Fixes: #3697

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.
