### PR TITLE
tests: add actionable error test for mismatched closing tag in markup

### DIFF
--- a/tests/test_markup_error_message.py
+++ b/tests/test_markup_error_message.py
@@ -1,0 +1,12 @@
+import pytest
+from rich.text import Text
+from rich.errors import MarkupError
+
+def test_invalid_markup_message_is_actionable_mismatched_close():
+    bad = "[bold]hello[/italic]"  # mismatched closing tag should raise
+    with pytest.raises(MarkupError) as exc:
+        Text.from_markup(bad)
+
+    msg = str(exc.value).lower()
+    # keep the assertions flexible so they work with current Rich messaging
+    assert any(word in msg for word in ("invalid", "mismatch", "closing", "end tag"))


### PR DESCRIPTION
<!-- See CONTRIBUTING: Rich is not accepting new features; this is tests-only. -->

## Type of changes
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist
- [x] I've run the latest black with default args on new code.  (`poetry run black --check .` passed)
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (N/A for tests-only; maintainers may advise)
- [x] I've added tests for new code (this PR adds a single test)
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description
Add a focused unit test that asserts malformed markup with a **mismatched closing tag**
(e.g., `"[bold]hello[/italic]"`) raises a `MarkupError` *and* that the message is
actionable. The assertions are intentionally flexible to avoid over-constraining the
exact wording while still guarding for helpful terms such as “invalid / mismatch /
closing / end tag”.

This is **tests-only** and does not change runtime behavior. It helps prevent future
regressions in error messaging clarity for invalid markup.

Relates to: #2993.