### PR TITLE
Fix infinite loop when ANSI escape sequences appear at string start

### DIFF
--- a/rich/cells.py
+++ b/rich/cells.py
@@ -207,6 +207,10 @@ def split_graphemes(
             # zero width characters are associated with the previous character
             start, _end, cell_length = spans[-1]
             spans[-1] = (start, index := index + 1, cell_length)
+        else:
+            # zero width character at start of text with no previous character to associate with
+            # skip it to avoid infinite loop
+            index += 1
 
     return (spans, total_width)
 

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -204,3 +204,26 @@ def test_non_printable():
     for ordinal in range(31):
         character = chr(ordinal)
         assert cell_len(character) == 0
+
+
+def test_ansi_at_start():
+    """Test that ANSI escape sequences at start of string don't cause infinite loop.
+    Regression test for issue #3958.
+    """
+    from rich.cells import split_graphemes
+
+    # ANSI escape sequences have zero width and should not cause infinite loop
+    # when they appear at the start of a string
+    text = '\x1b[38;5;249mi\x1b[0m\x1b[38;5;249mf\x1b[0m'
+    spans, total_width = split_graphemes(text)
+
+    # Should complete without hanging (previously caused infinite loop)
+    assert total_width >= 0
+    assert isinstance(spans, list)
+
+    # Test another case with ANSI at start
+    text2 = '\x1b[0mtest'
+    spans2, total_width2 = split_graphemes(text2)
+    # Should complete without hanging
+    assert total_width2 > 0
+    assert isinstance(spans2, list)


### PR DESCRIPTION
## Summary

Fixes #3958

When strings with ANSI escape sequences at the start were printed using `console.print()`, the program would hang in an infinite loop. This was a critical bug introduced in version 14.3.2.

## Root Cause

The issue was in `split_graphemes()` in `rich/cells.py`:

1. ANSI escape characters (`\x1b`) have zero cell width
2. Zero-width characters are normally associated with the previous character
3. When no previous character exists (at string start), the index wasn't incremented
4. This caused an infinite loop in the while loop at line 182

## Changes

- Added an else clause to handle zero-width characters when `spans` is empty
- When there's no previous character to associate with, skip the zero-width character
- Added test `test_ansi_at_start()` to verify the fix

## Test plan

- [x] Added regression test that verifies no infinite loop occurs
- [x] All existing cell tests pass
- [x] Manual testing with the exact strings from the issue report confirms they now print without hanging

## Before
```python
from rich.console import Console

Console().print('\x1b[38;5;249mi\x1b[0m')  # Hangs forever
```

## After
```python
from rich.console import Console

Console().print('\x1b[38;5;249mi\x1b[0m')  # Prints successfully
```