### PR TITLE
Fix FileProxy.isatty() to delegate to proxied file

### DIFF
--- a/rich/file_proxy.py
+++ b/rich/file_proxy.py
@@ -55,3 +55,6 @@ class FileProxy(io.TextIOBase):
 
     def fileno(self) -> int:
         return self.__file.fileno()
+
+    def isatty(self) -> bool:
+        return self.__file.isatty()

--- a/tests/test_file_proxy.py
+++ b/tests/test_file_proxy.py
@@ -35,3 +35,19 @@ def test_new_lines():
     assert file.getvalue() == "-\n"
     file_proxy.flush()
     assert file.getvalue() == "-\n-\n"
+
+
+def test_isatty_delegates_to_proxied_file():
+    """FileProxy.isatty() should delegate to the underlying file."""
+    import unittest.mock
+
+    console = Console()
+    mock_file = unittest.mock.MagicMock()
+    mock_file.isatty.return_value = True
+    file_proxy = FileProxy(console, mock_file)
+    assert file_proxy.isatty() is True
+    mock_file.isatty.assert_called_once()
+
+    # Verify False case also delegates correctly
+    mock_file.isatty.return_value = False
+    assert file_proxy.isatty() is False


### PR DESCRIPTION
## Problem

`FileProxy` (used by `Live` with `redirect_stdout=True`) inherits `isatty()` from `io.TextIOBase`, which always returns `False`. This breaks code that checks `sys.stdout.isatty()` inside a `Live` context.

```python
import sys
from rich.console import Console
from rich.live import Live

print(sys.stdout.isatty())  # True

with Live("hello", redirect_stdout=True):
    print(sys.stdout.isatty())  # False — should be True
```

## Root Cause

`io.TextIOBase.isatty()` exists in the MRO, so `FileProxy.__getattr__` is never called for `isatty`. The same issue was already addressed for `fileno()` (line 56).

## Fix

Add an explicit `isatty()` method that delegates to `self.__file.isatty()`, matching the existing `fileno()` pattern. Includes a test.

Closes #4041