### PR TITLE
Fix console.print() with empty args ignoring end parameter

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -1683,7 +1683,7 @@ class Console:
             new_line_start (bool, False): Insert a new line at the start if the output contains more than one line. Defaults to ``False``.
         """
         if not objects:
-            objects = (NewLine(),)
+            objects = ("",)
 
         if soft_wrap is None:
             soft_wrap = self.soft_wrap

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1127,3 +1127,24 @@ def test_tty_compatible() -> None:
     assert not console.is_terminal
     # Should not have auto-detected
     assert not console.file.called_isatty
+
+
+def test_print_empty_with_end():
+    """Regression test for https://github.com/Textualize/rich/issues/3701
+
+    console.print(end="!") should output "!" like Python's print(end="!").
+    """
+    # print(end="!") should output just "!"
+    file = io.StringIO()
+    Console(file=file, color_system=None).print(end="!")
+    assert file.getvalue() == "!"
+
+    # print() should output just "\n"
+    file = io.StringIO()
+    Console(file=file, color_system=None).print()
+    assert file.getvalue() == "\n"
+
+    # print(end="") should output nothing
+    file = io.StringIO()
+    Console(file=file, color_system=None).print(end="")
+    assert file.getvalue() == ""


### PR DESCRIPTION
## Summary

Fixes #3701.

When `console.print()` is called with no positional arguments, it replaces `objects` with `(NewLine(),)`. This means the `end` parameter is ignored:

```python
# Expected: outputs "!" (like Python's built-in print(end="!"))
# Actual: outputs "\n"
console.print(end="!")
```

The fix changes the empty-args fallback from `(NewLine(),)` to `("",)` so that `end` is properly appended through `_collect_renderables`.

### Before
```python
if not objects:
    objects = (NewLine(),)
```

### After
```python
if not objects:
    objects = ("",)
```

## Test plan
- Added `test_print_empty_with_end` covering:
  - `print(end="!")` → outputs `"!"`
  - `print()` → outputs `"\n"` (default behavior preserved)
  - `print(end="")` → outputs `""` (suppressed newline)
- Verified test fails without fix, passes with fix
- All existing console tests pass (99 tests)