### PR TITLE
Fix traceback __notes__ shown on all exceptions in chain

### DIFF
--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -467,8 +467,6 @@ class Traceback:
 
         from rich import _IMPORT_CWD
 
-        notes: List[str] = getattr(exc_value, "__notes__", None) or []
-
         grouped_exceptions: Set[BaseException] = (
             set() if _visited_exceptions is None else _visited_exceptions
         )
@@ -481,6 +479,7 @@ class Traceback:
                 return "<exception str() failed>"
 
         while True:
+            notes: List[str] = getattr(exc_value, "__notes__", None) or []
             stack = Stack(
                 exc_type=safe_str(exc_type.__name__),
                 exc_value=safe_str(exc_value),

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -375,6 +375,27 @@ def test_notes() -> None:
         assert traceback.trace.stacks[0].notes == ["Hello", "World"]
 
 
+@pytest.mark.skipif(
+    sys.version_info.minor < 11, reason="Not supported before Python 3.11"
+)
+def test_notes_chained_exceptions() -> None:
+    """Notes should only appear on the exception they were added to, not all."""
+    try:
+        try:
+            raise ValueError("original error")
+        except ValueError as exc:
+            raise RuntimeError("wrapped error") from exc
+    except RuntimeError as exc:
+        exc.add_note("This note belongs to RuntimeError only")
+        traceback = Traceback()
+
+        # stacks[0] is the outermost (RuntimeError), stacks[1] is the cause (ValueError)
+        assert traceback.trace.stacks[0].notes == [
+            "This note belongs to RuntimeError only"
+        ]
+        assert traceback.trace.stacks[1].notes == []
+
+
 def test_recursive_exception() -> None:
     """Regression test for https://github.com/Textualize/rich/issues/3708
 


### PR DESCRIPTION
## Summary
- Moves `__notes__` extraction inside the `while True` loop in `Traceback.extract()` so each exception in a chain gets its own notes
- Previously, notes were read once from the outermost exception and shared across all stacks in the chain

## Test plan
- Added `test_notes_chained_exceptions` that verifies notes only appear on the exception they were added to
- All existing traceback tests pass (`23 passed, 1 skipped` on Python 3.13)

Fixes #3960