### PR TITLE
Use faster generator for link IDs

### DIFF
--- a/rich/style.py
+++ b/rich/style.py
@@ -1,8 +1,9 @@
 import sys
 from functools import lru_cache
+from itertools import count
 from operator import attrgetter
 from pickle import dumps, loads
-from random import randint
+from random import getrandbits
 from typing import Any, Dict, Iterable, List, Optional, Type, Union, cast
 
 from . import errors
@@ -16,6 +17,9 @@ _hash_getter = attrgetter(
 
 # Style instances and style definitions are often interchangeable
 StyleType = Union[str, "Style"]
+
+
+_id_generator = count(getrandbits(24))
 
 
 class _Bit:
@@ -195,7 +199,7 @@ class Style:
         self._link = link
         self._meta = None if meta is None else dumps(meta)
         self._link_id = (
-            f"{randint(0, 999999)}{hash(self._meta)}" if (link or meta) else ""
+            f"{next(_id_generator)}{hash(self._meta)}" if (link or meta) else ""
         )
         self._hash: Optional[int] = None
         self._null = not (self._set_attributes or color or bgcolor or link or meta)
@@ -245,7 +249,7 @@ class Style:
         style._attributes = 0
         style._link = None
         style._meta = dumps(meta)
-        style._link_id = f"{randint(0, 999999)}{hash(style._meta)}"
+        style._link_id = f"{next(_id_generator)}{hash(style._meta)}"
         style._hash = None
         style._null = not (meta)
         return style
@@ -483,7 +487,7 @@ class Style:
         style._attributes = self._attributes
         style._set_attributes = self._set_attributes
         style._link = self._link
-        style._link_id = f"{randint(0, 999999)}" if self._link else ""
+        style._link_id = f"{next(_id_generator)}" if self._link else ""
         style._null = False
         style._meta = None
         style._hash = None
@@ -635,7 +639,7 @@ class Style:
         style._attributes = self._attributes
         style._set_attributes = self._set_attributes
         style._link = self._link
-        style._link_id = f"{randint(0, 999999)}" if self._link else ""
+        style._link_id = f"{next(_id_generator)}" if self._link else ""
         style._hash = self._hash
         style._null = False
         style._meta = self._meta
@@ -681,7 +685,7 @@ class Style:
         style._attributes = self._attributes
         style._set_attributes = self._set_attributes
         style._link = link
-        style._link_id = f"{randint(0, 999999)}" if link else ""
+        style._link_id = f"{next(_id_generator)}" if link else ""
         style._hash = None
         style._null = False
         style._meta = self._meta


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## AI?

- [ ] AI was used to generate this PR

AI was not used to generate this PR.

## Description

I was profiling some code that uses `rich` and noticed that some unusual time was spent in `random.getrandbits()` (which underlies `random.randint()`). The default RNG in Python is not the fastest to begin with (which is why e.g. [`fastrand`](https://github.com/lemire/fastrand) is a thing).

This PR switches the generator for `_link_id`s from a random number to a simple sequential counter (initialized once with randomness). This also has the happy side effect that link ID collisions are simply not possible anymore, whereas the birthday paradox says `random.randint(0, 999999)` tends to have a collision in the first 1,253 calls.

Running
```python
print(timeit.timeit(lambda: next(_id_generator), number=10000000))
print(timeit.timeit(lambda: randint(0, 999999), number=10000000))
```
shows that the new generator is about 8 times faster than the old one (0.381s vs 3.056s).