### PR TITLE
Fix console.print() with empty args to respect end parameter

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -1683,7 +1683,13 @@ class Console:
             new_line_start (bool, False): Insert a new line at the start if the output contains more than one line. Defaults to ``False``.
         """
         if not objects:
-            objects = (NewLine(),)
+            # When objects is empty, only print newline if end is "\n" (default)
+            # Otherwise, just print the end character (matching print() behavior)
+            if end == "\n":
+                objects = (NewLine(),)
+            else:
+                # Create empty object so that only the end character is printed
+                objects = (Text(""),)
 
         if soft_wrap is None:
             soft_wrap = self.soft_wrap

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1127,3 +1127,33 @@ def test_tty_compatible() -> None:
     assert not console.is_terminal
     # Should not have auto-detected
     assert not console.file.called_isatty
+
+
+def test_print_empty_with_end():
+    """Test that console.print() with empty args respects end parameter.
+    Regression test for issue #3701.
+    """
+    console = Console(file=io.StringIO(), legacy_windows=False)
+
+    # Test with custom end parameter
+    console.print(end="!")
+    output = console.file.getvalue()
+    assert output == "!", f"Expected '!' but got {output!r}"
+
+    # Test with empty end parameter
+    console = Console(file=io.StringIO(), legacy_windows=False)
+    console.print(end="")
+    output = console.file.getvalue()
+    assert output == "", f"Expected empty string but got {output!r}"
+
+    # Test with default end parameter (newline)
+    console = Console(file=io.StringIO(), legacy_windows=False)
+    console.print()
+    output = console.file.getvalue()
+    assert output == "\n", f"Expected newline but got {output!r}"
+
+    # Test with content and custom end
+    console = Console(file=io.StringIO(), legacy_windows=False)
+    console.print("test", end="!")
+    output = console.file.getvalue()
+    assert output == "test!", f"Expected 'test!' but got {output!r}"


### PR DESCRIPTION
## Summary

Fixes #3701

When `console.print()` was called with no arguments but a custom `end` parameter, it would print a newline instead of the end character. This was because empty objects were always replaced with `NewLine()` regardless of the `end` parameter.

## Changes

- Modified `Console.print()` in `rich/console.py` to only use `NewLine()` when `end` is the default `"\n"`
- When `end` is a custom value, use an empty `Text` object that will properly render with the custom end character
- Added test `test_print_empty_with_end()` to verify the fix

## Test plan

- [x] Added regression test that verifies end parameter works with empty args
- [x] All existing console print tests pass
- [x] Manual testing confirms behavior matches regular `print()`

## Before
```python
from rich.console import Console
console = Console()

print(end="!")  # Prints: !
console.print(end="!")  # Prints: \n (newline)
```

## After
```python
from rich.console import Console
console = Console()

print(end="!")  # Prints: !
console.print(end="!")  # Prints: ! (correctly)
```