### PR TITLE
Fix NO-BREAK SPACE (U+00A0) treated as word break in wrapping

### DIFF
--- a/rich/_wrap.py
+++ b/rich/_wrap.py
@@ -6,7 +6,7 @@ from typing import Iterable
 from ._loop import loop_last
 from .cells import cell_len, chop_cells
 
-re_word = re.compile(r"\s*\S+\s*")
+re_word = re.compile(r"[^\S\xa0]*[\S\xa0]+[^\S\xa0]*")
 
 
 def words(text: str) -> Iterable[tuple[int, int, str]]:

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -627,6 +627,19 @@ def test_wrap_multi_codepoint():
     ]
 
 
+def test_wrap_no_break_space():
+    """NO-BREAK SPACE (U+00A0) should not be treated as a word break."""
+    # https://github.com/Textualize/rich/issues/3545
+    # When the NBSP word fits, it stays on one line
+    text = Text("hello\u00a0world foo")
+    lines = text.wrap(Console(), 12)
+    assert lines[0].plain.startswith("hello\xa0world")
+    # When it doesn't fit on the line, it should NOT break at the NBSP.
+    # Instead it folds mid-word, keeping NBSP inside the word.
+    lines2 = text.wrap(Console(), 8)
+    assert "hello\xa0wo" in lines2[0].plain
+
+
 def test_wrap_long_words_justify_left():
     text = Text("X 123456789", justify="left")
     lines = text.wrap(Console(), 4)


### PR DESCRIPTION
Fixes #3545

## Summary

The word-splitting regex in `_wrap.py` uses `\s` which matches **all** Unicode whitespace, including U+00A0 NO-BREAK SPACE. This caused text like `hello\u00a0world` to be split into two separate words during wrapping, defeating the purpose of the non-breaking space.

**Before:** `\s*\S+\s*` — splits at NBSP  
**After:** `[^\S\xa0]*[\S\xa0]+[^\S\xa0]*` — treats NBSP as non-whitespace for word splitting

The fix uses `[^\S\xa0]` ("whitespace excluding NBSP") and `[\S\xa0]` ("non-whitespace or NBSP") so that NBSP-joined words stay together. When such a word is too wide for the line, it folds normally (breaking at character boundaries) rather than breaking at the non-breaking space.

## Test plan

- Added `test_wrap_no_break_space` covering both cases:
  - Width 12: `hello\u00a0world` fits on one line — stays together
  - Width 8: `hello\u00a0world` is too wide — folds mid-word, does NOT break at NBSP
- Test fails without the fix (NBSP treated as break point), passes with it
- All 24 existing wrap tests pass with no changes