### PR TITLE
Preserve inline code spans in markdown tables

### DIFF
--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -331,9 +331,10 @@ class TableDataElement(MarkdownElement):
         self.justify = justify
 
     def on_text(self, context: MarkdownContext, text: TextType) -> None:
-        text = Text(text) if isinstance(text, str) else text
-        text.stylize(context.current_style)
-        self.content.append_text(text)
+        if isinstance(text, str):
+            self.content.append(text, context.current_style)
+        else:
+            self.content.append_text(text)
 
 
 class ListElement(MarkdownElement):

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -73,7 +73,8 @@ import io
 import re
 
 from rich.console import Console, RenderableType
-from rich.markdown import Markdown
+from rich.markdown import Markdown, TableDataElement
+from rich.text import Span, Text
 
 re_link_ids = re.compile(r"id=[\d\.\-]*?;.*?\x1b")
 
@@ -197,6 +198,18 @@ def test_table_with_empty_cells() -> None:
     result = len(render(table_with_empty_cells).splitlines())
     expected = len(render(complete_table).splitlines())
     assert result == expected
+
+
+def test_table_data_element_preserves_existing_text_spans() -> None:
+    cell = TableDataElement(justify="left")
+    context = type("Context", (), {"current_style": "markdown.code"})()
+    text = Text("hello")
+    text.stylize("repr.str", 0, 5)
+
+    cell.on_text(context, text)
+
+    assert cell.content.plain == "hello"
+    assert cell.content.spans == [Span(0, 5, "repr.str")]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preserve existing Text spans when Markdown table cells receive already-highlighted inline code
- add a regression test for TableDataElement so inline code highlighting is not flattened in table cells

## Testing
- python -m pytest tests/test_markdown.py -k table_data_element_preserves_existing_text_spans -q

Closes #4038