### PR TITLE
Remove make log

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -92,3 +92,4 @@ The following people have contributed to the development of Rich:
 - [chthollyphile](https://github.com/chthollyphile)
 - [Jonathan Helmus](https://github.com/jjhelmus)
 - [Brandon Capener](https://github.com/bcapener)
+- [Alex Zheng](https://github.com/alexzheng111)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -160,9 +160,3 @@ def test_markup_and_highlight():
     render_plain = handler.console.file.getvalue()
     assert "FORMATTER" in render_plain
     assert log_message in render_plain
-
-
-if __name__ == "__main__":
-    render = make_log()
-    print(render)
-    print(repr(render))


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

The commit 26345530ad6164bd57ed9c0861cef221a5e52f27 removes the `make_log` definition in `test_logging.py`, despite its usage still remaining when running the test module. As a result, my code editor flags it as an error. This PR removes the `make_log` usage.