### PR TITLE
fix: delegate isatty() to proxied file in FileProxy

### DIFF
--- a/rich/file_proxy.py
+++ b/rich/file_proxy.py
@@ -55,3 +55,6 @@ class FileProxy(io.TextIOBase):
 
     def fileno(self) -> int:
         return self.__file.fileno()
+
+    def isatty(self) -> bool:
+        return self.__file.isatty()

--- a/tests/test_file_proxy.py
+++ b/tests/test_file_proxy.py
@@ -35,3 +35,10 @@ def test_new_lines():
     assert file.getvalue() == "-\n"
     file_proxy.flush()
     assert file.getvalue() == "-\n-\n"
+
+
+def test_isatty_delegates_to_proxied_file():
+    file = io.StringIO()
+    console = Console(file=file)
+    file_proxy = FileProxy(console, file)
+    assert file_proxy.isatty() == file.isatty()


### PR DESCRIPTION
`FileProxy` inherits `isatty()` from `io.TextIOBase`, which always returns `False`. This breaks code that checks `sys.stdout.isatty()` inside a `Live` context with `redirect_stdout=True`.

The fix adds an `isatty()` method that delegates to the proxied file, consistent with how `fileno()` is already handled.

Fixes #4041