### PR TITLE
Add option for custom animation frames when creating a Spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added option to use custom animation for Spinner. https://github.com/Textualize/rich/pull/3757
+
+### Changed
+
 ## [14.0.0] - 2025-03-30
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,6 +46,7 @@ The following people have contributed to the development of Rich:
 - [Paul McGuire](https://github.com/ptmcg)
 - [Antony Milne](https://github.com/AntonyMilneQB)
 - [Michael Milton](https://github.com/multimeric)
+- [Evan Minsk](https://github.com/iamevn)
 - [Martina Oefelein](https://github.com/oefe)
 - [Nathan Page](https://github.com/nathanrpage97)
 - [Dave Pearson](https://github.com/davep/)

--- a/rich/_spinners.py
+++ b/rich/_spinners.py
@@ -18,10 +18,12 @@ Spinners are from:
     ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
     IN THE SOFTWARE.
 """
+
 from typing import TypedDict, Union
+
 SpinnerAnimationType = TypedDict(
-        "SpinnerAnimationType",
-        {"interval": int, "frames": Union[str, list[str]]})
+    "SpinnerAnimationType", {"interval": int, "frames": Union[str, list[str]]}
+)
 
 SPINNERS: dict[str, SpinnerAnimationType] = {
     "dots": {

--- a/rich/_spinners.py
+++ b/rich/_spinners.py
@@ -18,8 +18,12 @@ Spinners are from:
     ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
     IN THE SOFTWARE.
 """
+from typing import TypedDict, Union
+SpinnerAnimationType = TypedDict(
+        "SpinnerAnimationType",
+        {"interval": int, "frames": Union[str, list[str]]})
 
-SPINNERS = {
+SPINNERS: dict[str, SpinnerAnimationType] = {
     "dots": {
         "interval": 80,
         "frames": "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏",

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -585,11 +585,11 @@ class SpinnerColumn(ProgressColumn):
         finished_text: TextType = " ",
         table_column: Optional[Column] = None,
         *,
-        custom_spinner: Optional[SpinnerAnimationType] = None
+        custom_spinner: Optional[SpinnerAnimationType] = None,
     ):
         self.spinner = Spinner(
-                spinner_name, style=style, speed=speed,
-                custom_spinner=custom_spinner)
+            spinner_name, style=style, speed=speed, custom_spinner=custom_spinner
+        )
         self.finished_text = (
             Text.from_markup(finished_text)
             if isinstance(finished_text, str)

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -45,6 +45,7 @@ else:
     from typing_extensions import Self  # pragma: no cover
 
 from . import filesize, get_console
+from ._spinners import SpinnerAnimationType
 from .console import Console, Group, JustifyMethod, RenderableType
 from .highlighter import Highlighter
 from .jupyter import JupyterMixin
@@ -573,6 +574,7 @@ class SpinnerColumn(ProgressColumn):
         style (StyleType, optional): Style of spinner. Defaults to "progress.spinner".
         speed (float, optional): Speed factor of spinner. Defaults to 1.0.
         finished_text (TextType, optional): Text used when task is finished. Defaults to " ".
+        custom_spinner (SpinnerAnimationType, optional): Custom animation to use in spinner. Defaults to None
     """
 
     def __init__(
@@ -582,8 +584,12 @@ class SpinnerColumn(ProgressColumn):
         speed: float = 1.0,
         finished_text: TextType = " ",
         table_column: Optional[Column] = None,
+        *,
+        custom_spinner: Optional[SpinnerAnimationType] = None
     ):
-        self.spinner = Spinner(spinner_name, style=style, speed=speed)
+        self.spinner = Spinner(
+                spinner_name, style=style, speed=speed,
+                custom_spinner=custom_spinner)
         self.finished_text = (
             Text.from_markup(finished_text)
             if isinstance(finished_text, str)

--- a/rich/spinner.py
+++ b/rich/spinner.py
@@ -32,7 +32,7 @@ class Spinner:
         *,
         style: Optional["StyleType"] = None,
         speed: float = 1.0,
-        custom_spinner: Optional["SpinnerAnimationType"] = None
+        custom_spinner: Optional["SpinnerAnimationType"] = None,
     ) -> None:
         if custom_spinner:
             spinner = custom_spinner

--- a/rich/spinner.py
+++ b/rich/spinner.py
@@ -6,6 +6,7 @@ from .table import Table
 from .text import Text
 
 if TYPE_CHECKING:
+    from ._spinners import SpinnerAnimationType
     from .console import Console, ConsoleOptions, RenderResult, RenderableType
     from .style import StyleType
 
@@ -18,6 +19,7 @@ class Spinner:
         text (RenderableType, optional): A renderable to display at the right of the spinner (str or Text typically). Defaults to "".
         style (StyleType, optional): Style for spinner animation. Defaults to None.
         speed (float, optional): Speed factor for animation. Defaults to 1.0.
+        custom_spinner (SpinnerAnimationType, optional): Custom animation to use in spinner. Defaults to None
 
     Raises:
         KeyError: If name isn't one of the supported spinner animations.
@@ -30,11 +32,15 @@ class Spinner:
         *,
         style: Optional["StyleType"] = None,
         speed: float = 1.0,
+        custom_spinner: Optional["SpinnerAnimationType"] = None
     ) -> None:
-        try:
-            spinner = SPINNERS[name]
-        except KeyError:
-            raise KeyError(f"no spinner called {name!r}")
+        if custom_spinner:
+            spinner = custom_spinner
+        else:
+            try:
+                spinner = SPINNERS[name]
+            except KeyError:
+                raise KeyError(f"no spinner called {name!r}")
         self.text: "Union[RenderableType, Text]" = (
             Text.from_markup(text) if isinstance(text, str) else text
         )

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -70,3 +70,29 @@ def test_spinner_markup():
     spinner = Spinner("dots", "[bold]spinning[/bold]")
     assert isinstance(spinner.text, Text)
     assert str(spinner.text) == "spinning"
+
+
+def test_custom_spinner_render():
+    time = 0.0
+
+    def get_time():
+        nonlocal time
+        return time
+
+    console = Console(
+        width=80, color_system=None, force_terminal=True, get_time=get_time
+    )
+    custom_spinner = {"interval": 50, "frames": "abc"}
+    console.begin_capture()
+    spinner = Spinner("custom", "Foo", custom_spinner=custom_spinner)
+    console.print(spinner)
+    time += 50 / 1000
+    console.print(spinner)
+    time += 50 / 1000
+    console.print(spinner)
+    time += 50 / 1000
+    console.print(spinner)
+    result = console.end_capture()
+    print(repr(result))
+    expected = "a Foo\nb Foo\nc Foo\na Foo\n"
+    assert result == expected


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Adding a way to use a custom animation for a Spinner by providing a  `custom_spinner` argument to the `Spinner` constructor matching the format from the `SPINNERS` list in `_spinners.py`.

```python
Spinner("custom", custom_spinner={"interval": 80, "frames": ["[<  ]", "[ = ]", "[  >]", "[ = ]"]})
```