### PR TITLE
Fix RichHandler ignoring %z timezone format specifier

### DIFF
--- a/rich/logging.py
+++ b/rich/logging.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from logging import Handler, LogRecord
 from pathlib import Path
 from types import ModuleType
@@ -224,7 +224,7 @@ class RichHandler(Handler):
         path = Path(record.pathname).name
         level = self.get_level_text(record)
         time_format = None if self.formatter is None else self.formatter.datefmt
-        log_time = datetime.fromtimestamp(record.created)
+        log_time = datetime.fromtimestamp(record.created, tz=timezone.utc).astimezone()
 
         log_renderable = self._log_render(
             self.console,


### PR DESCRIPTION
## Summary

Fixes #3877.

`RichHandler` uses `datetime.fromtimestamp(record.created)` which creates a **naive** datetime. When `log_time_format` includes `%z`, `strftime` produces an empty string instead of the timezone offset.

## Changes

Changed to `datetime.fromtimestamp(record.created, tz=timezone.utc).astimezone()` which creates a timezone-aware datetime in the local timezone, making `%z` (and `%Z`) work correctly.

## Before / After

With `log_time_format="%Y-%m-%dT%H:%M:%S%z"`:

Before: `2026-02-17T18:32:26` (no timezone)
After: `2026-02-17T18:32:26+0000` (timezone present)