### PR TITLE
fix: prevent infinite loop in Segment._split_cells with non-unit characters

### DIFF
--- a/rich/segment.py
+++ b/rich/segment.py
@@ -131,7 +131,12 @@ class Segment(NamedTuple):
 
         pos = int((cut / cell_length) * len(text))
 
-        while True:
+        max_iterations = len(text) + 2  # safety guard against infinite loops
+        for _ in range(max_iterations):
+            if pos < 0:
+                pos = 0
+            if pos > len(text):
+                pos = len(text)
             before = text[:pos]
             cell_pos = cell_len(before)
             out_by = cell_pos - cut
@@ -140,12 +145,12 @@ class Segment(NamedTuple):
                     _Segment(before, style, control),
                     _Segment(text[pos:], style, control),
                 )
-            if out_by == -1 and cell_size(text[pos]) == 2:
+            if out_by == -1 and pos < len(text) and cell_size(text[pos]) == 2:
                 return (
                     _Segment(text[:pos] + " ", style, control),
                     _Segment(" " + text[pos + 1 :], style, control),
                 )
-            if out_by == +1 and cell_size(text[pos - 1]) == 2:
+            if out_by == +1 and pos > 0 and cell_size(text[pos - 1]) == 2:
                 return (
                     _Segment(text[: pos - 1] + " ", style, control),
                     _Segment(" " + text[pos:], style, control),
@@ -154,6 +159,12 @@ class Segment(NamedTuple):
                 pos += 1
             else:
                 pos -= 1
+
+        # Fallback: could not find exact cut position, split at closest
+        return (
+            _Segment(text[:pos], style, control),
+            _Segment(text[pos:], style, control),
+        )
 
     def split_cells(self, cut: int) -> Tuple["Segment", "Segment"]:
         """Split segment in to two segments at the specified column.


### PR DESCRIPTION
## Problem

Fixes #3299

`Segment._split_cells` could enter an infinite loop when cutting at positions within multi-codepoint grapheme clusters (e.g. ZWJ sequences like `👨‍👩‍👧`). The `while True` loop had no exit condition for cases where:

1. `out_by` was not exactly 0, -1, or +1
2. The `cell_size` checks didn't match the characters at the split position

This happens because some multi-codepoint clusters have intermediate positions where `cell_size` returns 0 (for combining characters and ZWJ), and the loop keeps adjusting `pos` without ever hitting the exact boundary.

## Fix

- Added bounds checking (`pos < 0` and `pos > len(text)`)  
- Added a max iteration guard (`len(text) + 2`) that falls back to splitting at the closest position
- All 952 existing tests pass
- Verified the fix with ZWJ sequences that previously caused hangs

## Testing

```python
from rich.segment import Segment

# Previously caused infinite loop
s = Segment('👨‍👩‍👧', None, None)
result = s.split_cells(2)
# Now returns in <1ms instead of hanging
```