### PR TITLE
Fix Text.from_ansi() stripping trailing newlines

### DIFF
--- a/rich/text.py
+++ b/rich/text.py
@@ -326,6 +326,8 @@ class Text(JupyterMixin):
         )
         decoder = AnsiDecoder()
         result = joiner.join(line for line in decoder.decode(text))
+        if text.endswith("\n"):
+            result.append("\n")
         return result
 
     @classmethod

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -45,7 +45,7 @@ def test_decode_example():
         console.print(text)
     result = capture.get()
     print(repr(result))
-    expected = "\x1b[1mC:\\Users\\stefa\\AppData\\Local\\Temp\\tmp3ydingba:\x1b[0m In function '\x1b[1mmain\x1b[0m':\n\x1b[1mC:\\Users\\stefa\\AppData\\Local\\Temp\\tmp3ydingba:3:5:\x1b[0m \x1b[1;35mwarning: \x1b[0munused variable '\x1b[1ma\x1b[0m' \n[\x1b[1;35m-Wunused-variable\x1b[0m]\n    3 | int \x1b[1;35ma\x1b[0m=1;\n      |     \x1b[1;35m^\x1b[0m\n"
+    expected = "\x1b[1mC:\\Users\\stefa\\AppData\\Local\\Temp\\tmp3ydingba:\x1b[0m In function '\x1b[1mmain\x1b[0m':\n\x1b[1mC:\\Users\\stefa\\AppData\\Local\\Temp\\tmp3ydingba:3:5:\x1b[0m \x1b[1;35mwarning: \x1b[0munused variable '\x1b[1ma\x1b[0m' \n[\x1b[1;35m-Wunused-variable\x1b[0m]\n    3 | int \x1b[1;35ma\x1b[0m=1;\n      |     \x1b[1;35m^\x1b[0m\n\n"
     assert result == expected
 
 
@@ -55,7 +55,7 @@ def test_decode_example():
         # https://github.com/Textualize/rich/issues/2688
         (
             b"\x1b[31mFound 4 errors in 2 files (checked 18 source files)\x1b(B\x1b[m\n",
-            "Found 4 errors in 2 files (checked 18 source files)",
+            "Found 4 errors in 2 files (checked 18 source files)\n",
         ),
         # https://mail.python.org/pipermail/python-list/2007-December/424756.html
         (b"Hallo", "Hallo"),
@@ -68,6 +68,18 @@ def test_decode_issue_2688(ansi_bytes, expected_text):
     text = Text.from_ansi(ansi_bytes.decode())
 
     assert str(text) == expected_text
+
+
+def test_from_ansi_trailing_newline():
+    """Regression test for https://github.com/Textualize/rich/issues/3577
+
+    Text.from_ansi() should preserve trailing newlines.
+    """
+    assert Text.from_ansi("text").plain == "text"
+    assert Text.from_ansi("text\n").plain == "text\n"
+    assert Text.from_ansi("text\n\n").plain == "text\n\n"
+    assert Text.from_ansi("\n").plain == "\n"
+    assert Text.from_ansi("").plain == ""
 
 
 @pytest.mark.parametrize("code", [*"0123456789:;<=>?"])


### PR DESCRIPTION
## Summary

Fixes #3577.

`Text.from_ansi()` strips trailing newlines because `AnsiDecoder.decode()` uses `str.splitlines()`, which does not preserve a trailing newline:

```python
>>> "text\n".splitlines()
['text']  # trailing newline lost
```

The fix appends `"\n"` to the result in `from_ansi()` when the input ends with `"\n"`, making it consistent with `Text()`:

```python
# Before: trailing newline lost
Text.from_ansi("text\n").plain == "text"

# After: trailing newline preserved
Text.from_ansi("text\n").plain == "text\n"
```

## Test plan
- Added `test_from_ansi_trailing_newline` covering:
  - `"text"` → `"text"` (no newline, unchanged)
  - `"text\n"` → `"text\n"` (single trailing newline preserved)
  - `"text\n\n"` → `"text\n\n"` (double trailing newline preserved)
  - `"\n"` → `"\n"` (newline-only input)
  - `""` → `""` (empty input)
- Updated `test_decode_example` and `test_decode_issue_2688` to expect preserved newlines
- Verified regression test fails without fix, passes with fix
- All 24 ANSI tests pass