### PR TITLE
Allow file:// hyperlinks Fixes #3786

### DIFF
--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -544,10 +544,12 @@ class Markdown(JupyterMixin):
         parser = MarkdownIt().enable("strikethrough").enable("table")
         # Allow file:// URLs in links
         original_validate = parser.validateLink
+
         def validate_link(url: str) -> bool:
             if url.lower().startswith("file://"):
                 return True
             return original_validate(url)
+
         parser.validateLink = validate_link
         self.markup = markup
         self.parsed = parser.parse(markup)

--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -542,6 +542,13 @@ class Markdown(JupyterMixin):
         inline_code_theme: str | None = None,
     ) -> None:
         parser = MarkdownIt().enable("strikethrough").enable("table")
+        # Allow file:// URLs in links
+        original_validate = parser.validateLink
+        def validate_link(url: str) -> bool:
+            if url.lower().startswith("file://"):
+                return True
+            return original_validate(url)
+        parser.validateLink = validate_link
         self.markup = markup
         self.parsed = parser.parse(markup)
         self.code_theme = code_theme

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -199,6 +199,26 @@ def test_table_with_empty_cells() -> None:
     assert result == expected
 
 
+def test_file_url_hyperlink():
+    """Test that file:// URLs are rendered as hyperlinks."""
+    markdown = Markdown("[test file](file:///path/to/file.txt)")
+    result = render(markdown)
+    # Check that the link is rendered with the hyperlink escape sequences
+    # The exact format is: \x1b]8;id=0;foo\x1b\\test file\x1b]8;;\x1b\\
+    assert "\x1b]8;" in result  # OSC 8 hyperlink start sequence
+    assert "test file" in result
+    assert "file:///path/to/file.txt" in result or "foo" in result  # URL is either preserved or replaced by test helper
+
+
+def test_file_url_vs_http_url():
+    """Test that both file:// and http:// URLs are treated as hyperlinks."""
+    markdown = Markdown("[http link](http://example.com) and [file link](file:///etc/hosts)")
+    result = render(markdown)
+    # Both should be rendered as hyperlinks with OSC 8 sequences
+    hyperlink_count = result.count("\x1b]8;")
+    assert hyperlink_count >= 2  # At least 2 hyperlinks (start sequences)
+
+
 if __name__ == "__main__":
     markdown = Markdown(MARKDOWN)
     rendered = render(markdown)


### PR DESCRIPTION
# Enable file:// hyperlinks in Rich Fixes #3786

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [[black](https://github.com/psf/black)](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This PR fixes an issue where `file://` hyperlinks were not working in Rich due to the underlying markdown-it-py implementation. The markdown-it-py library blocks file:// URLs for security reasons when rendering in browser environments, but this security restriction doesn't apply to Rich since it runs locally.

### Problem
- `file://` hyperlinks in Rich markup were not being rendered as clickable links
- This was caused by markdown-it-py's security policy that disables file:// URLs by default
- The security concern (preventing access to local files in web browsers) doesn't apply to Rich's local terminal use case

### Solution
- Modified Rich's markdown processing to allow `file://` URLs when rendering hyperlinks
- This change is safe for Rich's use case since the code runs locally anyway, not in a browser context
- Users can now create hyperlinks to local files using standard `file://` URL syntax

### Example Usage
```python
from rich.console import Console
from rich.markdown import Markdown

console = Console()
markdown = Markdown("[Local File](file:///path/to/local/file.txt)")
console.print(markdown)
```
