### PR TITLE
Fix __notes__ from outermost exception shown on all exceptions in chain

### DIFF
--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -467,8 +467,6 @@ class Traceback:
 
         from rich import _IMPORT_CWD
 
-        notes: List[str] = getattr(exc_value, "__notes__", None) or []
-
         grouped_exceptions: Set[BaseException] = (
             set() if _visited_exceptions is None else _visited_exceptions
         )
@@ -481,6 +479,7 @@ class Traceback:
                 return "<exception str() failed>"
 
         while True:
+            notes: List[str] = getattr(exc_value, "__notes__", None) or []
             stack = Stack(
                 exc_type=safe_str(exc_type.__name__),
                 exc_value=safe_str(exc_value),


### PR DESCRIPTION
## Summary

- **Fixes #3960** -- `Traceback.__notes__` from the outermost exception was incorrectly displayed on every exception in a chained traceback.
- Moved the `notes` assignment (`getattr(exc_value, "__notes__", ...)`) from before the `while True` loop to inside it, so each `Stack` reads notes from its own `exc_value` rather than reusing the same list for all.
- Added two regression tests: one verifying notes only appear on the exception that has them, and another verifying each exception in a chain gets its own distinct notes.

## Root Cause

In `Traceback.extract()`, the `notes` list was read once from the initial `exc_value` before the loop that walks `__cause__`/`__context__`. Since the same `notes` reference was passed to every `Stack`, all exceptions in the chain incorrectly displayed the outermost exception's notes.

## Test plan

- [x] Verified with the exact reproduction script from the issue -- note now only appears on `RuntimeError`, not `ValueError`
- [x] Added `test_notes_chained_exceptions` -- notes on outer only, inner has none
- [x] Added `test_notes_on_each_chained_exception` -- each exception has its own distinct notes
- [x] All 24 existing traceback tests pass (1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)