### PR TITLE
Fix table title justification when soft_wrap=True

### DIFF
--- a/rich/text.py
+++ b/rich/text.py
@@ -1231,9 +1231,6 @@ class Text(JupyterMixin):
             if "\t" in line:
                 line.expand_tabs(tab_size)
             if no_wrap:
-                if overflow == "ignore":
-                    lines.append(line)
-                    continue
                 new_lines = Lines([line])
             else:
                 offsets = divide_line(str(line), width, fold=wrap_overflow == "fold")
@@ -1244,9 +1241,13 @@ class Text(JupyterMixin):
                 new_lines.justify(
                     console, width, justify=wrap_justify, overflow=wrap_overflow
                 )
-            for line in new_lines:
-                line.truncate(width, overflow=wrap_overflow)
-            lines.extend(new_lines)
+            if overflow == "ignore":
+                # When overflow is ignored (soft_wrap), don't truncate
+                lines.extend(new_lines)
+            else:
+                for line in new_lines:
+                    line.truncate(width, overflow=wrap_overflow)
+                lines.extend(new_lines)
         return lines
 
     def fit(self, width: int) -> Lines:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -406,6 +406,29 @@ def test_padding_width():
     assert output == expected
 
 
+def test_title_justify_with_soft_wrap():
+    """Regression test for https://github.com/Textualize/rich/issues/3948
+    
+    Table title should be centered when soft_wrap=True.
+    """
+    table = Table(title="The Title", title_justify="center")
+    table.add_column("Column 1")
+    table.add_column("Column 2")
+    
+    console = Console(record=True, width=40, force_terminal=True)
+    console.print(table, soft_wrap=True)
+    output = console.export_text()
+    
+    lines = output.split("\n")
+    # The title line should be centered (not left-aligned)
+    title_line = lines[0]
+    # Check that "The Title" is centered by verifying leading whitespace
+    # A centered title in a 40-char wide console should have leading spaces
+    assert title_line.strip() == "The Title"
+    # The title should NOT start at position 0 (should be centered)
+    assert title_line.startswith(" ")
+
+
 if __name__ == "__main__":
     render = render_tables()
     print(render)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1010,6 +1010,20 @@ def test_wrap_invalid_style():
     console.print(a, justify="full")
 
 
+def test_wrap_justify_with_overflow_ignore():
+    """Regression test for https://github.com/Textualize/rich/issues/3948
+    
+    Text should still be justified when overflow=ignore (soft_wrap=True).
+    """
+    console = Console(width=40)
+    text = Text("Short text", justify="center")
+    lines = text.wrap(console, 40, overflow="ignore")
+    assert len(lines) == 1
+    # The text should be centered (padded with spaces)
+    line_str = str(lines[0])
+    assert line_str == "Short text".center(40)
+
+
 def test_apply_meta():
     text = Text("foobar")
     text.apply_meta({"foo": "bar"}, 1, 3)


### PR DESCRIPTION
## Summary

Fixes #3948

When `soft_wrap=True`, the console sets `overflow='ignore'`. The previous fix for #3937 (trailing whitespace) caused the `wrap()` method to skip justification entirely when `overflow='ignore'`, resulting in table titles being left-aligned instead of centered.

### Root Cause

PR #3937 added this early return:
```python
if overflow == "ignore":
    lines.append(line)
    continue
```

This bypassed all processing including `new_lines.justify()`, causing titles to not be centered.

### Fix

Restructured the `wrap()` method to:
1. Always create `new_lines` and apply justification
2. Only skip truncation when `overflow='ignore'` (not justification)

## Test Plan

Added two tests:
- `test_wrap_justify_with_overflow_ignore` in `test_text.py` - verifies text centering works with overflow=ignore
- `test_title_justify_with_soft_wrap` in `test_table.py` - verifies table title is centered when soft_wrap=True

### Before/After

Before (title left-aligned):
```
The Title                  
┏━━━━━━━━━━┳━━━━━━━━━━┓
┃ Column 1 ┃ Column 2 ┃
┗━━━━━━━━━━┻━━━━━━━━━━┛
```

After (title centered):
```
        The Title         
┏━━━━━━━━━━┳━━━━━━━━━━┓
┃ Column 1 ┃ Column 2 ┃
┗━━━━━━━━━━┻━━━━━━━━━━┛
```