### PR TITLE
Fix poetry command in CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,8 @@ Enter the directory containing your copy of Rich (`cd rich`).
 
 Poetry can be used to create an isolated _virtual environment_ for the project:
 
-```
+```bash
+poetry self add poetry-plugin-shell # (If using Poetry > 2.0.0))
 poetry shell
 ```
 


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fix the issue in https://github.com/Textualize/rich/issues/3817

The problem is caused by the deprecation of `poetry shell` in the latest poetry release (>v2.0.0)
