### PR TITLE
fix(typo): correct typo in Text.divide docstring

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,6 +61,7 @@ The following people have contributed to the development of Rich:
 - [Min RK](https://github.com/minrk)
 - [Clément Robert](https://github.com/neutrinoceros)
 - [Brian Rutledge](https://github.com/bhrutledge)
+- [royiro](https://github.com/royiro10)
 - [Tushar Sadhwani](https://github.com/tusharsadhwani)
 - [Luca Salvarani](https://github.com/LukeSavefrogs)
 - [Paul Sanders](https://github.com/sanders41)

--- a/rich/text.py
+++ b/rich/text.py
@@ -1105,7 +1105,7 @@ class Text(JupyterMixin):
         return lines
 
     def divide(self, offsets: Iterable[int]) -> Lines:
-        """Divide text in to a number of lines at given offsets.
+        """Divide text into a number of lines at given offsets.
 
         Args:
             offsets (Iterable[int]): Offsets used to divide text.


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

## Type of changes

- [x] Documentation / docstrings

## Checklist

- [ x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This PR fixes a small typo in the Text.divide docstring.
It does not affect functionality or behavior — documentation only.
