### PR TITLE
Fix: Clear console buffer on UnicodeEncodeError to prevent crash when…

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -2108,7 +2108,10 @@ class Console:
                     else:
                         text = self._render_buffer(self._buffer[:])
                         try:
-                            self.file.write(text)
+                            try:
+                                self.file.write(text)
+                            except UnicodeEncodeError as error:
+                                self._buffer = []
                         except UnicodeEncodeError as error:
                             error.reason = f"{error.reason}\n*** You may need to add PYTHONIOENCODING=utf-8 to your environment ***"
                             raise


### PR DESCRIPTION
Added a try/except block around write to buffer to prevent crashes when the program tries to exits and a unicodeEncode error happens.

<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here.

**Important:** Link to an issue or discussion regarding these changes. 
