### PR TITLE
Private random generator for style link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added a random generator as class attribute for `Style` for `randint` calls when creating link ids to avoid affecting the global random generator.
+
 ## [14.0.0] - 2025-03-30
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -92,3 +92,4 @@ The following people have contributed to the development of Rich:
 - [chthollyphile](https://github.com/chthollyphile)
 - [Jonathan Helmus](https://github.com/jjhelmus)
 - [Brandon Capener](https://github.com/bcapener)
+- [MamoruDS](https://github.com/MamoruDS)

--- a/rich/style.py
+++ b/rich/style.py
@@ -1,7 +1,7 @@
+import random
 import sys
 from functools import lru_cache
 from marshal import dumps, loads
-from random import randint
 from typing import Any, Dict, Iterable, List, Optional, Type, Union, cast
 
 from . import errors
@@ -54,6 +54,8 @@ class Style:
         link (str, link): Link URL. Defaults to None.
 
     """
+
+    _RNG = random.Random()
 
     _color: Optional[Color]
     _bgcolor: Optional[Color]
@@ -190,7 +192,9 @@ class Style:
         self._link = link
         self._meta = None if meta is None else dumps(meta)
         self._link_id = (
-            f"{randint(0, 999999)}{hash(self._meta)}" if (link or meta) else ""
+            f"{self._RNG.randint(0, 999999)}{hash(self._meta)}"
+            if (link or meta)
+            else ""
         )
         self._hash: Optional[int] = None
         self._null = not (self._set_attributes or color or bgcolor or link or meta)
@@ -240,7 +244,7 @@ class Style:
         style._attributes = 0
         style._link = None
         style._meta = dumps(meta)
-        style._link_id = f"{randint(0, 999999)}{hash(style._meta)}"
+        style._link_id = f"{cls._RNG.randint(0, 999999)}{hash(style._meta)}"
         style._hash = None
         style._null = not (meta)
         return style
@@ -487,7 +491,7 @@ class Style:
         style._attributes = self._attributes
         style._set_attributes = self._set_attributes
         style._link = self._link
-        style._link_id = f"{randint(0, 999999)}" if self._link else ""
+        style._link_id = f"{self._RNG.randint(0, 999999)}" if self._link else ""
         style._null = False
         style._meta = None
         style._hash = None
@@ -639,7 +643,7 @@ class Style:
         style._attributes = self._attributes
         style._set_attributes = self._set_attributes
         style._link = self._link
-        style._link_id = f"{randint(0, 999999)}" if self._link else ""
+        style._link_id = f"{self._RNG.randint(0, 999999)}" if self._link else ""
         style._hash = self._hash
         style._null = False
         style._meta = self._meta
@@ -685,7 +689,7 @@ class Style:
         style._attributes = self._attributes
         style._set_attributes = self._set_attributes
         style._link = link
-        style._link_id = f"{randint(0, 999999)}" if link else ""
+        style._link_id = f"{self._RNG.randint(0, 999999)}" if link else ""
         style._hash = None
         style._null = False
         style._meta = self._meta


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Added a private random generator as class attribute for `Style` (`Style._RNG`) for `randint` calls when creating link ids. This should not change any behavior of `Style` but avoids affecting the global random generator.