### PR TITLE
test: add coverage for the progress bar when total is None

### DIFF
--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -684,6 +684,12 @@ def test_task_progress_column_speed() -> None:
     assert speed_text.plain == "8.9×10⁶ it/s"
 
 
+def test_percentage_completed_with_no_total():
+    """Test that percentage_completed returns None if total is None."""
+    bar = ProgressBar(total=None)
+    assert bar.percentage_completed is None
+
+
 if __name__ == "__main__":
     _render = render_progress()
     print(_render)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Adds missing test coverage for `ProgressBar` when `total=None` to get `progress_bar.py` to 100%.
*(I didn't open an issue before this PR as it's just a test coverage improvement).*