### PR TITLE
Fix: spacing on arc spinner

### DIFF
--- a/rich/_spinners.py
+++ b/rich/_spinners.py
@@ -151,7 +151,7 @@ SPINNERS = {
     "boxBounce": {"interval": 120, "frames": "▖▘▝▗"},
     "boxBounce2": {"interval": 100, "frames": "▌▀▐▄"},
     "triangle": {"interval": 50, "frames": "◢◣◤◥"},
-    "arc": {"interval": 100, "frames": "◜◠◝◞◡◟"},
+    "arc": {"interval": 100, "frames": ["◜ ", "◠ ", " ◝", " ◞", "◡ ", "◟ "]},
     "circle": {"interval": 120, "frames": "◡⊙◠"},
     "squareCorners": {"interval": 180, "frames": "◰◳◲◱"},
     "circleQuarters": {"interval": 120, "frames": "◴◷◶◵"},


### PR DESCRIPTION
## Type of changes

- [x] Bug fix

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

The arc animation was missing spaces on a couple of the frames, making it drop back by one char and wibbling my wobblies. Patch is a one-liner that fixes it. Also tried to make it consistent size, but the top and bottom of the arc seem ambiguous, and take up 1 space in fonts that render them "properly" vs "nicely" 

> In [5]: wcswidth("◠")
> Out[5]: 1


Properly (it was never gonna work anyway)

![Screenshot from 2025-06-09 08-46-13](https://github.com/user-attachments/assets/bdd69d7f-3498-4ce1-acff-7f9e0674031c)


Nicely (looks nice now)

![Screenshot from 2025-06-09 08-49-19](https://github.com/user-attachments/assets/d105817b-223b-4296-885c-b4a9dc54bd33)

