### PR TITLE
Fix reset() visible parameter docstring

### DIFF
--- a/rich/progress.py
+++ b/rich/progress.py
@@ -1493,7 +1493,7 @@ class Progress(JupyterMixin):
             start (bool, optional): Start the task after reset. Defaults to True.
             total (float, optional): New total steps in task, or None to use current total. Defaults to None.
             completed (int, optional): Number of steps completed. Defaults to 0.
-            visible (bool, optional): Enable display of the task. Defaults to True.
+            visible (bool, optional): Set visibility of the task. If not provided, visibility is unchanged. Defaults to None.
             description (str, optional): Change task description if not None. Defaults to None.
             **fields (str): Additional data fields required for rendering.
         """


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description
This PR fixes a docstring inconsistency in `Progress.reset()` regarding the
`visible` parameter.

The docstring previously stated that `visible` defaults to `True`, but the
actual behavior preserves the existing visibility unless `visible` is
explicitly provided.

This change updates the documentation to reflect the current and intended
behavior without modifying runtime logic.

Fixes #3834