### PR TITLE
 Don't use windows legacy terminal support when ctypes is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- Don't use windows legacy terminal support when ctypes is not available.
+
 ## [14.2.0] - 2025-10-09
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@ The following people have contributed to the development of Rich:
 - [Ed Davis](https://github.com/davised)
 - [Pete Davison](https://github.com/pd93)
 - [James Estevez](https://github.com/jstvz)
+- [Jeong, YunWon](https://github.com/youknowone)
 - [Jonathan Eunice](https://github.com/jonathan-3play)
 - [Aryaz Eghbali](https://github.com/AryazE)
 - [Oleksis Fraga](https://github.com/oleksis)

--- a/rich/console.py
+++ b/rich/console.py
@@ -581,6 +581,12 @@ def get_windows_console_features() -> "WindowsConsoleFeatures":  # pragma: no co
 
 def detect_legacy_windows() -> bool:
     """Detect legacy Windows."""
+    try:
+        import ctypes  # noqa: F401
+    except ImportError:
+        # No ctypes doesn't mean no legacy windows,
+        # but legacy windows mode requires ctypes, so we force it off.
+        return False
     return WINDOWS and not get_windows_console_features().vt
 
 


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Hello, I am a developer of RustPython project. RustPython currently doesn't have ctypes, but trying to support pip.
rich is currently bundled in pip. When pip is trying to use rich on legacy windows terminal, it requires ctypes and raising error.
This patch changes rich not to turn on legacy windows terminal supports when ctypes is not available.

Could you check if this is an acceptable approach for rich? Then I will add a test to prevent regressions.
