### PR TITLE
docs: add quick Windows demo and test instructions (attrs note)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,3 +437,27 @@ See also [Rich CLI](https://github.com/textualize/rich-cli) for a command line a
 See also Rich's sister project, [Textual](https://github.com/Textualize/textual), which you can use to build sophisticated User Interfaces in the terminal.
 
 ![textual-splash](https://github.com/user-attachments/assets/4caeb77e-48c0-4cf7-b14d-c53ded855ffd)
+
+### Quick Demo (Windows PowerShell)
+
+```powershell
+python -m venv .venv
+. .\.venv\Scripts\Activate.ps1
+pip install -U pip
+pip install -e .
+python - << "PY"
+from rich import print
+from rich.table import Table
+print("[bold green]Rich works![/]")
+t = Table(title="Sample Results"); t.add_column("Name"); t.add_column("Score", justify="right")
+t.add_row("Alpha","92"); t.add_row("Beta","87"); t.add_row("Gamma","95")
+print(t)
+PY
+
+**“Run Tests (dev setup)”**
+```md
+### Run Tests (dev setup)
+
+```bash
+pip install pytest attrs
+pytest -q


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ X] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

Summary
This adds a short Windows PowerShell quickstart for Rich and a one-liner for running tests locally. It also notes that installing attrs may be required for a clean pytest -q run on a fresh env.

Why
New contributors on Windows may not know the PowerShell venv activation command, and first test runs can fail with ModuleNotFoundError: No module named 'attr'.

What changed

README: Quick Demo (Windows PowerShell) snippet

README: Run Tests (dev setup) snippet: pip install pytest attrs → pytest -q

Tested
Windows 11 + Python 3.13

Demo renders table and progress bar

Tests: 883 passed, 23 skipped on my machine

Notes
Happy to adjust placement/wording or move this into CONTRIBUTING if preferred.

