### PR TITLE
Fix table title alignment when soft_wrap=True

### DIFF
--- a/rich/text.py
+++ b/rich/text.py
@@ -1231,9 +1231,6 @@ class Text(JupyterMixin):
             if "\t" in line:
                 line.expand_tabs(tab_size)
             if no_wrap:
-                if overflow == "ignore":
-                    lines.append(line)
-                    continue
                 new_lines = Lines([line])
             else:
                 offsets = divide_line(str(line), width, fold=wrap_overflow == "fold")

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -406,6 +406,58 @@ def test_padding_width():
     assert output == expected
 
 
+def test_soft_wrap_title_justify():
+    """Test that table title justification is preserved when soft_wrap=True.
+    Regression test for issue #3948.
+    """
+    console = Console(width=25, force_terminal=True, legacy_windows=False)
+
+    # Test center justify (default)
+    table_center = Table(title="The Title", title_justify="center")
+    table_center.add_column("Column 1")
+    table_center.add_column("Column 2")
+
+    # Test right justify
+    table_right = Table(title="The Title", title_justify="right")
+    table_right.add_column("Column 1")
+    table_right.add_column("Column 2")
+
+    # Test left justify
+    table_left = Table(title="The Title", title_justify="left")
+    table_left.add_column("Column 1")
+    table_left.add_column("Column 2")
+
+    # Render with soft_wrap=True
+    console_sw = Console(width=25, force_terminal=True, legacy_windows=False, record=True)
+    console_sw.print(table_center, soft_wrap=True)
+    output_center = console_sw.export_text()
+
+    console_sw = Console(width=25, force_terminal=True, legacy_windows=False, record=True)
+    console_sw.print(table_right, soft_wrap=True)
+    output_right = console_sw.export_text()
+
+    console_sw = Console(width=25, force_terminal=True, legacy_windows=False, record=True)
+    console_sw.print(table_left, soft_wrap=True)
+    output_left = console_sw.export_text()
+
+    # Check that center title is centered (has leading spaces)
+    title_line_center = output_center.split('\n')[0]
+    assert title_line_center.strip() == "The Title"
+    assert title_line_center.startswith(" "), "Center-justified title should have leading spaces"
+
+    # Check that right title is right-aligned (has more leading spaces)
+    title_line_right = output_right.split('\n')[0]
+    assert title_line_right.strip() == "The Title"
+    leading_spaces_right = len(title_line_right) - len(title_line_right.lstrip())
+    leading_spaces_center = len(title_line_center) - len(title_line_center.lstrip())
+    assert leading_spaces_right > leading_spaces_center, "Right-justified title should have more leading spaces than center"
+
+    # Check that left title has no leading spaces
+    title_line_left = output_left.split('\n')[0]
+    assert title_line_left.strip() == "The Title"
+    assert not title_line_left.startswith(" "), "Left-justified title should not have leading spaces"
+
+
 if __name__ == "__main__":
     render = render_tables()
     print(render)


### PR DESCRIPTION
## Summary

Fixes #3948

When `console.print()` is called with `soft_wrap=True`, it sets `overflow='ignore'` which was causing text justification to be skipped entirely. This resulted in table titles always appearing left-aligned regardless of the `title_justify` setting.

## Changes

- Modified `Text.wrap()` in `rich/text.py` to apply justification even when `overflow == "ignore"`
- Added test `test_soft_wrap_title_justify()` to verify the fix works for center, right, and left justification

## Test plan

- [x] Added regression test that verifies title justification is preserved with soft_wrap
- [x] All existing table tests pass
- [x] All existing text tests pass
- [x] Manual testing confirms titles are now properly justified with soft_wrap=True

## Before
```python
from rich.console import Console
from rich.table import Table

table = Table(title="The Title", title_justify="center")
table.add_column("Column 1")
table.add_column("Column 2")

Console().print(table, soft_wrap=True)
```

Output: Title was left-aligned

## After

Output: Title is properly centered

Generated with Claude Code