### PR TITLE
Fix ValueError in traceback when f_lasti is negative

### DIFF
--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -542,29 +542,30 @@ class Traceback:
                 last_instruction = None
                 if sys.version_info >= (3, 11):
                     instruction_index = frame_summary.f_lasti // 2
-                    instruction_position = next(
-                        islice(
-                            frame_summary.f_code.co_positions(),
-                            instruction_index,
-                            instruction_index + 1,
+                    if instruction_index >= 0:
+                        instruction_position = next(
+                            islice(
+                                frame_summary.f_code.co_positions(),
+                                instruction_index,
+                                instruction_index + 1,
+                            )
                         )
-                    )
-                    (
-                        start_line,
-                        end_line,
-                        start_column,
-                        end_column,
-                    ) = instruction_position
-                    if (
-                        start_line is not None
-                        and end_line is not None
-                        and start_column is not None
-                        and end_column is not None
-                    ):
-                        last_instruction = (
-                            (start_line, start_column),
-                            (end_line, end_column),
-                        )
+                        (
+                            start_line,
+                            end_line,
+                            start_column,
+                            end_column,
+                        ) = instruction_position
+                        if (
+                            start_line is not None
+                            and end_line is not None
+                            and start_column is not None
+                            and end_column is not None
+                        ):
+                            last_instruction = (
+                                (start_line, start_column),
+                                (end_line, end_column),
+                            )
 
                 if filename and not filename.startswith("<"):
                     if not os.path.isabs(filename):


### PR DESCRIPTION
Fixes #3607

## Summary

When `f_lasti` is `-1` (can happen during `KeyboardInterrupt` or other edge cases where no instruction has executed yet), the computed `instruction_index` becomes negative. This is passed to `islice()` which raises:

```
ValueError: Indices for islice() must be None or an integer: 0 <= x <= sys.maxsize.
```

Added a guard: when `instruction_index < 0`, skip the instruction position lookup entirely and leave `last_instruction` as `None`. This matches the behavior for Python < 3.11 where instruction positions aren't available.

## Test plan

- Added `test_traceback_negative_lasti` that mocks `walk_tb` to yield frames with `f_lasti = -1`
- Without the fix: `ValueError` from `islice()`
- With the fix: gracefully handles the case, `last_instruction` is `None`
- Existing finely-grained traceback tests still pass