### PR TITLE
Remove runtime dependency on typing-extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- The dependency on `typing_extensions` has been removed
+
 ## [14.0.0] - 2025-03-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ include = ["rich/py.typed"]
 
 [tool.poetry.dependencies]
 python = ">=3.8.0"
-typing-extensions = { version = ">=4.0.0, <5.0", python = "<3.11" }
 pygments = "^2.13.0"
 ipywidgets = { version = ">=7.5.1,<9", optional = true }
 markdown-it-py = ">=2.2.0"
@@ -44,6 +43,7 @@ pytest-cov = "^3.0.0"
 attrs = "^21.4.0"
 pre-commit = "^2.17.0"
 asv = "^0.5.1"
+typing-extensions = { version = ">=4.0.0, <5.0", python = "<3.11" }
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/rich/_ratio.py
+++ b/rich/_ratio.py
@@ -1,12 +1,6 @@
-import sys
 from fractions import Fraction
 from math import ceil
-from typing import cast, List, Optional, Sequence
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol  # pragma: no cover
+from typing import List, Optional, Protocol, Sequence, cast
 
 
 class Edge(Protocol):

--- a/rich/align.py
+++ b/rich/align.py
@@ -1,11 +1,5 @@
-import sys
 from itertools import chain
-from typing import TYPE_CHECKING, Iterable, Optional
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal  # pragma: no cover
+from typing import TYPE_CHECKING, Iterable, Literal, Optional
 
 from .constrain import Constrain
 from .jupyter import JupyterMixin

--- a/rich/box.py
+++ b/rich/box.py
@@ -1,11 +1,4 @@
-import sys
-from typing import TYPE_CHECKING, Iterable, List
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal  # pragma: no cover
-
+from typing import TYPE_CHECKING, Iterable, List, Literal
 
 from ._loop import loop_last
 

--- a/rich/console.py
+++ b/rich/console.py
@@ -22,26 +22,20 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Mapping,
     NamedTuple,
     Optional,
+    Protocol,
     TextIO,
     Tuple,
     Type,
     Union,
     cast,
+    runtime_checkable,
 )
 
 from rich._null_file import NULL_FILE
-
-if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol, runtime_checkable
-else:
-    from typing_extensions import (
-        Literal,
-        Protocol,
-        runtime_checkable,
-    )  # pragma: no cover
 
 from . import errors, themes
 from ._emoji_replace import _emoji_replace

--- a/rich/control.py
+++ b/rich/control.py
@@ -1,11 +1,5 @@
-import sys
 import time
-from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Union
-
-if sys.version_info >= (3, 8):
-    from typing import Final
-else:
-    from typing_extensions import Final  # pragma: no cover
+from typing import TYPE_CHECKING, Callable, Dict, Final, Iterable, List, Union
 
 from .segment import ControlCode, ControlType, Segment
 

--- a/rich/emoji.py
+++ b/rich/emoji.py
@@ -1,17 +1,10 @@
-import sys
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
+from ._emoji_codes import EMOJI
+from ._emoji_replace import _emoji_replace
 from .jupyter import JupyterMixin
 from .segment import Segment
 from .style import Style
-from ._emoji_codes import EMOJI
-from ._emoji_replace import _emoji_replace
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal  # pragma: no cover
-
 
 if TYPE_CHECKING:
     from .console import Console, ConsoleOptions, RenderResult

--- a/rich/live_render.py
+++ b/rich/live_render.py
@@ -1,11 +1,4 @@
-import sys
-from typing import Optional, Tuple
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal  # pragma: no cover
-
+from typing import Literal, Optional, Tuple
 
 from ._loop import loop_last
 from .console import Console, ConsoleOptions, RenderableType, RenderResult

--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
-import sys
-from typing import ClassVar, Iterable
+from typing import ClassVar, Iterable, get_args
 
 from markdown_it import MarkdownIt
 from markdown_it.token import Token
-
-if sys.version_info >= (3, 8):
-    from typing import get_args
-else:
-    from typing_extensions import get_args  # pragma: no cover
 
 from rich.table import Table
 

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -14,6 +14,7 @@ from os import PathLike, stat
 from threading import Event, RLock, Thread
 from types import TracebackType
 from typing import (
+    TYPE_CHECKING,
     Any,
     BinaryIO,
     Callable,
@@ -23,6 +24,7 @@ from typing import (
     Generic,
     Iterable,
     List,
+    Literal,
     NamedTuple,
     NewType,
     Optional,
@@ -34,15 +36,11 @@ from typing import (
     Union,
 )
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal  # pragma: no cover
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self  # pragma: no cover
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self  # pragma: no cover
 
 from . import filesize, get_console
 from .console import Console, Group, JustifyMethod, RenderableType
@@ -1178,7 +1176,7 @@ class Progress(JupyterMixin):
         if not self.console.is_interactive and not self.console.is_jupyter:
             self.console.print()
 
-    def __enter__(self) -> Self:
+    def __enter__(self) -> "Self":
         self.start()
         return self
 


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] (**NA**) I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I'd like to get rid of pip's vendored copy of typing-extensions. Rich is the primary blocker, but it turns out that rich doesn't really need typing-extensions since requiring Python 3.8+.

It is still used for typing_extensions.Self (which was only added to the stdlib in Python 3.11) but the import is now guarded under TYPE_CHECKING so end-users don't have to install typing_extensions.