### PR TITLE
Fix issues #3820 expand=False didn't work when it contains Columns

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -74,6 +74,7 @@ The following people have contributed to the development of Rich:
 - [Damian Shaw](https://github.com/notatallshaw)
 - [Nicolas Simonds](https://github.com/0xDEC0DE)
 - [Aaron Stephens](https://github.com/aaronst)
+- [Stranger](https://github.com/Stranger-Jie)
 - [Karolina Surma](https://github.com/befeleme)
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)
 - [Nils Vu](https://github.com/nilsvu)

--- a/rich/columns.py
+++ b/rich/columns.py
@@ -178,16 +178,17 @@ class Columns(JupyterMixin):
         padding = left + right
         renderables = [*self.renderables, title] if title else [*self.renderables]
 
+        maximum_width = sum(
+            measure_renderables(
+                console,
+                options.update_width(options.max_width - padding - 2),
+                [renderable],
+            ).maximum
+            for renderable in renderables
+        )
+
         if self.width is None:
-            width = (
-                measure_renderables(
-                    console,
-                    options.update_width(options.max_width - padding - 2),
-                    renderables,
-                ).maximum
-                + padding
-                + 2
-            )
+            width = maximum_width + padding + 2
         else:
             width = self.width
         return Measurement(width, width)

--- a/rich/columns.py
+++ b/rich/columns.py
@@ -6,7 +6,7 @@ from typing import Dict, Iterable, List, Optional, Tuple
 from .align import Align, AlignMethod
 from .console import Console, ConsoleOptions, RenderableType, RenderResult
 from .constrain import Constrain
-from .measure import Measurement
+from .measure import Measurement, measure_renderables
 from .padding import Padding, PaddingDimensions
 from .table import Table
 from .text import TextType
@@ -169,6 +169,28 @@ class Columns(JupyterMixin):
                 row = row[::-1]
             add_row(*row)
         yield table
+
+    def __rich_measure__(
+        self, console: "Console", options: "ConsoleOptions"
+    ) -> "Measurement":
+        title = self.title
+        _, right, _, left = Padding.unpack(self.padding)
+        padding = left + right
+        renderables = [*self.renderables, title] if title else [*self.renderables]
+
+        if self.width is None:
+            width = (
+                measure_renderables(
+                    console,
+                    options.update_width(options.max_width - padding - 2),
+                    renderables,
+                ).maximum
+                + padding
+                + 2
+            )
+        else:
+            width = self.width
+        return Measurement(width, width)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -3,6 +3,7 @@ import io
 import pytest
 
 from rich.console import Console
+from rich.columns import Columns
 from rich.panel import Panel
 from rich.segment import Segment
 from rich.style import Style
@@ -16,6 +17,8 @@ tests = [
     Panel(Panel("Hello, World", padding=0), padding=0),
     Panel("Hello, World", title="FOO", padding=0),
     Panel("Hello, World", subtitle="FOO", padding=0),
+    Panel(Columns(["Hello", "World"]), padding=0),
+    Panel(Columns(["Hello", "World"]), expand=False, padding=0),
 ]
 
 expected = [
@@ -26,6 +29,8 @@ expected = [
     "╭────────────────────────────────────────────────╮\n│╭──────────────────────────────────────────────╮│\n││Hello, World                                  ││\n│╰──────────────────────────────────────────────╯│\n╰────────────────────────────────────────────────╯\n",
     "╭───────────────────── FOO ──────────────────────╮\n│Hello, World                                    │\n╰────────────────────────────────────────────────╯\n",
     "╭────────────────────────────────────────────────╮\n│Hello, World                                    │\n╰───────────────────── FOO ──────────────────────╯\n",
+    "╭────────────────────────────────────────────────╮\n│Hello World                                     │\n╰────────────────────────────────────────────────╯\n",
+    "╭──────────────╮\n│Hello World   │\n╰──────────────╯\n",
 ]
 
 


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description
#3820 , This is a simple fix that adds a method similar to the `__rich_measure__` in Panel to `Conlumns` class.
<img width="888" height="236" alt="image" src="https://github.com/user-attachments/assets/72793ba3-b5e5-40e8-86e9-2f661ad5967a" />

