### PR TITLE
Fix ValueError in _guess_lexer for single-line source files

### DIFF
--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -755,7 +755,7 @@ class Traceback:
             # No extension, look at first line to see if it is a hashbang
             # Note, this is an educated guess and not a guarantee
             # If it fails, the only downside is that the code is highlighted strangely
-            new_line_index = code.index("\n")
+            new_line_index = code.find("\n")
             first_line = code[:new_line_index] if new_line_index != -1 else code
             if first_line.startswith("#!") and "python" in first_line.lower():
                 return "python"


### PR DESCRIPTION
`_guess_lexer` uses `str.index()` to find the first newline in source code, but `index()` raises `ValueError` when the substring isn't found. The subsequent check `if new_line_index != -1` only makes sense with `str.find()`, which returns `-1` on miss.

When a traceback includes a frame from a single-line source file (no trailing newline), `_guess_lexer` crashes with an unhandled `ValueError` instead of rendering the traceback.

Changed `code.index("\n")` → `code.find("\n")` so the existing `-1` guard works as intended.
