### PR TITLE
fixing with none rich colored text

### DIFF
--- a/rich/cells.py
+++ b/rich/cells.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import re
 from functools import lru_cache
 from typing import Callable
 
 from ._cell_widths import CELL_WIDTHS
+
+_RE_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
 
 # Ranges of unicode ordinals that produce a 1-cell wide character
 # This is non-exhaustive, but covers most common Western characters
@@ -43,6 +47,8 @@ def cached_cell_len(text: str) -> int:
     Returns:
         int: Get the number of cells required to display text.
     """
+    if "\x1b" in text:
+        text = _RE_ANSI.sub("", text)
     if _is_single_cell_widths(text):
         return len(text)
     return sum(map(get_character_cell_size, text))
@@ -59,6 +65,10 @@ def cell_len(text: str, _cell_len: Callable[[str], int] = cached_cell_len) -> in
     """
     if len(text) < 512:
         return _cell_len(text)
+
+    if "\x1b" in text:
+        text = _RE_ANSI.sub("", text)
+
     if _is_single_cell_widths(text):
         return len(text)
     return sum(map(get_character_cell_size, text))


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description
This pull request addresses a bug where the Panel component, and others relying on cell_len, fail to correctly calculate the width of content that includes raw ANSI escape codes. This typically occurs when displaying text colored by a library other than rich.
The issue stems from cell_len not stripping these non-printable ANSI characters before measuring the string's visible length. Consequently, the escape codes are counted as part of the width, causing the Panel to render much wider than its actual content, breaking the layout.

This fix introduces a regular expression to rich/cells.py that sanitizes input strings by removing ANSI codes within the cell_len and cached_cell_len functions. This ensures that the measured width accurately reflects the visible text, allowing rich components to correctly render pre-formatted text.

## Before
A Panel wrapping a string with ANSI color codes renders incorrectly, with a width that far exceeds the visible content.
<img width="1362" height="267" alt="image" src="https://github.com/user-attachments/assets/63705f01-4246-41f0-b99c-d0994fc15224" />

## After
The same Panel now correctly calculates the content width, ignoring the ANSI codes, and renders with the expected dimensions.
<img width="376" height="269" alt="image" src="https://github.com/user-attachments/assets/e06a4fcc-7489-4131-a20c-15548329294b" />
