### PR TITLE
Fix typos and add missing docstrings across several modules

### DIFF
--- a/rich/containers.py
+++ b/rich/containers.py
@@ -28,7 +28,7 @@ T = TypeVar("T")
 
 
 class Renderables:
-    """A list subclass which renders its contents to the console."""
+    """A list-like container which renders its contents to the console."""
 
     def __init__(
         self, renderables: Optional[Iterable["RenderableType"]] = None
@@ -57,6 +57,11 @@ class Renderables:
         return Measurement(_min, _max)
 
     def append(self, renderable: "RenderableType") -> None:
+        """Append a renderable to the list.
+
+        Args:
+            renderable (RenderableType): Any renderable object.
+        """
         self._renderables.append(renderable)
 
     def __iter__(self) -> Iterable["RenderableType"]:
@@ -64,7 +69,7 @@ class Renderables:
 
 
 class Lines:
-    """A list subclass which can render to the console."""
+    """A list-like container of Text lines which can render to the console."""
 
     def __init__(self, lines: Iterable["Text"] = ()) -> None:
         self._lines: List["Text"] = list(lines)
@@ -76,12 +81,10 @@ class Lines:
         return iter(self._lines)
 
     @overload
-    def __getitem__(self, index: int) -> "Text":
-        ...
+    def __getitem__(self, index: int) -> "Text": ...
 
     @overload
-    def __getitem__(self, index: slice) -> List["Text"]:
-        ...
+    def __getitem__(self, index: slice) -> List["Text"]: ...
 
     def __getitem__(self, index: Union[slice, int]) -> Union["Text", List["Text"]]:
         return self._lines[index]
@@ -100,12 +103,30 @@ class Lines:
         yield from self._lines
 
     def append(self, line: "Text") -> None:
+        """Append a line to the end of the list.
+
+        Args:
+            line (Text): A Text instance to append.
+        """
         self._lines.append(line)
 
     def extend(self, lines: Iterable["Text"]) -> None:
+        """Extend the list by appending all lines from an iterable.
+
+        Args:
+            lines (Iterable[Text]): An iterable of Text instances.
+        """
         self._lines.extend(lines)
 
     def pop(self, index: int = -1) -> "Text":
+        """Remove and return a line at the given index.
+
+        Args:
+            index (int, optional): Index of line to remove. Defaults to -1 (last).
+
+        Returns:
+            Text: The removed Text instance.
+        """
         return self._lines.pop(index)
 
     def justify(

--- a/rich/control.py
+++ b/rich/control.py
@@ -108,7 +108,7 @@ class Control:
     def move_to_column(cls, x: int, y: int = 0) -> "Control":
         """Move to the given column, optionally add offset to row.
 
-        Returns:
+        Args:
             x (int): absolute x (column)
             y (int): optional y offset (row)
 

--- a/rich/emoji.py
+++ b/rich/emoji.py
@@ -7,7 +7,6 @@ from .style import Style
 from ._emoji_codes import EMOJI
 from ._emoji_replace import _emoji_replace
 
-
 if TYPE_CHECKING:
     from .console import Console, ConsoleOptions, RenderResult
 
@@ -22,7 +21,7 @@ class NoEmoji(Exception):
 class Emoji(JupyterMixin):
     __slots__ = ["name", "style", "_char", "variant"]
 
-    VARIANTS = {"text": "\uFE0E", "emoji": "\uFE0F"}
+    VARIANTS = {"text": "\ufe0e", "emoji": "\ufe0f"}
 
     def __init__(
         self,
@@ -34,7 +33,8 @@ class Emoji(JupyterMixin):
 
         Args:
             name (str): Name of emoji.
-            style (Union[str, Style], optional): Optional style. Defaults to None.
+            style (Union[str, Style], optional): Optional style. Defaults to "none".
+            variant (Optional[EmojiVariant], optional): Optional emoji variant, either "emoji" or "text". Defaults to None.
 
         Raises:
             NoEmoji: If the emoji doesn't exist.
@@ -82,7 +82,7 @@ if __name__ == "__main__":  # pragma: no cover
     console = Console(record=True)
 
     columns = Columns(
-        (f":{name}: {name}" for name in sorted(EMOJI.keys()) if "\u200D" not in name),
+        (f":{name}: {name}" for name in sorted(EMOJI.keys()) if "\u200d" not in name),
         column_first=True,
     )
 

--- a/rich/file_proxy.py
+++ b/rich/file_proxy.py
@@ -26,6 +26,17 @@ class FileProxy(io.TextIOBase):
         return getattr(self.__file, name)
 
     def write(self, text: str) -> int:
+        """Write text to the console via the proxy.
+
+        Args:
+            text (str): Text to write.
+
+        Returns:
+            int: Number of characters written.
+
+        Raises:
+            TypeError: If text is not a string.
+        """
         if not isinstance(text, str):
             raise TypeError(f"write() argument must be str, not {type(text).__name__}")
         buffer = self.__buffer
@@ -48,6 +59,7 @@ class FileProxy(io.TextIOBase):
         return len(text)
 
     def flush(self) -> None:
+        """Flush the internal buffer to the console."""
         output = "".join(self.__buffer)
         if output:
             self.__console.print(output)

--- a/rich/highlighter.py
+++ b/rich/highlighter.py
@@ -27,7 +27,7 @@ class Highlighter(ABC):
             TypeError: If not called with text or str.
 
         Returns:
-            Text: A test instance with highlighting applied.
+            Text: A text instance with highlighting applied.
         """
         if isinstance(text, str):
             highlight_text = Text(text)

--- a/rich/progress_bar.py
+++ b/rich/progress_bar.py
@@ -131,12 +131,10 @@ class ProgressBar(JupyterMixin):
         Args:
             console (Console): Console instance.
             width (int): Width in characters of pulse animation.
-
-        Returns:
-            RenderResult: [description]
+            ascii (bool, optional): Use ASCII characters only. Defaults to False.
 
         Yields:
-            Iterator[Segment]: Segments to render pulse
+            Segment: Segments to render pulse.
         """
         fore_style = console.get_style(self.pulse_style, default="white")
         back_style = console.get_style(self.style, default="black")

--- a/rich/screen.py
+++ b/rich/screen.py
@@ -4,14 +4,12 @@ from .segment import Segment
 from .style import StyleType
 from ._loop import loop_last
 
-
 if TYPE_CHECKING:
     from .console import (
         Console,
         ConsoleOptions,
         RenderResult,
         RenderableType,
-        Group,
     )
 
 
@@ -19,8 +17,9 @@ class Screen:
     """A renderable that fills the terminal screen and crops excess.
 
     Args:
-        renderable (RenderableType): Child renderable.
+        *renderables (RenderableType): One or more child renderables.
         style (StyleType, optional): Optional background style. Defaults to None.
+        application_mode (bool, optional): Enable application mode, using newline-carriage return instead of just newline. Defaults to False.
     """
 
     renderable: "RenderableType"


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [x] AI was used to generate this PR

This PR was generated using Claude Code (claude-opus-4-6). No associated issue or discussion exists yet; if the maintainers prefer one, I am happy to open a discussion first.

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes several documentation issues found across `rich/` modules:

- **highlighter.py**: Fix typo "A test instance" -> "A text instance" in `Highlighter.__call__` return docstring
- **control.py**: Fix mislabeled `Returns:` section that should be `Args:` in `Control.move_to_column`
- **progress_bar.py**: Remove placeholder `[description]` text from `ProgressBar._render_pulse` docstring, add missing `ascii` parameter, and fix `Yields` type annotation
- **containers.py**: Add missing docstrings for `Renderables.append`, `Lines.append`, `Lines.extend`, and `Lines.pop`; fix inaccurate "list subclass" wording in both class docstrings (neither class subclasses `list`)
- **emoji.py**: Document missing `variant` parameter in `Emoji.__init__` and correct the `style` default value from `None` to `"none"`
- **screen.py**: Document missing `application_mode` parameter and fix `*renderables` variadic param in `Screen` class docstring; remove unused `Group` import from `TYPE_CHECKING` block
- **file_proxy.py**: Add docstrings for `FileProxy.write` and `FileProxy.flush`

All changes are documentation-only (docstrings, typo fixes). No logic, behavior, or test changes.