### PR TITLE
Allow custom spinners across `rich` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `TTY_INTERACTIVE` environment variable to force interactive mode off or on https://github.com/Textualize/rich/pull/3777
+- Allowed custom spinner animations throughout the library https://github.com/Textualize/rich/pull/3791
 
 ## [14.0.0] - 2025-03-30
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -94,3 +94,4 @@ The following people have contributed to the development of Rich:
 - [Jonathan Helmus](https://github.com/jjhelmus)
 - [Brandon Capener](https://github.com/bcapener)
 - [Alex Zheng](https://github.com/alexzheng111)
+- [Maddy Guthridge](https://maddyguthridge.com/)

--- a/docs/source/console.rst
+++ b/docs/source/console.rst
@@ -136,6 +136,10 @@ Run the following command to see the available choices for ``spinner``::
 
     python -m rich.spinner
 
+You can use a custom spinner by providing a dictionary with the following properties
+
+* ``"interval"`` Intended time per frame of spinner
+* ``"frames"`` Frames of the spinner. If this is a single ``str``, each character is a single frame. If a ``list[str]`` is given, each list element is a single frame.
 
 Justify / Alignment
 -------------------

--- a/rich/_spinners.py
+++ b/rich/_spinners.py
@@ -19,7 +19,20 @@ Spinners are from:
     IN THE SOFTWARE.
 """
 
-SPINNERS = {
+from typing import TypedDict, List, Dict
+
+
+class SpinnerInfo(TypedDict):
+    interval: float
+    """Intended time per frame, in milliseconds"""
+    frames: List[str] | str
+    """
+    Frames of this spinner. If a single `str`, each character is a single
+    frame. If a `list[str]`, each list element is a single frame.
+    """
+
+
+SPINNERS: Dict[str, SpinnerInfo] = {
     "dots": {
         "interval": 80,
         "frames": "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏",

--- a/rich/_spinners.py
+++ b/rich/_spinners.py
@@ -19,13 +19,13 @@ Spinners are from:
     IN THE SOFTWARE.
 """
 
-from typing import TypedDict, List, Dict
+from typing import TypedDict, List, Dict, Union
 
 
 class SpinnerInfo(TypedDict):
     interval: float
     """Intended time per frame, in milliseconds"""
-    frames: List[str] | str
+    frames: Union[List[str], str]
     """
     Frames of this spinner. If a single `str`, each character is a single
     frame. If a `list[str]`, each list element is a single frame.

--- a/rich/_spinners.py
+++ b/rich/_spinners.py
@@ -22,7 +22,7 @@ Spinners are from:
 from typing import TypedDict, List, Dict, Union
 
 
-class SpinnerInfo(TypedDict):
+class SpinnerAnimation(TypedDict):
     interval: float
     """Intended time per frame, in milliseconds"""
     frames: Union[List[str], str]
@@ -32,7 +32,7 @@ class SpinnerInfo(TypedDict):
     """
 
 
-SPINNERS: Dict[str, SpinnerInfo] = {
+SPINNERS: Dict[str, SpinnerAnimation] = {
     "dots": {
         "interval": 80,
         "frames": "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏",

--- a/rich/console.py
+++ b/rich/console.py
@@ -36,7 +36,7 @@ from typing import (
 )
 
 from rich._null_file import NULL_FILE
-from rich._spinners import SpinnerInfo
+from rich._spinners import SpinnerAnimation
 
 from . import errors, themes
 from ._emoji_replace import _emoji_replace
@@ -1164,7 +1164,7 @@ class Console:
         self,
         status: RenderableType,
         *,
-        spinner: Union[str, SpinnerInfo] = "dots",
+        spinner: Union[str, SpinnerAnimation] = "dots",
         spinner_style: StyleType = "status.spinner",
         speed: float = 1.0,
         refresh_per_second: float = 12.5,
@@ -2182,9 +2182,9 @@ class Console:
             str: String containing console contents.
 
         """
-        assert (
-            self.record
-        ), "To export console contents set record=True in the constructor or instance"
+        assert self.record, (
+            "To export console contents set record=True in the constructor or instance"
+        )
 
         with self._record_buffer_lock:
             if styles:
@@ -2238,9 +2238,9 @@ class Console:
         Returns:
             str: String containing console contents as HTML.
         """
-        assert (
-            self.record
-        ), "To export console contents set record=True in the constructor or instance"
+        assert self.record, (
+            "To export console contents set record=True in the constructor or instance"
+        )
         fragments: List[str] = []
         append = fragments.append
         _theme = theme or DEFAULT_TERMINAL_THEME

--- a/rich/console.py
+++ b/rich/console.py
@@ -36,6 +36,7 @@ from typing import (
 )
 
 from rich._null_file import NULL_FILE
+from rich._spinners import SpinnerInfo
 
 from . import errors, themes
 from ._emoji_replace import _emoji_replace
@@ -1163,7 +1164,7 @@ class Console:
         self,
         status: RenderableType,
         *,
-        spinner: str = "dots",
+        spinner: Union[str, SpinnerInfo] = "dots",
         spinner_style: StyleType = "status.spinner",
         speed: float = 1.0,
         refresh_per_second: float = 12.5,

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -46,7 +46,7 @@ from .highlighter import Highlighter
 from .jupyter import JupyterMixin
 from .live import Live
 from .progress_bar import ProgressBar
-from .spinner import Spinner, SpinnerInfo
+from .spinner import Spinner, SpinnerAnimation
 from .style import StyleType
 from .table import Column, Table
 from .text import Text, TextType
@@ -575,7 +575,7 @@ class SpinnerColumn(ProgressColumn):
 
     def __init__(
         self,
-        spinner_name: Union[str, SpinnerInfo] = "dots",
+        spinner_name: Union[str, SpinnerAnimation] = "dots",
         style: Optional[StyleType] = "progress.spinner",
         speed: float = 1.0,
         finished_text: TextType = " ",
@@ -591,7 +591,7 @@ class SpinnerColumn(ProgressColumn):
 
     def set_spinner(
         self,
-        spinner_name: Union[str, SpinnerInfo],
+        spinner_name: Union[str, SpinnerAnimation],
         spinner_style: Optional[StyleType] = "progress.spinner",
         speed: float = 1.0,
     ) -> None:

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -46,7 +46,7 @@ from .highlighter import Highlighter
 from .jupyter import JupyterMixin
 from .live import Live
 from .progress_bar import ProgressBar
-from .spinner import Spinner
+from .spinner import Spinner, SpinnerInfo
 from .style import StyleType
 from .table import Column, Table
 from .text import Text, TextType
@@ -575,7 +575,7 @@ class SpinnerColumn(ProgressColumn):
 
     def __init__(
         self,
-        spinner_name: str = "dots",
+        spinner_name: Union[str, SpinnerInfo] = "dots",
         style: Optional[StyleType] = "progress.spinner",
         speed: float = 1.0,
         finished_text: TextType = " ",
@@ -591,7 +591,7 @@ class SpinnerColumn(ProgressColumn):
 
     def set_spinner(
         self,
-        spinner_name: str,
+        spinner_name: Union[str, SpinnerInfo],
         spinner_style: Optional[StyleType] = "progress.spinner",
         speed: float = 1.0,
     ) -> None:

--- a/rich/spinner.py
+++ b/rich/spinner.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Optional, Union
 
-from ._spinners import SPINNERS, SpinnerInfo
+from ._spinners import SPINNERS, SpinnerAnimation
 from .measure import Measurement
 from .table import Table
 from .text import Text
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 # want to use our type definition.
 __all__ = [
     "Spinner",
-    "SpinnerInfo",
+    "SpinnerAnimation",
 ]
 
 
@@ -33,7 +33,7 @@ class Spinner:
 
     def __init__(
         self,
-        name: str | SpinnerInfo,
+        name: str | SpinnerAnimation,
         text: "RenderableType" = "",
         *,
         style: Optional["StyleType"] = None,

--- a/rich/status.py
+++ b/rich/status.py
@@ -1,7 +1,7 @@
 from types import TracebackType
 from typing import Optional, Type, Union
 
-from ._spinners import SpinnerInfo
+from ._spinners import SpinnerAnimation
 from .console import Console, RenderableType
 from .jupyter import JupyterMixin
 from .live import Live
@@ -26,7 +26,7 @@ class Status(JupyterMixin):
         status: RenderableType,
         *,
         console: Optional[Console] = None,
-        spinner: Union[str, SpinnerInfo] = "dots",
+        spinner: Union[str, SpinnerAnimation] = "dots",
         spinner_style: StyleType = "status.spinner",
         speed: float = 1.0,
         refresh_per_second: float = 12.5,
@@ -55,7 +55,7 @@ class Status(JupyterMixin):
         self,
         status: Optional[RenderableType] = None,
         *,
-        spinner: Union[str, SpinnerInfo, None] = None,
+        spinner: Union[str, SpinnerAnimation, None] = None,
         spinner_style: Optional[StyleType] = None,
         speed: Optional[float] = None,
     ) -> None:

--- a/rich/status.py
+++ b/rich/status.py
@@ -1,6 +1,7 @@
 from types import TracebackType
-from typing import Optional, Type
+from typing import Optional, Type, Union
 
+from ._spinners import SpinnerInfo
 from .console import Console, RenderableType
 from .jupyter import JupyterMixin
 from .live import Live
@@ -25,7 +26,7 @@ class Status(JupyterMixin):
         status: RenderableType,
         *,
         console: Optional[Console] = None,
-        spinner: str = "dots",
+        spinner: Union[str, SpinnerInfo] = "dots",
         spinner_style: StyleType = "status.spinner",
         speed: float = 1.0,
         refresh_per_second: float = 12.5,
@@ -54,7 +55,7 @@ class Status(JupyterMixin):
         self,
         status: Optional[RenderableType] = None,
         *,
-        spinner: Optional[str] = None,
+        spinner: Union[str, SpinnerInfo, None] = None,
         spinner_style: Optional[StyleType] = None,
         speed: Optional[float] = None,
     ) -> None:

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -3,7 +3,7 @@ import pytest
 from rich.console import Console
 from rich.measure import Measurement
 from rich.rule import Rule
-from rich.spinner import Spinner, SpinnerInfo
+from rich.spinner import Spinner, SpinnerAnimation
 from rich.text import Text
 
 
@@ -73,7 +73,7 @@ def test_spinner_markup():
 
 
 def test_custom_spinner_render():
-    custom_spinner: SpinnerInfo = {
+    custom_spinner: SpinnerAnimation = {
         "interval": 80,
         "frames": "abcdef",
     }

--- a/tests/test_spinner.py
+++ b/tests/test_spinner.py
@@ -3,7 +3,7 @@ import pytest
 from rich.console import Console
 from rich.measure import Measurement
 from rich.rule import Rule
-from rich.spinner import Spinner
+from rich.spinner import Spinner, SpinnerInfo
 from rich.text import Text
 
 
@@ -70,3 +70,28 @@ def test_spinner_markup():
     spinner = Spinner("dots", "[bold]spinning[/bold]")
     assert isinstance(spinner.text, Text)
     assert str(spinner.text) == "spinning"
+
+
+def test_custom_spinner_render():
+    custom_spinner: SpinnerInfo = {
+        "interval": 80,
+        "frames": "abcdef",
+    }
+    time = 0.0
+
+    def get_time():
+        nonlocal time
+        return time
+
+    console = Console(
+        width=80, color_system=None, force_terminal=True, get_time=get_time
+    )
+    console.begin_capture()
+    spinner = Spinner(custom_spinner, "Foo")
+    console.print(spinner)
+    time += 80 / 1000
+    console.print(spinner)
+    result = console.end_capture()
+    print(repr(result))
+    expected = "a Foo\nb Foo\n"
+    assert result == expected


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

## Type of changes

- [x] New feature
- [x] Documentation / docstrings
- [x] Tests

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review. (I am keen!)

## Description

Resolves #3790 

***The feature***
* Adds type definition to spinner animation dictionary
* Allows a custom spinner animation parameter in place of a spinner name, allowing users to specify their very own animations if they desire
* This is implemented in `Spinner`, `Console.status`, `Status` and `progress.SpinnerColumn` (let me know if I missed anything)

***Documentation***
* I documented custom spinner support in `console.rst`
* Spinners don't have their own dedicated documentation page. Should one be added? If so, this should be documented there.
* Notably, all tests still pass.

***Is this worth adding despite Rich rejecting most new features?***
* Imo this feature is worthwhile adding, since it cannot easily be added through a third-party library (unless that library reimplements spinners as a whole). Imo this makes it easier to extend the core library.
* This shouldn't break backwards compatibility, as all changed function parameters still accept their original types, as well as the new types.

***Design considerations***
* In an ideal world, all these functions would accept a `Spinner` object themselves, rather than their assorted set of other parameters (`spinner`, `spinner_style` and `speed`), which would make patterns like dependency injection simpler
* However, accepting a `Spinner` object (rather than constructing one based on these parameters) would make those other parameters ambiguous in the case where a `Spinner` object is given.
* As such, this design is probably the best for fitting with the existing code-base, and avoiding confusion and breaking changes.