### PR TITLE
Fix table title not justified when soft_wrap is True

### DIFF
--- a/rich/text.py
+++ b/rich/text.py
@@ -1231,9 +1231,6 @@ class Text(JupyterMixin):
             if "\t" in line:
                 line.expand_tabs(tab_size)
             if no_wrap:
-                if overflow == "ignore":
-                    lines.append(line)
-                    continue
                 new_lines = Lines([line])
             else:
                 offsets = divide_line(str(line), width, fold=wrap_overflow == "fold")

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -406,6 +406,32 @@ def test_padding_width():
     assert output == expected
 
 
+def test_table_title_justify_soft_wrap():
+    """Regression test for https://github.com/Textualize/rich/issues/3948
+
+    Table title should respect title_justify when printed with soft_wrap=True.
+    """
+    table = Table(title="The Title", title_justify="center")
+    table.add_column("Column 1")
+    table.add_column("Column 2")
+
+    # Without soft_wrap
+    f1 = io.StringIO()
+    Console(file=f1, width=60, force_terminal=True, color_system=None).print(table)
+    normal_title = f1.getvalue().splitlines()[0]
+
+    # With soft_wrap
+    f2 = io.StringIO()
+    Console(file=f2, width=60, force_terminal=True, color_system=None).print(
+        table, soft_wrap=True
+    )
+    soft_wrap_title = f2.getvalue().splitlines()[0]
+
+    # Both should have centered title (leading spaces)
+    assert normal_title == soft_wrap_title
+    assert normal_title.startswith(" ")
+
+
 if __name__ == "__main__":
     render = render_tables()
     print(render)


### PR DESCRIPTION
## Summary

Fixes #3948.

Since Rich 14.3.0, table titles always appear left-aligned when printed with `soft_wrap=True`, regardless of `title_justify`.

## Root cause

In `Text.wrap()`, when both `no_wrap=True` and `overflow="ignore"` (both set by `soft_wrap=True`), lines were appended directly and the justification step was skipped entirely via an early `continue`.

## Changes

Removed the early `continue` branch so that text justification runs even when `no_wrap=True` and `overflow="ignore"`. The `truncate()` and `justify()` methods already handle `overflow="ignore"` correctly (they're no-ops for truncation), so the only behavioral change is that justification padding is now applied.

## Before / After

```python
table = Table(title="The Title", title_justify="center")
table.add_column("Column 1")
table.add_column("Column 2")
console.print(table, soft_wrap=True)
```

Before: `The Title` (left-aligned)
After: `       The Title       ` (centered)