### PR TITLE
Fix `@auto` to be safe with `tuple`-valued attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `@auto` to be safe with `tuple`-valued positionals https://github.com/Textualize/rich/pull/4014
+
 ## [14.3.3] - 2026-02-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `@auto` to be safe with `tuple`-valued positionals https://github.com/Textualize/rich/pull/4014
+- Fixed `@auto` to be safe with `tuple`-valued positionals https://github.com/Textualize/rich/issues/4016
 
 ## [14.3.3] - 2026-02-19
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -100,3 +100,4 @@ The following people have contributed to the development of Rich:
 - [Brandon Capener](https://github.com/bcapener)
 - [Alex Zheng](https://github.com/alexzheng111)
 - [Sebastian Speitel](https://github.com/SebastianSpeitel)
+- [David S.](https://github.com/finite-state-machine)

--- a/rich/repr.py
+++ b/rich/repr.py
@@ -71,13 +71,13 @@ def auto(
                 signature = inspect.signature(self.__init__)
                 for name, param in signature.parameters.items():
                     if param.kind == param.POSITIONAL_ONLY:
-                        yield getattr(self, name)
+                        yield None, getattr(self, name)
                     elif param.kind in (
                         param.POSITIONAL_OR_KEYWORD,
                         param.KEYWORD_ONLY,
                     ):
                         if param.default is param.empty:
-                            yield getattr(self, param.name)
+                            yield None, getattr(self, param.name)
                         else:
                             yield param.name, getattr(self, param.name), param.default
             except Exception as error:

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -124,6 +124,9 @@ def test_rich_repr_auto() -> None:
         == f"Bird('penguin', ['fish'], another={repr(stupid_class)}, extinct={repr(not_stupid)})"
     )
 
+def test_rich_repr_auto_with_tuples() -> None:
+    assert repr(Egg(('hello', 'world'), egg=2)) == "Egg(('hello', 'world'), egg=2)"
+
 
 def test_rich_repr_auto_angular() -> None:
     assert repr(AngularEgg("hello", egg=2)) == "<AngularEgg 'hello' egg=2>"


### PR DESCRIPTION


<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- AI was *NOT* used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

When `@auto` is representing an attribute (`__init__()` arg) which is emitted as positional (rather than with the attribute name), the implementation yields the value directly. If that value is a `tuple`, it will be misinterpreted as a `(name, value, ...)` group, causing `TypeError`s later when rendering.

Fixes #4016.