### PR TITLE
Fix Console.input() ignoring end attribute of Text prompt

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -2164,7 +2164,13 @@ class Console:
             str: Text read from stdin.
         """
         if prompt:
-            self.print(prompt, markup=markup, emoji=emoji, end="")
+            prompt_end = getattr(prompt, "end", "\n")
+            self.print(
+                prompt,
+                markup=markup,
+                emoji=emoji,
+                end="" if prompt_end == "\n" else prompt_end,
+            )
         if password:
             result = getpass("", stream=stream)
         else:

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -409,6 +409,39 @@ def test_input_password(monkeypatch, capsys) -> None:
     assert user_input == "bar"
 
 
+def test_input_prompt_end(monkeypatch, capsys) -> None:
+    """Regression test for https://github.com/Textualize/rich/issues/3643
+
+    Console.input() should respect the end attribute of a Text prompt.
+    """
+
+    def fake_input(prompt=""):
+        console.file.write(prompt)
+        return "bar"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    console = Console()
+
+    # String prompt: end="" (default behavior, cursor stays on same line)
+    user_input = console.input(prompt="foo:")
+    assert capsys.readouterr().out == "foo:"
+    assert user_input == "bar"
+
+    # Text prompt with custom end: should use that end value
+    from rich.text import Text
+
+    prompt_text = Text("enter value", end=": ")
+    user_input = console.input(prompt=prompt_text)
+    assert capsys.readouterr().out == "enter value: "
+    assert user_input == "bar"
+
+    # Text prompt with default end ("\n"): should use "" to keep cursor on same line
+    prompt_text_default = Text("enter value")
+    user_input = console.input(prompt=prompt_text_default)
+    assert capsys.readouterr().out == "enter value"
+    assert user_input == "bar"
+
+
 def test_status() -> None:
     console = Console(file=io.StringIO(), force_terminal=True, width=20)
     status = console.status("foo")


### PR DESCRIPTION
## Summary

Fixes #3643.

`Console.input()` hardcodes `end=""` when printing the prompt, ignoring any custom `end` attribute set on a `Text` object:

```python
# Current behavior: "enter value" (end=": " is ignored)
# Expected behavior: "enter value: "
prompt = Text("enter value", end=": ")
console.input(prompt=prompt)
```

The fix reads the prompt's `end` attribute via `getattr`. If `end` is the default `"\n"`, it uses `""` (preserving existing behavior — cursor stays on the prompt line). If `end` has been explicitly changed, that value is used.

### Before
```python
self.print(prompt, markup=markup, emoji=emoji, end="")
```

### After
```python
prompt_end = getattr(prompt, "end", "\n")
self.print(
    prompt,
    markup=markup,
    emoji=emoji,
    end="" if prompt_end == "\n" else prompt_end,
)
```

## Test plan
- Added `test_input_prompt_end` covering:
  - String prompt: `end=""` (unchanged default behavior)
  - Text prompt with custom `end=": "`: uses custom end value
  - Text prompt with default `end="\n"`: uses `""` (cursor stays on prompt line)
- Verified test fails without fix, passes with fix
- Existing `test_input` and `test_input_password` still pass