### PR TITLE
fix(syntax): prevent clipping with syntax + padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+-  Fix: word‐wrapped `Syntax` with padding clipped characters (#3727).
+
 ## [14.0.0] - 2025-03-30
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,7 @@ The following people have contributed to the development of Rich:
 - [Hugo van Kemenade](https://github.com/hugovk)
 - [Andrew Kettmann](https://github.com/akettmann)
 - [Alexander Krasnikov](https://github.com/askras)
+- [Adam Kuhn](https://github.com/arkuhn)
 - [Martin Larralde](https://github.com/althonos)
 - [Hedy Li](https://github.com/hedythedev)
 - [Henry Mai](https://github.com/tanducmai)

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -625,7 +625,16 @@ class Syntax(JupyterMixin):
     def __rich_console__(
         self, console: Console, options: ConsoleOptions
     ) -> RenderResult:
-        segments = Segments(self._get_syntax(console, options))
+        # Reduce available width by padding if necessary, otherwise content is clipped
+        inner_options = options
+        if self.padding:
+            _, pad_right, _, pad_left = Padding.unpack(self.padding)
+            if pad_left or pad_right:
+                inner_width = max(0, options.max_width - pad_left - pad_right)
+                inner_options = options.update_width(inner_width)
+
+        segments = Segments(self._get_syntax(console, inner_options))
+
         if self.padding:
             yield Padding(segments, style=self._get_base_style(), pad=self.padding)
         else:

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -423,6 +423,31 @@ def test_background_color_override_includes_padding():
     )
 
 
+def test_syntax_word_wrap_with_horizontal_padding():
+    """Regression test for https://github.com/Textualize/rich/issues/3727"""
+
+    EXAMPLE_CODE = """\
+    class ListViewExample(App):
+        def compose(self) -> ComposeResult:
+            yield ListView(
+                ListItem(Label("One")),
+                ListItem(Label("Two")),
+                ListItem(Label("Three")),
+            )
+            yield Footer()\
+    """
+    width = 32
+    console = Console(width=width, file=io.StringIO(), record=True)
+
+    syntax = Syntax(EXAMPLE_CODE, "python", word_wrap=True, padding=(0, 2))
+    console.print(syntax)
+    text_output = console.export_text()
+
+    assert "One" in text_output
+    assert "Two" in text_output
+    assert "Three" in text_output
+
+
 if __name__ == "__main__":
     syntax = Panel.fit(
         Syntax(


### PR DESCRIPTION
Reduce render width by padding to keep wrapped lines within console width/prevent [clipping](https://github.com/Textualize/rich/issues/3727).


<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
