### PR TITLE
Disable html_inline in Markdown to prevent text swallowing

### DIFF
--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -555,7 +555,12 @@ class Markdown(JupyterMixin):
         inline_code_lexer: str | None = None,
         inline_code_theme: str | None = None,
     ) -> None:
-        parser = MarkdownIt().enable("strikethrough").enable("table")
+        parser = (
+            MarkdownIt()
+            .enable("strikethrough")
+            .enable("table")
+            .disable("html_inline")
+        )
         self.markup = markup
         self.parsed = parser.parse(markup)
         self.code_theme = code_theme

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -199,6 +199,17 @@ def test_table_with_empty_cells() -> None:
     assert result == expected
 
 
+def test_angle_brackets_not_swallowed():
+    """Regression test for https://github.com/Textualize/rich/issues/3565
+
+    Text that looks like HTML tags (e.g. 0<foo or foo>10) should not be
+    silently dropped.
+    """
+    md = Markdown("Do something if 0<foo or foo>10")
+    output = render(md)
+    assert "0<foo or foo>10" in output
+
+
 if __name__ == "__main__":
     markdown = Markdown(MARKDOWN)
     rendered = render(markdown)


### PR DESCRIPTION
## Summary

Fixes #3565.

Rich's Markdown renderer silently drops text that looks like HTML tags. For example:

```python
>>> from rich.console import Console
>>> from rich.markdown import Markdown
>>> Console().print(Markdown("Do something if 0<foo or foo>10"))
Do something if 010
```

The `<foo or foo>` is parsed as an `html_inline` token by markdown-it, but Rich has no handler for inline HTML — the token is simply discarded.

The fix disables the `html_inline` rule in the MarkdownIt parser, since Rich does not render inline HTML. This was also suggested by the issue reporter.

### Before
```python
parser = MarkdownIt().enable("strikethrough").enable("table")
```

### After
```python
parser = (
    MarkdownIt()
    .enable("strikethrough")
    .enable("table")
    .disable("html_inline")
)
```

## Test plan
- Added `test_angle_brackets_not_swallowed` verifying `"0<foo or foo>10"` is preserved in output
- Verified test fails without fix (text swallowed), passes with fix
- All existing markdown tests pass (1 pre-existing failure in `test_inline_code` due to pygments version difference, unrelated)