### PR TITLE
docs: add quickstart for contributors (venv, install, pytest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,3 +437,15 @@ See also [Rich CLI](https://github.com/textualize/rich-cli) for a command line a
 See also Rich's sister project, [Textual](https://github.com/Textualize/textual), which you can use to build sophisticated User Interfaces in the terminal.
 
 ![textual-splash](https://github.com/user-attachments/assets/4caeb77e-48c0-4cf7-b14d-c53ded855ffd)
+
+---
+
+### Quickstart for Contributors
+
+If you’d like to set up Rich locally for development or testing, here’s a simple way to get started:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate     # On Windows: .venv\Scripts\activate
+pip install -e . && pip install pytest attrs
+pytest -q


### PR DESCRIPTION
Adds a short "Quickstart for Contributors" section in the README to make setup faster. It includes virtual environment creation, dependency installs, and pytest commands so new contributors can start testing immediately.

