### PR TITLE
Fix _split_cells for non-unit cell widths

### DIFF
--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -344,6 +344,26 @@ def test_split_cells_single() -> None:
         assert cell_len(right.text) == test.cell_length - position
 
 
+def test_split_cells_non_unit_width() -> None:
+    """Check that split cells handles non-unit cell widths correctly.
+
+    Regression test for https://github.com/Textualize/rich/issues/3299
+    """
+    # Wide chars followed by zero-width chars
+    segment = Segment("\U0001f98a\U0001f98a\U0001f98a\n\n\n\n\n\n")
+    for position in range(0, segment.cell_length + 1):
+        left, right = Segment._split_cells(segment, position)
+        assert cell_len(left.text) == position
+        assert cell_len(right.text) == segment.cell_length - position
+
+    # Wide chars followed by single-width chars
+    segment = Segment("\U0001f98a\U0001f98a\U0001f98aabcdef")
+    for position in range(0, segment.cell_length + 1):
+        left, right = Segment._split_cells(segment, position)
+        assert cell_len(left.text) == position
+        assert cell_len(right.text) == segment.cell_length - position
+
+
 def test_segment_lines_renderable():
     lines = [[Segment("hello"), Segment(" "), Segment("world")], [Segment("foo")]]
     segment_lines = SegmentLines(lines)


### PR DESCRIPTION
## Summary

Fixes #3299.

`Segment._split_cells` used a heuristic to estimate the character index for a given cell position, then adjusted incrementally with `+1`/`-1` steps. This approach didn't handle strings with mixed character widths well — particularly when double-width characters (emoji, CJK) were combined with zero-width or single-width characters, the initial estimate could be far off and the adjustment logic could produce incorrect splits.

This replaces the heuristic search with a straightforward linear scan that walks through the text accumulating cell widths until the cut point is reached. The new approach:

- Always finds the correct split point regardless of character width distribution
- Correctly handles zero-width, single-width, and double-width characters in any combination
- Still replaces double-width characters that straddle the cut point with two spaces (preserving display width)

## Test plan

- Added regression test `test_split_cells_non_unit_width` covering the exact examples from the issue (wide chars + zero-width chars, wide chars + single-width chars)
- All existing split_cells tests continue to pass (62 tests total)