### PR TITLE
Add enable_link_path parameter to disable OSC 8 hyperlinks - Addresse…

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -611,6 +611,7 @@ class Console:
         highlight (bool, optional): Enable automatic highlighting. Defaults to True.
         log_time (bool, optional): Boolean to enable logging of time by :meth:`log` methods. Defaults to True.
         log_path (bool, optional): Boolean to enable the logging of the caller by :meth:`log`. Defaults to True.
+        enable_link_path (bool, optional): Boolean to enable terminal hyperlinks in file paths logged by :meth:`log`. Defaults to True.
         log_time_format (Union[str, TimeFormatterCallable], optional): If ``log_time`` is enabled, either string for strftime or callable that formats the time. Defaults to "[%X] ".
         highlighter (HighlighterType, optional): Default highlighter.
         legacy_windows (bool, optional): Enable legacy Windows mode, or ``None`` to auto detect. Defaults to ``None``.
@@ -648,6 +649,7 @@ class Console:
         highlight: bool = True,
         log_time: bool = True,
         log_path: bool = True,
+        enable_link_path: bool = True,
         log_time_format: Union[str, FormatTimeCallable] = "[%X]",
         highlighter: Optional["HighlighterType"] = ReprHighlighter(),
         legacy_windows: Optional[bool] = None,
@@ -723,6 +725,7 @@ class Console:
             show_path=log_path,
             time_format=log_time_format,
         )
+        self.enable_link_path = enable_link_path
         self.highlighter: HighlighterType = highlighter or _null_highlighter
         self.safe_box = safe_box
         self.get_datetime = get_datetime or datetime.now
@@ -1977,6 +1980,9 @@ class Console:
 
             filename, line_no, locals = self._caller_frame_info(_stack_offset)
             link_path = None if filename.startswith("<") else os.path.abspath(filename)
+            # Disable hyperlinks if enable_link_path is False, but keep the path text
+            if not self.enable_link_path:
+                link_path = None
             path = filename.rpartition(os.sep)[-1]
             if log_locals:
                 locals_map = {

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -59,6 +59,48 @@ def test_justify():
     assert result == "                 foo\n"
 
 
+def test_enable_link_path():
+    """Test that enable_link_path=False disables hyperlinks but keeps path text."""
+    console = Console(
+        file=io.StringIO(),
+        width=80,
+        force_terminal=True,
+        log_time_format="[TIME]",
+        color_system="truecolor",
+        legacy_windows=False,
+        enable_link_path=False,  # Disable hyperlinks
+    )
+    console.log("Test message")
+    output = console.file.getvalue()
+    
+    # Should NOT contain OSC 8 hyperlink escape sequences
+    assert "\x1b]8;" not in output
+    
+    # Should still contain the path text (filename)
+    assert "test_log.py" in output
+
+
+def test_enable_link_path_default():
+    """Test that enable_link_path defaults to True (hyperlinks enabled)."""
+    console = Console(
+        file=io.StringIO(),
+        width=80,
+        force_terminal=True,
+        log_time_format="[TIME]",
+        color_system="truecolor",
+        legacy_windows=False,
+        # enable_link_path not specified, should default to True
+    )
+    console.log("Test message")
+    output = console.file.getvalue()
+    
+    # Should contain OSC 8 hyperlink escape sequences
+    assert "\x1b]8;" in output
+    
+    # Should also contain the path text
+    assert "test_log.py" in output
+
+
 if __name__ == "__main__":
     render = render_log()
     print(render)


### PR DESCRIPTION
**Title:**
```
Add enable_link_path parameter to disable OSC 8 hyperlinks
```

**Description:**
```markdown
## Problem
Fixes #3896

In Jupyter notebooks and remote server environments, OSC 8 hyperlinks generated by `console.log()` cause issues:
- Large vertical spacing in Jupyter due to HTML block rendering
- Visible escape sequences when using `force_jupyter=False`
- Hyperlinks are not useful when file paths don't exist on client machines

Previously, the only workaround was to 'monkey-patch' the private `_log_render` method.

## Solution
Added a new `enable_link_path` parameter to the `Console` class:
- Defaults to `True` (backward compatible - existing behavior unchanged)
- When set to `False`, disables OSC 8 hyperlink generation
- File path text is still displayed (only the escape codes are removed)

## Example Usage
```python
from rich.console import Console

# For Jupyter notebooks or remote servers
console = Console(
    force_jupyter=False,
    enable_link_path=False,  # Disable hyperlinks
    log_time=True,
    log_path=True
)

console.log("Clean output without OSC 8 escape sequences")
```

## Testing
- Added `test_enable_link_path()` - verifies hyperlinks are disabled
- Added `test_enable_link_path_default()` - verifies default behavior unchanged
- All existing tests pass