### PR TITLE
docs(contributing): remove another reference to poetry shell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,6 @@ poetry install
 ```
 
 The rest of this guide assumes you're inside the virtual environment.
-If you're having difficulty running any of the commands that follow,
-ensure you're inside the virtual environment by running `poetry shell`.
 
 ## Developing
 


### PR DESCRIPTION
The shell command was removed in Poetry 2.0 back in January 2025.

When `CONTRIBUTING.md` was updated recently to reflect this change, it looks like another reference to `poetry shell` was missed.

Closes #3634
Closes #3817

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.