### PR TITLE
Include LICENSE file in wheel metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
-include = ["rich/py.typed"]
+include = ["rich/py.typed", "LICENSE"]
 
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Adds `LICENSE` to the `include` list in `pyproject.toml` so the license file is included in wheel distributions.

Fixes #3965