### PR TITLE
Clear console buffer on UnicodeEncodeError to prevent crash during cleanup

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -2104,6 +2104,7 @@ class Console:
                                         batch.clear()
                             except UnicodeEncodeError as error:
                                 error.reason = f"{error.reason}\n*** You may need to add PYTHONIOENCODING=utf-8 to your environment ***"
+                                del self._buffer[:]
                                 raise
                     else:
                         text = self._render_buffer(self._buffer[:])
@@ -2111,6 +2112,7 @@ class Console:
                             self.file.write(text)
                         except UnicodeEncodeError as error:
                             error.reason = f"{error.reason}\n*** You may need to add PYTHONIOENCODING=utf-8 to your environment ***"
+                            del self._buffer[:]
                             raise
 
                     self.file.flush()


### PR DESCRIPTION
## Summary

Fixes #3907.

When a `UnicodeEncodeError` occurs writing the console buffer (e.g., UTF-8 content on a cp1252 stream), the buffer retains the unencodable content. This causes a second **unhandled** `UnicodeEncodeError` during context manager cleanup (e.g., `Progress.__exit__()` -> `Console.__exit__()` -> `_write_buffer()`), violating the context manager contract.

## Changes

Added `del self._buffer[:]` in both `except UnicodeEncodeError` handlers in `_write_buffer()` before re-raising the error. This ensures the unencodable content is cleared so subsequent buffer writes (like during cleanup) don't re-encounter the same content.

## Before (bug)

```python
with Progress(console=console) as progress:
    try:
        file_proxy.write("Hello 🌍")  # UnicodeEncodeError (caught)
    except UnicodeEncodeError:
        pass  # handled
# Progress.__exit__() -> second UnicodeEncodeError (UNHANDLED crash)
```

## After (fix)

```python
with Progress(console=console) as progress:
    try:
        file_proxy.write("Hello 🌍")  # UnicodeEncodeError (caught)
    except UnicodeEncodeError:
        pass  # handled
# Progress.__exit__() completes gracefully
```