### PR TITLE
Truncate long object representations in `to_repr`

### DIFF
--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -610,6 +610,8 @@ def traverse(
         else:
             try:
                 obj_repr = repr(obj)
+                if max_string is not None and len(obj_repr) > max_string:
+                    obj_repr = f"{obj_repr[:max_string]}..."
             except Exception as error:
                 obj_repr = f"<repr-error {str(error)!r}>"
         return obj_repr


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Hi Rich maintainers,

First off, thank you for creating and maintaining `rich` – it's an incredibly useful library that I use frequently!

This PR addresses the issue of very long object representations in tracebacks, especially when `show_locals=True` is enabled. Objects like large NumPy arrays, PyTorch tensors, or JAX arrays can produce extremely verbose `repr()` outputs, making tracebacks difficult to read and navigate.

Currently, `to_repr` truncates strings and bytes if they exceed `max_string`. This change extends similar truncation logic to the generic `repr(obj)` output. If `max_string` is set and the `repr()` of an object exceeds this length, it will be truncated with an ellipsis (`...`).

This is a partial solution that helps improve readability for general objects whose `repr()` is too long. It doesn't allow for type-specific custom representations, which has been discussed in issues like [#3393](https://github.com/Textualize/rich/issues/3393) and PR [#3394](https://github.com/Textualize/rich/pull/3394). I believe allowing external registration of `__rich_repr__` or similar custom display functions would be a more comprehensive solution, as mentioned in discussion [#1258](https://github.com/Textualize/rich/discussions/1258). See discussion [#3774](https://github.com/Textualize/rich/discussions/3774).

However, I hope this small change can provide an immediate improvement for users dealing with overly long representations in tracebacks.

Thank you for your consideration and for all your work on Rich!