### PR TITLE
Fix locals_overlow typo in Traceback.__init__

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,5 @@
+`_guess_lexer` uses `str.index()` to find the first newline in source code, but `index()` raises `ValueError` when the substring isn't found. The subsequent check `if new_line_index != -1` only makes sense with `str.find()`, which returns `-1` on miss.
+
+When a traceback includes a frame from a single-line source file (no trailing newline), `_guess_lexer` crashes with an unhandled `ValueError` instead of rendering the traceback.
+
+Changed `code.index("\n")` → `code.find("\n")` so the existing `-1` guard works as intended.

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -307,7 +307,7 @@ class Traceback:
         locals_max_depth: Optional[int] = None,
         locals_hide_dunder: bool = True,
         locals_hide_sunder: bool = False,
-        locals_overlow: Optional[OverflowMethod] = None,
+        locals_overflow: Optional[OverflowMethod] = None,
         indent_guides: bool = True,
         suppress: Iterable[Union[str, ModuleType]] = (),
         max_frames: int = 100,
@@ -334,7 +334,7 @@ class Traceback:
         self.locals_max_depth = locals_max_depth
         self.locals_hide_dunder = locals_hide_dunder
         self.locals_hide_sunder = locals_hide_sunder
-        self.locals_overflow = locals_overlow
+        self.locals_overflow = locals_overflow
 
         self.suppress: Sequence[str] = []
         for suppress_entity in suppress:
@@ -424,7 +424,7 @@ class Traceback:
             locals_max_depth=locals_max_depth,
             locals_hide_dunder=locals_hide_dunder,
             locals_hide_sunder=locals_hide_sunder,
-            locals_overlow=locals_overflow,
+            locals_overflow=locals_overflow,
             suppress=suppress,
             max_frames=max_frames,
         )


### PR DESCRIPTION
The `Traceback.__init__` parameter `locals_overlow` is misspelled — it should be `locals_overflow`.

This means constructing a `Traceback` directly with the correct keyword `locals_overflow=...` raises `TypeError: unexpected keyword argument`. The only way to pass it currently is through `from_exception`, which maps the correct name to the typo internally.

Fixed the parameter name in `__init__`, the assignment in the body, and the keyword argument in `from_exception`.
