### PR TITLE
Fix Panel crash when box=None

### DIFF
--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -16,6 +16,9 @@ tests = [
     Panel(Panel("Hello, World", padding=0), padding=0),
     Panel("Hello, World", title="FOO", padding=0),
     Panel("Hello, World", subtitle="FOO", padding=0),
+    Panel("Hello, World", box=None, padding=0),
+    Panel("Hello, World", box=None, expand=False, padding=0),
+    Panel.fit("Hello, World", box=None, padding=0),
 ]
 
 expected = [
@@ -26,6 +29,9 @@ expected = [
     "╭────────────────────────────────────────────────╮\n│╭──────────────────────────────────────────────╮│\n││Hello, World                                  ││\n│╰──────────────────────────────────────────────╯│\n╰────────────────────────────────────────────────╯\n",
     "╭───────────────────── FOO ──────────────────────╮\n│Hello, World                                    │\n╰────────────────────────────────────────────────╯\n",
     "╭────────────────────────────────────────────────╮\n│Hello, World                                    │\n╰───────────────────── FOO ──────────────────────╯\n",
+    "Hello, World                                      \n\n",
+    "Hello, World\n\n",
+    "Hello, World\n\n",
 ]
 
 


### PR DESCRIPTION
Panel.__init__ accepts box as Optional[Box] but passing None causes an AttributeError in __rich_console__ because it calls self.box.substitute() without checking for None first.

This handles box=None throughout the rendering and measurement paths, similar to how Table already supports box=None. When box is None the panel content renders without any border.

Fixes #3609