### PR TITLE
fix(ReprHighlighter): highlight only standalone hex; support 0X/sign/underscores; add boundary tests

### DIFF
--- a/rich/highlighter.py
+++ b/rich/highlighter.py
@@ -95,7 +95,7 @@ class ReprHighlighter(RegexHighlighter):
             r"\b(?P<bool_true>True)\b|\b(?P<bool_false>False)\b|\b(?P<none>None)\b",
             r"(?P<ellipsis>\.\.\.)",
             r"(?P<number_complex>(?<!\w)(?:\-?[0-9]+\.?[0-9]*(?:e[-+]?\d+?)?)(?:[-+](?:[0-9]+\.?[0-9]*(?:e[-+]?\d+)?))?j)",
-            r"(?P<number>(?<!\w)\-?[0-9]+\.?[0-9]*(e[-+]?\d+?)?\b|0x[0-9a-fA-F]*)",
+            r"(?P<number>(?<!\w)\-?[0-9]+\.?[0-9]*(e[-+]?\d+?)?\b|(?<![0-9A-Za-z_])[+-]?0[xX][0-9A-Fa-f](?:_?[0-9A-Fa-f])*(?![0-9A-Za-z_]))",
             r"(?P<path>\B(/[-\w._+]+)*\/)(?P<filename>[-\w._+]*)?",
             r"(?<![\\\w])(?P<str>b?'''.*?(?<!\\)'''|b?'.*?(?<!\\)'|b?\"\"\".*?(?<!\\)\"\"\"|b?\".*?(?<!\\)\")",
             r"(?P<url>(file|https|http|ws|wss)://[-0-9a-zA-Z$_+!`(),.?/;:&=%#~@]*)",


### PR DESCRIPTION

<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

## Type of changes

- [ x ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ x ] Tests
- [ ] Other

## Checklist

- [ x ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ x ] I've added tests for new code.
- [ x ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Summary
Fixes false positives where ReprHighlighter highlighted embedded 0x… (e.g., 1920x1080). Tightens the regex to match standalone hex literals only, while supporting optional sign, uppercase 0X, and single underscore separators between digits.

Related issue
Fixes #3854

Regex

(?<![0-9A-Za-z_])[+-]?0[xX][0-9A-Fa-f](?:_?[0-9A-Fa-f])*(?![0-9A-Za-z_])


Changes

rich/highlighter.py: updated hex branch in ReprHighlighter.

tests/test_highlighter.py: added expanded boundary cases (signs, 0X, underscores, punctuation boundaries, invalid underscores).

QA

Focused + full tests: pytest -q 

Tooling: black, ruff, mypy clean on touched files

Scope

Scoped to ReprHighlighter; JSON highlighter unchanged.
