### PR TITLE
Fix raw markup printed on prompt errors sometimes

### DIFF
--- a/rich/prompt.py
+++ b/rich/prompt.py
@@ -262,7 +262,7 @@ class PromptBase(Generic[PromptType]):
             value (str): String entered by user.
             error (InvalidResponse): Exception instance the initiated the error.
         """
-        self.console.print(error)
+        self.console.print(error, markup=True)
 
     def pre_prompt(self) -> None:
         """Hook to display something before the prompt."""

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -111,3 +111,16 @@ def test_prompt_confirm_default():
     output = console.file.getvalue()
     print(repr(output))
     assert output == expected
+
+
+def test_prompt_confirm_markup():
+    INPUT = "foo\nNO\ny"
+    console = Console(file=io.StringIO(), markup=False)
+    answer = Confirm.ask(
+        "continue", console=console, stream=io.StringIO(INPUT), default=True
+    )
+    assert answer is True
+    expected = "continue [y/n] (y): Please enter Y or N\ncontinue [y/n] (y): Please enter Y or N\ncontinue [y/n] (y): "
+    output = console.file.getvalue()
+    print(repr(output))
+    assert output == expected


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

PromptBase.on_validate_error() should explicitly ask for markup in case the console passed to it has markup disabled globally.

Fixes #3881.