### PR TITLE
Fix FileProxy.isatty() always returning False instead of delegating to proxied file

### DIFF
--- a/rich/file_proxy.py
+++ b/rich/file_proxy.py
@@ -55,3 +55,6 @@ class FileProxy(io.TextIOBase):
 
     def fileno(self) -> int:
         return self.__file.fileno()
+
+    def isatty(self) -> bool:
+        return self.__file.isatty()

--- a/tests/test_file_proxy.py
+++ b/tests/test_file_proxy.py
@@ -35,3 +35,22 @@ def test_new_lines():
     assert file.getvalue() == "-\n"
     file_proxy.flush()
     assert file.getvalue() == "-\n-\n"
+
+
+def test_isatty_delegates_to_proxied_file():
+    """FileProxy.isatty() must delegate to the underlying file.
+
+    io.TextIOBase.isatty() always returns False, so without an explicit
+    override the result would be wrong when the proxied file is a tty.
+    Regression test for https://github.com/Textualize/rich/issues/4041
+    """
+    tty_file = io.StringIO()
+    tty_file.isatty = lambda: True  # type: ignore[method-assign]
+
+    non_tty_file = io.StringIO()
+    # StringIO.isatty() already returns False, but be explicit
+    non_tty_file.isatty = lambda: False  # type: ignore[method-assign]
+
+    console = Console()
+    assert FileProxy(console, tty_file).isatty() is True
+    assert FileProxy(console, non_tty_file).isatty() is False


### PR DESCRIPTION
Fixes #4041.

## Problem

`FileProxy` extends `io.TextIOBase`, whose `isatty()` unconditionally returns `False`. The `__getattr__` fallback that delegates unknown attributes to the wrapped file is never reached for `isatty()` because it is already resolved through the `io.TextIOBase` MRO.

This means any code that calls `sys.stdout.isatty()` inside a `Live` context (with `redirect_stdout=True`) gets the wrong answer — always `False` — even when the real stdout is a terminal.

## Fix

Add an explicit `isatty()` override that delegates to `self.__file.isatty()`, exactly like `fileno()` already does:

```python
def isatty(self) -> bool:
    return self.__file.isatty()
```

## Test

`test_isatty_delegates_to_proxied_file` in `tests/test_file_proxy.py` verifies that a `FileProxy` wrapping a tty-like file returns `True`, and one wrapping a non-tty returns `False`.