### PR TITLE
Fix _get_padding_width() to respect pad_edge setting

### DIFF
--- a/rich/table.py
+++ b/rich/table.py
@@ -702,6 +702,13 @@ class Table(JupyterMixin):
         if self.collapse_padding:
             if column_index > 0:
                 pad_left = max(0, pad_left - pad_right)
+        if not self.pad_edge:
+            first_column = column_index == 0
+            last_column = column_index == len(self.columns) - 1
+            if first_column:
+                pad_left = 0
+            if last_column:
+                pad_right = 0
         return pad_left + pad_right
 
     def _measure_column(

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -382,6 +382,42 @@ def test_columns_highlight_added_by_add_row() -> None:
     assert output == expected
 
 
+def test_pad_edge_false_with_fixed_width_columns() -> None:
+    """Regression test for https://github.com/Textualize/rich/issues/3892
+    
+    When pad_edge=False with fixed-width columns, the edge columns should not
+    have extra padding added to their width calculation.
+    """
+    output = io.StringIO()
+    console = Console(
+        width=60,
+        file=output,
+        force_terminal=True,
+        legacy_windows=False,
+        color_system=None,
+        _environ={},
+    )
+
+    table = Table(
+        Column('verb', width=5),
+        Column('noun', width=5),
+        Column('wh', width=2),
+        box=None,
+        pad_edge=False,
+        expand=False,
+        show_header=True,
+    )
+    table.add_row('hello', 'world', 'oh')
+    console.print(table)
+    
+    result = output.getvalue().rstrip('\n')
+    expected = '\n'.join([
+        'verb   noun   wh',
+        'hello  world  oh'
+    ])
+    assert result == expected
+
+
 if __name__ == "__main__":
     render = render_tables()
     print(render)


### PR DESCRIPTION
## Summary

Fixes #3892

When `pad_edge=False` is set on a Table with fixed-width columns, the first and last columns were being rendered wider than their specified width. This was because `_get_padding_width()` was returning the full padding width without accounting for the `pad_edge` setting.

## Root Cause

The `_get_cells()` method already correctly handles `pad_edge=False` by zeroing out padding for edge cells. However, `_get_padding_width()` (used in `_measure_column()`) did not apply the same logic, causing width calculations to include padding that wouldn't actually be rendered.

## Fix

Added the same `pad_edge` check to `_get_padding_width()`:
- For the first column: set `pad_left = 0` when `pad_edge=False`
- For the last column: set `pad_right = 0` when `pad_edge=False`

## Testing

Added regression test `test_pad_edge_false_with_fixed_width_columns` that reproduces the exact scenario from the issue. All existing table tests continue to pass.

## Before/After

Before (with `pad_edge=False` and fixed widths):
```
verb     noun     wh  
hello    world    oh  
```

After:
```
verb   noun   wh
hello  world  oh
```