### PR TITLE
fix(traceback): highlight win32 paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed highlighting of Windows paths in tracebacks. https://github.com/Textualize/rich/pull/3734
+
 ## [14.0.0] - 2025-03-30
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,6 +46,7 @@ The following people have contributed to the development of Rich:
 - [Paul McGuire](https://github.com/ptmcg)
 - [Antony Milne](https://github.com/AntonyMilneQB)
 - [Michael Milton](https://github.com/multimeric)
+- [Zoltan Nagy](https://github.com/abesto)
 - [Martina Oefelein](https://github.com/oefe)
 - [Nathan Page](https://github.com/nathanrpage97)
 - [Dave Pearson](https://github.com/davep/)

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -246,7 +246,7 @@ class Trace:
 
 
 class PathHighlighter(RegexHighlighter):
-    highlights = [r"(?P<dim>.*/)(?P<bold>.+)"]
+    highlights = [r"(?P<dim>.*(/|\\))(?P<bold>.+)"]
 
 
 class Traceback:

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -6,8 +6,9 @@ from typing import List
 import pytest
 
 from rich.console import Console
+from rich.text import Span
 from rich.theme import Theme
-from rich.traceback import Traceback, install
+from rich.traceback import install, PathHighlighter, Traceback
 
 
 def test_handler():
@@ -373,3 +374,18 @@ def test_notes() -> None:
         traceback = Traceback()
 
         assert traceback.trace.stacks[0].notes == ["Hello", "World"]
+
+
+def test_path_highlighter() -> None:
+    """Check that PathHighlighter correctly highlights both win32 and *nix paths"""
+    path_highlighter = PathHighlighter()
+
+    assert path_highlighter("/foo/bar/baz").spans == [
+        Span(0, 9, "dim"),
+        Span(9, 12, "bold"),
+    ]
+
+    assert path_highlighter("'\\\\?\\C:\\foo\\bar\\baz").spans == [
+        Span(0, 16, "dim"),
+        Span(16, 19, "bold"),
+    ]


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

`PathHighlighter` uses a regex to parse paths for highlighting. It used `/` as the final path component delimiter. This PR changes that to "either `/` or `\`".

I toyed with using `os.path.sep`, but there's no reason to *not* highlight paths from other OSes than the one we're running on at the moment.
