### PR TITLE
Fix elapsed time stuck after stop_task() and reset()

### DIFF
--- a/rich/progress.py
+++ b/rich/progress.py
@@ -1054,6 +1054,7 @@ class Task:
     def _reset(self) -> None:
         """Reset progress."""
         self._progress.clear()
+        self.stop_time = None
         self.finished_time = None
         self.finished_speed = None
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -487,6 +487,35 @@ def test_reset() -> None:
     assert not task._progress
 
 
+def test_reset_after_stop() -> None:
+    """Regression test for https://github.com/Textualize/rich/issues/3705
+
+    Elapsed time should resume from zero after reset() on a stopped task.
+    """
+    elapsed_time = 0.0
+
+    def get_time() -> float:
+        return elapsed_time
+
+    progress = Progress(get_time=get_time)
+    task_id = progress.add_task("test", total=100)
+    task = progress.tasks[task_id]
+
+    # Advance and stop the task
+    elapsed_time = 5.0
+    progress.advance(task_id, 50)
+    progress.stop_task(task_id)
+    assert task.elapsed == 5.0  # stopped at 5 seconds
+
+    # Reset and restart
+    elapsed_time = 10.0
+    progress.reset(task_id, start=True)
+
+    # Elapsed should reflect time since reset, not since original start
+    elapsed_time = 12.0
+    assert task.elapsed == 2.0  # 12.0 - 10.0 = 2.0 since reset
+
+
 def test_progress_max_refresh() -> None:
     """Test max_refresh argument."""
     time = 0.0


### PR DESCRIPTION
## Summary

Fixes #3705.

When a task is stopped with `stop_task()` and then restarted with `reset(start=True)`, the `TimeElapsedColumn` shows a frozen (or negative) elapsed time instead of counting from zero.

**Root cause:** `Task._reset()` clears `_progress`, `finished_time`, and `finished_speed`, but does not clear `stop_time`. After `reset()`, the task has a fresh `start_time` but the stale `stop_time` from before the reset. The `elapsed` property returns `stop_time - start_time`, which is negative when `stop_time < start_time`.

**Fix:** Added `self.stop_time = None` to `Task._reset()`.

## Test plan
- Added `test_reset_after_stop` using a mock time function to verify:
  - Task stopped at t=5.0 has elapsed=5.0
  - After reset at t=10.0, elapsed at t=12.0 is 2.0 (not -5.0)
- Verified test fails without fix (elapsed=-5.0), passes with fix
- Existing `test_reset` still passes