### PR TITLE
Propagate console formatting overrides

### DIFF
--- a/rich/columns.py
+++ b/rich/columns.py
@@ -64,7 +64,16 @@ class Columns(JupyterMixin):
     ) -> RenderResult:
         render_str = console.render_str
         renderables = [
-            render_str(renderable) if isinstance(renderable, str) else renderable
+            (
+                render_str(
+                    renderable,
+                    emoji=options.emoji,
+                    markup=options.markup,
+                    highlight=options.highlight,
+                )
+                if isinstance(renderable, str)
+                else renderable
+            )
             for renderable in self.renderables
         ]
         if not renderables:

--- a/rich/console.py
+++ b/rich/console.py
@@ -139,6 +139,8 @@ class ConsoleOptions:
     """Overflow value override for renderable."""
     no_wrap: Optional[bool] = False
     """Disable wrapping for text."""
+    emoji: Optional[bool] = None
+    """Emoji override for render_str."""
     highlight: Optional[bool] = None
     """Highlight override for render_str."""
     markup: Optional[bool] = None
@@ -169,6 +171,7 @@ class ConsoleOptions:
         justify: Union[Optional[JustifyMethod], NoChange] = NO_CHANGE,
         overflow: Union[Optional[OverflowMethod], NoChange] = NO_CHANGE,
         no_wrap: Union[Optional[bool], NoChange] = NO_CHANGE,
+        emoji: Union[Optional[bool], NoChange] = NO_CHANGE,
         highlight: Union[Optional[bool], NoChange] = NO_CHANGE,
         markup: Union[Optional[bool], NoChange] = NO_CHANGE,
         height: Union[Optional[int], NoChange] = NO_CHANGE,
@@ -187,6 +190,8 @@ class ConsoleOptions:
             options.overflow = overflow
         if not isinstance(no_wrap, NoChange):
             options.no_wrap = no_wrap
+        if not isinstance(emoji, NoChange):
+            options.emoji = emoji
         if not isinstance(highlight, NoChange):
             options.highlight = highlight
         if not isinstance(markup, NoChange):
@@ -1325,7 +1330,10 @@ class Console:
             render_iterable = renderable.__rich_console__(self, _options)
         elif isinstance(renderable, str):
             text_renderable = self.render_str(
-                renderable, highlight=_options.highlight, markup=_options.markup
+                renderable,
+                emoji=_options.emoji,
+                highlight=_options.highlight,
+                markup=_options.markup,
             )
             render_iterable = text_renderable.__rich_console__(self, _options)
         else:
@@ -1712,6 +1720,7 @@ class Console:
                 width=min(width, self.width) if width is not None else NO_CHANGE,
                 height=height,
                 no_wrap=no_wrap,
+                emoji=emoji,
                 markup=markup,
                 highlight=highlight,
             )

--- a/rich/measure.py
+++ b/rich/measure.py
@@ -97,7 +97,10 @@ class Measurement(NamedTuple):
             return Measurement(0, 0)
         if isinstance(renderable, str):
             renderable = console.render_str(
-                renderable, markup=options.markup, highlight=False
+                renderable,
+                emoji=options.emoji,
+                markup=options.markup,
+                highlight=False,
             )
         renderable = rich_cast(renderable)
         if is_renderable(renderable):

--- a/rich/rule.py
+++ b/rich/rule.py
@@ -65,7 +65,13 @@ class Rule(JupyterMixin):
         if isinstance(self.title, Text):
             title_text = self.title
         else:
-            title_text = console.render_str(self.title, style="rule.text")
+            title_text = console.render_str(
+                self.title,
+                style="rule.text",
+                emoji=options.emoji,
+                markup=options.markup,
+                highlight=options.highlight,
+            )
 
         title_text.plain = title_text.plain.replace("\n", " ")
         title_text.expand_tabs()

--- a/rich/table.py
+++ b/rich/table.py
@@ -491,14 +491,22 @@ class Table(JupyterMixin):
         table_width = sum(widths) + extra_width
 
         render_options = options.update(
-            width=table_width, highlight=self.highlight, height=None
+            width=table_width,
+            highlight=pick_bool(options.highlight, self.highlight),
+            height=None,
         )
 
         def render_annotation(
             text: TextType, style: StyleType, justify: "JustifyMethod" = "center"
         ) -> "RenderResult":
             render_text = (
-                console.render_str(text, style=style, highlight=False)
+                console.render_str(
+                    text,
+                    style=style,
+                    emoji=render_options.emoji,
+                    markup=render_options.markup,
+                    highlight=render_options.highlight,
+                )
                 if isinstance(text, str)
                 else text
             )
@@ -833,7 +841,7 @@ class Table(JupyterMixin):
                     no_wrap=column.no_wrap,
                     overflow=column.overflow,
                     height=None,
-                    highlight=column.highlight,
+                    highlight=pick_bool(options.highlight, column.highlight),
                 )
                 lines = console.render_lines(
                     cell.renderable,

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -71,6 +71,19 @@ def test_render():
     assert render() == expected
 
 
+def test_columns_respect_markup_and_emoji_overrides() -> None:
+    console = Console(file=io.StringIO(), width=60, legacy_windows=False)
+    console.print(
+        Columns(["[bold]Hello[/bold]", ":warning:"]),
+        markup=False,
+        emoji=False,
+    )
+
+    result = console.file.getvalue()
+    assert "[bold]Hello[/bold]" in result
+    assert ":warning:" in result
+
+
 if __name__ == "__main__":
     result = render()
     print(result)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -51,6 +51,17 @@ def test_soft_wrap() -> None:
     assert console.file.getvalue() == "foo " * 20
 
 
+def test_nested_render_respects_markup_and_emoji_overrides() -> None:
+    class NestedRenderable:
+        def __rich_console__(self, console, options):
+            yield "[bold]:warning:[/bold]"
+
+    console = Console(file=io.StringIO(), legacy_windows=False)
+    console.print(NestedRenderable(), markup=False, emoji=False)
+
+    assert console.file.getvalue() == "[bold]:warning:[/bold]\n"
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_16color_terminal() -> None:
     console = Console(

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -34,3 +34,11 @@ def test_clamp():
     assert measurement.clamp(None, 50) == Measurement(20, 50)
     assert measurement.clamp(30, None) == Measurement(30, 100)
     assert measurement.clamp(None, None) == Measurement(20, 100)
+
+
+def test_measurement_respects_markup_and_emoji_overrides() -> None:
+    console = Console()
+    text = "[bold]:warning:[/bold]"
+    options = console.options.update(markup=False, emoji=False)
+
+    assert Measurement.get(console, options, text) == Measurement(len(text), len(text))

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -128,3 +128,10 @@ def test_repr():
 def test_error():
     with pytest.raises(ValueError):
         Rule(characters="")
+
+
+def test_rule_respects_markup_and_emoji_overrides() -> None:
+    console = Console(width=60, file=io.StringIO(), legacy_windows=False, _environ={})
+    console.print(Rule("[bold]:warning:[/bold]"), markup=False, emoji=False)
+
+    assert "[bold]:warning:[/bold]" in console.file.getvalue()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -102,6 +102,19 @@ def test_not_renderable():
         table.add_row(Foo())
 
 
+def test_table_title_respects_markup_and_emoji_overrides() -> None:
+    console = Console(width=80, file=io.StringIO(), legacy_windows=False, _environ={})
+    table = Table(title="[bold]:warning:[/bold]")
+    table.add_column("Column")
+    table.add_row("value")
+
+    console.print(table, markup=False, emoji=False)
+
+    result = console.file.getvalue()
+    normalized = result.replace("\n", "").replace(" ", "")
+    assert "[bold]:warning:[/bold]" in normalized
+
+
 def test_init_append_column():
     header_names = ["header1", "header2", "header3"]
     test_columns = [


### PR DESCRIPTION
## Summary
- add emoji to ConsoleOptions and propagate console formatting overrides through nested string rendering
- pass emoji, markup, and highlight overrides through the Console, Columns, Measurement, Rule, and Table code paths
- add regression tests covering nested renderables, columns, measurement, rules, and table titles

## Testing
- python -m pytest tests/test_console.py tests/test_columns.py tests/test_measure.py tests/test_rule.py tests/test_table.py tests/test_markdown.py -q

Closes #4028