### PR TITLE
feat: Add custom pretty printing for pathlib.Path objects

### DIFF
--- a/rich/pretty.py
+++ b/rich/pretty.py
@@ -1,5 +1,6 @@
 import builtins
 import collections
+import pathlib
 import dataclasses
 import inspect
 import os
@@ -816,6 +817,12 @@ def traverse(
                     child_node.key_separator = "="
                     append(child_node)
             pop_visited(obj_id)
+        
+        # START of new code block
+        elif isinstance(obj, pathlib.Path):
+            node = Node(value_repr=repr(str(obj)))
+        # END of new code block
+
         elif _safe_isinstance(obj, _CONTAINERS):
             for container_type in _CONTAINERS:
                 if _safe_isinstance(obj, container_type):

--- a/test_my_fix.py
+++ b/test_my_fix.py
@@ -1,0 +1,11 @@
+# test_my_fix.py
+import pathlib
+from rich.pretty import pprint
+
+# Create a Path object to test
+my_file_path = pathlib.Path("./my_folder/my_script.py")
+
+# This will use the code you just modified!
+print("--- Running test with the fix ---")
+pprint(my_file_path)
+print("-------------------------------")


### PR DESCRIPTION
### Summary

This PR improves the pretty-printing of `pathlib.Path` objects by rendering them as strings instead of their default object representation.

### Problem

Currently, `rich.pretty.pprint` displays a `pathlib.Path` object using its default `__repr__`, which looks like `PosixPath('/path/to/file.txt')`. While technically correct, this is verbose and doesn't stand out in complex outputs where file paths are common.

### Solution

The changes in this PR intercept `pathlib.Path` objects during the rendering process and convert them to their string equivalent.

**Before:**
`PosixPath('my_folder/my_script.py')`

**After:**
`'my_folder/my_script.py'` (This will be colored as a string by the highlighter)

