### PR TITLE
Fix Jupyter hanging issue in dynamic_progress.py example

### DIFF
--- a/examples/dynamic_progress.py
+++ b/examples/dynamic_progress.py
@@ -88,7 +88,8 @@ overall_task_id = overall_progress.add_task("", total=len(apps))
 # use own live instance as context manager with group of progress bars,
 # which allows for running multiple different progress bars in parallel,
 # and dynamically showing/hiding them
-with Live(progress_group):
+LiveProgress = Live(progress_group)
+with LiveProgress:
     for idx, (name, step_times) in enumerate(apps):
         # update message on overall progress bar
         top_descr = "[bold #AAAAAA](%d out of %d apps installed)" % (idx, len(apps))
@@ -115,3 +116,7 @@ with Live(progress_group):
     overall_progress.update(
         overall_task_id, description="[bold green]%s apps installed, done!" % len(apps)
     )
+
+    LiveProgress.update(progress_group, refresh=True)
+    LiveProgress.stop()
+

--- a/examples/dynamic_progress.py
+++ b/examples/dynamic_progress.py
@@ -117,6 +117,7 @@ with LiveProgress:
         overall_task_id, description="[bold green]%s apps installed, done!" % len(apps)
     )
 
+    # final update and closing of the main progress
     LiveProgress.update(progress_group, refresh=True)
     LiveProgress.stop()
 


### PR DESCRIPTION
## Description
Fix an issue where the `examples/dynamic_progress.py` script would hang indefinitely when run in a Jupyter notebook.

The problem occurs because the `Live` display does not properly clean up after itself in the Jupyter environment, leaving the progress bar output stuck.

## Solution
- Created `Live` instance outside the context to have explicit control
- Added explicit `live.stop()` call before exiting the context to ensure proper cleanup
- Tested locally in Jupyter notebook — the example now completes without hanging

## Related Issue
Fixes #3880

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Ran the example in a Jupyter notebook environment
- Verified that the script completes without hanging
- Tested in regular terminal to ensure no regression

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings