### PR TITLE
docs(progress): remove reverted IterationSpeedColumn

### DIFF
--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -163,7 +163,6 @@ The following column objects are available:
 - :class:`~rich.progress.TransferSpeedColumn` Displays transfer speed (assumes the steps are bytes).
 - :class:`~rich.progress.SpinnerColumn` Displays a "spinner" animation.
 - :class:`~rich.progress.RenderableColumn` Displays an arbitrary Rich renderable in the column.
-- :class:`~rich.progress.IterationSpeedColumn` Displays iteration speed in it/s (iterations per second).
 
 To implement your own columns, extend the :class:`~rich.progress.ProgressColumn` class and use it as you would the other columns.
 


### PR DESCRIPTION
Remove `IterationSpeedColumn` from the progress documentation, as this addition was reverted not long after being merged
(see https://github.com/Textualize/rich/pull/3332#issuecomment-2383977334).

Closes #3739.

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.
