### PR TITLE
Fix exception notes duplicated across chained exceptions

### DIFF
--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -467,8 +467,6 @@ class Traceback:
 
         from rich import _IMPORT_CWD
 
-        notes: List[str] = getattr(exc_value, "__notes__", None) or []
-
         grouped_exceptions: Set[BaseException] = (
             set() if _visited_exceptions is None else _visited_exceptions
         )
@@ -481,6 +479,7 @@ class Traceback:
                 return "<exception str() failed>"
 
         while True:
+            notes: List[str] = getattr(exc_value, "__notes__", None) or []
             stack = Stack(
                 exc_type=safe_str(exc_type.__name__),
                 exc_value=safe_str(exc_value),


### PR DESCRIPTION
## Summary

Fixes #3960.

When displaying chained exceptions where only the outermost exception has `__notes__` (PEP 678), Rich incorrectly shows those notes on **every** exception in the chain. This is because `notes` is read once before the extraction loop and the same list is reused for all `Stack` objects.

## Changes

Moved the `notes = getattr(exc_value, "__notes__", ...)` assignment from before the `while True` loop to inside it, so each exception in the chain reads its own `__notes__`.

## Before (bug)

```
ValueError: original error
[NOTE] This note was added to RuntimeError only    ← wrong

The above exception was the direct cause of the following exception:

RuntimeError: wrapped error
[NOTE] This note was added to RuntimeError only    ← correct
```

## After (fix)

```
ValueError: original error

The above exception was the direct cause of the following exception:

RuntimeError: wrapped error
[NOTE] This note was added to RuntimeError only    ← only here
```