### PR TITLE
Handle dead weakref.proxy objects in rich_cast

### DIFF
--- a/rich/protocol.py
+++ b/rich/protocol.py
@@ -28,15 +28,19 @@ def rich_cast(renderable: object) -> "RenderableType":
     from rich.console import RenderableType
 
     rich_visited_set: Set[type] = set()  # Prevent potential infinite loop
-    while hasattr(renderable, "__rich__") and not isclass(renderable):
-        # Detect object which claim to have all the attributes
-        if hasattr(renderable, _GIBBERISH):
-            return repr(renderable)
-        cast_method = getattr(renderable, "__rich__")
-        renderable = cast_method()
-        renderable_type = type(renderable)
-        if renderable_type in rich_visited_set:
-            break
-        rich_visited_set.add(renderable_type)
+    try:
+        while hasattr(renderable, "__rich__") and not isclass(renderable):
+            # Detect object which claim to have all the attributes
+            if hasattr(renderable, _GIBBERISH):
+                return repr(renderable)
+            cast_method = getattr(renderable, "__rich__")
+            renderable = cast_method()
+            renderable_type = type(renderable)
+            if renderable_type in rich_visited_set:
+                break
+            rich_visited_set.add(renderable_type)
+    except ReferenceError:
+        # Dead weakref.proxy objects raise ReferenceError on attribute access
+        return repr(renderable)
 
     return cast(RenderableType, renderable)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,4 +1,5 @@
 import io
+import weakref
 
 from rich.abc import RichRenderable
 from rich.console import Console
@@ -82,3 +83,20 @@ def test_cast_recursive():
     console = Console(file=io.StringIO())
     console.print(A())
     assert console.file.getvalue() == "<B>\n"
+
+
+def test_rich_cast_dead_weakref_proxy():
+    """Regression test for https://github.com/Textualize/rich/issues/3656
+
+    Dead weakref.proxy objects should render via repr() instead of raising.
+    """
+
+    class Obj:
+        pass
+
+    proxy = weakref.proxy(Obj())  # referent is immediately GC'd
+
+    console = Console(file=io.StringIO(), color_system=None)
+    console.print(proxy)
+    output = console.file.getvalue()
+    assert "weakproxy" in output


### PR DESCRIPTION
## Summary

Fixes #3656.

`console.print()` crashes with `ReferenceError` when given a dead `weakref.proxy` object, because `hasattr()` on a dead proxy raises `ReferenceError` instead of returning `False`:

```python
import weakref
from rich import print

class Foo: pass
print(weakref.proxy(Foo()))  # ReferenceError!
```

The fix wraps the attribute inspection loop in `rich_cast()` with a `try/except ReferenceError` that falls back to `repr()`, which handles dead proxies gracefully:

```python
>>> repr(weakref.proxy(Foo()))
'<weakproxy at 0x... to NoneType at 0x...>'
```

## Test plan
- Added `test_rich_cast_dead_weakref_proxy` — creates a proxy to a GC'd object and prints it
- Verified test fails without fix (ReferenceError), passes with fix
- All existing protocol tests pass (7 tests)