### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -4,7 +4,7 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: python3 -m pip install codespell
       - run: codespell --ignore-words-list="ba,fo,hel,revered,womens"
           --skip="./README.*.md,*.svg,*.ai,./benchmarks/snippets.py,./tests,./tools,*.lock"

--- a/.github/workflows/newissue.yml
+++ b/.github/workflows/newissue.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
       - name: Install FAQtory

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,9 +16,9 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -44,7 +44,7 @@ jobs:
           source $VENV
           pytest tests -v --cov=./rich --cov-report=xml:./coverage.xml --cov-report term-missing
       - name: Upload code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/readmechanged.yml
+++ b/.github/workflows/readmechanged.yml
@@ -11,7 +11,7 @@ jobs:
   send_notification:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Send notification to README Authors
       env:
         GITHUB_TOKEN: ${{ secrets.GHP_README_WORKFLOW }}


### PR DESCRIPTION
---

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

This PR updates outdated GitHub Action versions to ensure compatibility and security. The changes include:

- `codecov/codecov-action` from `v4` to `v5` in `.github/workflows/pythonpackage.yml`
- `actions/checkout` from `v4` to `v6` in multiple workflows: `.github/workflows/newissue.yml`, `.github/workflows/codespell.yml`, `.github/workflows/codeql.yml`, `.github/workflows/readmechanged.yml`

The update ensures that the workflows use the latest stable versions of the actions, which include improved functionality, better performance, and enhanced security features.

**Link to an issue or discussion regarding these changes:** [Issue/Discussion Link]

---