### PR TITLE
Add documentation for TaskProgressColumn

### DIFF
--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -163,6 +163,7 @@ The following column objects are available:
 - :class:`~rich.progress.TransferSpeedColumn` Displays transfer speed (assumes the steps are bytes).
 - :class:`~rich.progress.SpinnerColumn` Displays a "spinner" animation.
 - :class:`~rich.progress.RenderableColumn` Displays an arbitrary Rich renderable in the column.
+- :class:`~rich.progress.TaskProgressColumn` Displays task completion progress as a percentage.
 
 To implement your own columns, extend the :class:`~rich.progress.ProgressColumn` class and use it as you would the other columns.
 

--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -297,3 +297,20 @@ Example
 -------
 
 See `downloader.py <https://github.com/willmcgugan/rich/blob/master/examples/downloader.py>`_ for a realistic application of a progress display. This script can download multiple concurrent files with a progress bar, transfer speed and file size.
+
+TaskProgressColumn
+~~~~~~~~~~~~~~~~~~
+
+The ``TaskProgressColumn`` displays the percentage of task completion.
+
+It is typically used to show how much of a task has been completed relative to
+its total value. This column is included in the default progress columns and is
+useful when tracking long-running tasks.
+
+Example::
+
+    from rich.progress import Progress, TaskProgressColumn
+
+    progress = Progress(
+        TaskProgressColumn(),
+    )


### PR DESCRIPTION
This PR adds documentation explaining the purpose and usage of
TaskProgressColumn in the Rich progress module.

The documentation helps users understand how TaskProgressColumn
displays task completion percentage and how it can be used when
configuring custom progress columns.