### PR TITLE
Fix inspect(sort=False) to preserve instance attribute order

### DIFF
--- a/rich/_inspect.py
+++ b/rich/_inspect.py
@@ -133,7 +133,12 @@ class Inspect(JupyterMixin):
                 return (error, None)
 
         obj = self.obj
-        keys = dir(obj)
+        if not self.sort and hasattr(obj, "__dict__"):
+            # Preserve instance attribute insertion order
+            keys = list(obj.__dict__.keys())
+        else:
+            keys = dir(obj)
+
         total_items = len(keys)
         if not self.dunder:
             keys = [key for key in keys if not key.startswith("__")]

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -497,7 +497,28 @@ def test_object_types_mro_as_strings(obj: object, expected_result: Sequence[str]
         # fmt: on
     ),
 )
+
 def test_object_is_one_of_types(
     obj: object, types: Sequence[str], expected_result: bool
 ):
     assert is_object_one_of_types(obj, types) is expected_result
+
+def test_inspect_preserves_instance_attribute_order_when_sort_false():
+    class Example:
+        def __init__(self):
+            self.b = 1
+            self.a = 2
+
+    example = Example()
+
+    # Render inspect output with sort=False
+    output = render(example, methods=False, value=False, sort=False)
+
+    # Attribute order should be preserved: b then a
+    b_index = output.find("b = 1")
+    a_index = output.find("a = 2")
+
+    assert b_index != -1
+    assert a_index != -1
+    assert b_index < a_index
+


### PR DESCRIPTION
This PR fixes an issue where `inspect(sort=False)` did not preserve the
insertion order of instance attributes.

Previously, instance attributes were always displayed in alphabetical order
because `dir(obj)` returns a sorted list of attribute names. This behavior
ignored the `sort=False` option.

To fix this, when `sort=False` and the object has a `__dict__`, the instance
attribute insertion order is used instead of `dir(obj)`.

A test was added to ensure the attribute order is preserved when `sort=False`.