### PR TITLE
Fix print(markup=False) leaking into Live renderables

### DIFF
--- a/rich/live_render.py
+++ b/rich/live_render.py
@@ -88,6 +88,9 @@ class LiveRender:
     ) -> RenderResult:
         renderable = self.renderable
         style = console.get_style(self.style)
+        # Reset markup and highlight to console defaults so that transient
+        # settings from print() calls don't leak into the live display.
+        options = options.update(markup=None, highlight=None)
         lines = console.render_lines(renderable, options, style=style, pad=False)
         shape = Segment.get_shape(lines)
 


### PR DESCRIPTION
Fixes #3751

## Summary

When `console.print(line, markup=False)` is called while a `Live` display is active, the `markup=False` setting propagates through `ConsoleOptions` into `LiveRender.__rich_console__`, causing markup in the live display (e.g. `[green]text[/]`) to be rendered as literal text instead of styled output.

This happens because `Live.process_renderables()` appends the `LiveRender` to the same renderables list that `print()` processes, so all renderables share the same `render_options` — including the transient `markup=False`.

**Fix:** In `LiveRender.__rich_console__`, reset `markup` and `highlight` back to `None` (console defaults) before rendering. This ensures the live display always uses the console's own settings, regardless of what any individual `print()` call specifies.

## Test plan

- Added `test_rich_console_markup_not_leaked` that:
  - Creates a `LiveRender` with markup content (`[bold]hello[/bold]`)
  - Passes `ConsoleOptions` with `markup=False` (simulating a `print(markup=False)` call)
  - Verifies the markup is interpreted (not shown literally)
- Test fails without fix (`[bold]` appears as literal text), passes with fix
- All existing live render tests pass