### PR TITLE
Fix parsing of RGB codes that use colon delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed extraction of recursive exceptions https://github.com/Textualize/rich/pull/3772
 - Fixed padding applied to Syntax https://github.com/Textualize/rich/pull/3782
 - Fixed `Panel` title missing the panel background style https://github.com/Textualize/rich/issues/3569
+- Fixed parsing of SGR color codes using colons https://github.com/Textualize/rich/pull/3789 
 
 ### Added
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ The following people have contributed to the development of Rich:
 - [Robin Bowes](https://github.com/yo61)
 - [Dennis Brakhane](https://github.com/brakhane)
 - [Darren Burns](https://github.com/darrenburns)
+- [Alex Carney](https://github.com/alcarney)
 - [Ceyda Cinarel](https://github.com/cceyda)
 - [Jim Crist-Harif](https://github.com/jcrist)
 - [Ed Davis](https://github.com/davised)

--- a/rich/ansi.py
+++ b/rich/ansi.py
@@ -144,6 +144,7 @@ class AnsiDecoder:
         Returns:
             Text: A Text instance marked up according to ansi codes.
         """
+
         from_ansi = Color.from_ansi
         from_rgb = Color.from_rgb
         _Style = Style
@@ -163,7 +164,7 @@ class AnsiDecoder:
                 # Ignore invalid codes, because we want to be lenient
                 codes = [
                     min(255, int(_code) if _code else 0)
-                    for _code in sgr.split(";")
+                    for _code in sgr.replace("::", ";").replace(":", ";").split(";")
                     if _code.isdigit() or _code == ""
                 ]
                 iter_codes = iter(codes)

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -1,5 +1,4 @@
 import pytest
-
 from rich.ansi import AnsiDecoder
 from rich.console import Console
 from rich.style import Style
@@ -68,6 +67,23 @@ def test_decode_issue_2688(ansi_bytes, expected_text):
     text = Text.from_ansi(ansi_bytes.decode())
 
     assert str(text) == expected_text
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        (
+            "\x1b[38;2;255;0;0mred\x1b[0m text",
+            Text("red text", spans=[Span(0, 3, Style.parse("#ff0000"))]),
+        ),
+        (
+            "\x1b[38:2::255:0:0mred\x1b[0m text",
+            Text("red text", spans=[Span(0, 3, Style.parse("#ff0000"))]),
+        ),
+    ],
+)
+def test_decode_sgr_rgb(text, expected):
+    assert Text.from_ansi(text) == expected
 
 
 @pytest.mark.parametrize("code", [*"0123456789:;<=>?"])


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

There are apparently two ways to "spell" the escape code sequence to set a truecolor value. One way [uses semicolon delimiters](https://en.wikipedia.org/wiki/ANSI_escape_code#24-bit), while the other  [uses colon delimiters](https://wezterm.org/escape-sequences.html#csi-382-foreground-color-rgb)

![image](https://github.com/user-attachments/assets/131b9fcd-d23c-4dfc-8a5c-a931aad0f559)

However, when parsing escape codes using `Text.from_ansi`, rich only recognises codes that use semicolon delimiters
```
❯ uv run --with rich python
Python 3.13.5 (main, Jun 26 2025, 21:20:04) [Clang 20.1.4 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from rich.text import Text

>>> Text.from_ansi('\x1b[38;2;255;0;0mred\x1b[0m text')
<text 'red text' [Span(0, 3, Style(color=Color('#ff0000', ColorType.TRUECOLOR, triplet=ColorTriplet(red=255, green=0, blue=0))))] ''>

>>> Text.from_ansi('\x1b[38:2::255:0:0mred\x1b[0m text')
<text 'red text' [] ''>
```

This PR tweaks the `AnsiDecoder` so that it converts colons to semicolons, allowing both style of codes to be parsed 
