### PR TITLE
Fix infinite loop in split_graphemes with zero-width leading characters

### DIFF
--- a/rich/cells.py
+++ b/rich/cells.py
@@ -197,6 +197,9 @@ def split_graphemes(
                         cell_length += 1
                         total_width += 1
                     spans[-1] = (start, index, cell_length)
+            else:
+                # variation selector with no preceding character, skip
+                index += 1
             continue
 
         if character_width := get_character_cell_size(character, unicode_version):
@@ -207,6 +210,9 @@ def split_graphemes(
             # zero width characters are associated with the previous character
             start, _end, cell_length = spans[-1]
             spans[-1] = (start, index := index + 1, cell_length)
+        else:
+            # zero width character with no preceding span, just skip it
+            index += 1
 
     return (spans, total_width)
 

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -204,3 +204,19 @@ def test_non_printable():
     for ordinal in range(31):
         character = chr(ordinal)
         assert cell_len(character) == 0
+
+
+def test_split_graphemes_ansi_escape():
+    """Regression test for https://github.com/Textualize/rich/issues/3958
+
+    ANSI escape characters (\\x1b) have cell width 0 and caused an infinite
+    loop in split_graphemes when they appeared before any measured character.
+    """
+    spans, cell_length = split_graphemes("\x1bHello")
+    assert cell_length == 5
+
+    spans, cell_length = split_graphemes("\x1b")
+    assert cell_length == 0
+
+    spans, cell_length = split_graphemes("\x1b[31mHello\x1b[0m")
+    assert cell_length > 0


### PR DESCRIPTION
## Summary

Fixes #3958.

When `split_graphemes()` encounters a character with cell width 0 (such as ANSI escape `\x1b`, codepoint 27) before any measured character has been seen, the `index` is never advanced, causing an infinite loop. This is a regression in 14.3.2 where `get_character_cell_size()` correctly started returning 0 for control characters, but `split_graphemes()` didn't handle the case where `spans` is empty.

## Root cause

In `split_graphemes()`, when `get_character_cell_size()` returns 0 (falsy):
- If `spans` is non-empty, the zero-width character is attached to the previous span and `index` advances
- If `spans` is empty, neither branch executes and `index` stays the same → infinite loop

A similar issue exists in the SPECIAL character handling: if a variation selector `\ufe0f` appears with no preceding measured character, the `continue` fires without advancing `index`.

## Changes

Added `else` branches in both locations to advance `index` when there's no preceding span to attach to. All 57 existing cells tests pass.