### PR TITLE
Fix incomplete support for stderr in Legacy Windows layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- `console.get_windows_console_features` and `console.detect_legacy_windows` now have an optional `file` parameter https://github.com/Textualize/rich/pull/4072
+
+### Fixed
+
+- Fixed the auto-detection of `Console.legacy_windows` for the stderr stream, when stdout is redirected https://github.com/Textualize/rich/pull/4072
+- Fixed legacy Windows rendering for the stderr stream https://github.com/Textualize/rich/pull/4072
+
 ## [14.3.3] - 2026-02-19
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -100,3 +100,4 @@ The following people have contributed to the development of Rich:
 - [Brandon Capener](https://github.com/bcapener)
 - [Alex Zheng](https://github.com/alexzheng111)
 - [Sebastian Speitel](https://github.com/SebastianSpeitel)
+- [Jakub Kuczys](https://github.com/Jackenmen)

--- a/rich/_win32_console.py
+++ b/rich/_win32_console.py
@@ -17,11 +17,26 @@ import time
 from ctypes import Structure, byref, wintypes
 from typing import IO, NamedTuple, Type, cast
 
+from rich._fileno import get_fileno
 from rich.color import ColorSystem
 from rich.style import Style
 
+try:
+    STDOUT_FILENO = sys.__stdout__.fileno()  # type: ignore[union-attr]
+except Exception:
+    STDOUT_FILENO = 1
+try:
+    STDERR_FILENO = sys.__stderr__.fileno()  # type: ignore[union-attr]
+except Exception:
+    STDERR_FILENO = 2
+
 STDOUT = -11
+STDERR = -12
 ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4
+FILENO_TO_HANDLE = {
+    STDOUT_FILENO: STDOUT,
+    STDERR_FILENO: STDERR,
+}
 
 COORD = wintypes._COORD
 
@@ -360,7 +375,7 @@ class LegacyWindowsTerm:
     ]
 
     def __init__(self, file: "IO[str]") -> None:
-        handle = GetStdHandle(STDOUT)
+        handle = GetStdHandle(FILENO_TO_HANDLE.get(get_fileno(file), STDOUT))
         self._handle = handle
         default_text = GetConsoleScreenBufferInfo(handle).wAttributes
         self._default_text = default_text

--- a/rich/_win32_console.py
+++ b/rich/_win32_console.py
@@ -10,7 +10,19 @@ from typing import Any
 windll: Any = None
 if sys.platform == "win32":
     windll = ctypes.LibraryLoader(ctypes.WinDLL)
+    # `type: ignore` is needed only on Windows and mypy reports unused-ignore when not in an if
+    try:
+        STDOUT_FILENO = sys.__stdout__.fileno()  # type: ignore[union-attr]
+    except Exception:
+        STDOUT_FILENO = 1
+    try:
+        STDERR_FILENO = sys.__stderr__.fileno()  # type: ignore[union-attr]
+    except Exception:
+        STDERR_FILENO = 2
 else:
+    # mypy does not realize that anything past the raise is unreachable and reports undefined name
+    STDOUT_FILENO = 1
+    STDERR_FILENO = 2
     raise ImportError(f"{__name__} can only be imported on Windows")
 
 import time
@@ -20,15 +32,6 @@ from typing import IO, NamedTuple, Type, cast
 from rich._fileno import get_fileno
 from rich.color import ColorSystem
 from rich.style import Style
-
-try:
-    STDOUT_FILENO = sys.__stdout__.fileno()  # type: ignore[union-attr]
-except Exception:
-    STDOUT_FILENO = 1
-try:
-    STDERR_FILENO = sys.__stderr__.fileno()  # type: ignore[union-attr]
-except Exception:
-    STDERR_FILENO = 2
 
 STDOUT = -11
 STDERR = -12

--- a/rich/_windows.py
+++ b/rich/_windows.py
@@ -1,5 +1,6 @@
 import sys
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -24,6 +25,8 @@ try:
 
     from rich._win32_console import (
         ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+        FILENO_TO_HANDLE,
+        STDOUT,
         GetConsoleMode,
         GetStdHandle,
         LegacyWindowsError,
@@ -31,19 +34,23 @@ try:
 
 except (AttributeError, ImportError, ValueError):
     # Fallback if we can't load the Windows DLL
-    def get_windows_console_features() -> WindowsConsoleFeatures:
+    def get_windows_console_features(
+        fileno: Optional[int] = None,
+    ) -> WindowsConsoleFeatures:
         features = WindowsConsoleFeatures()
         return features
 
 else:
 
-    def get_windows_console_features() -> WindowsConsoleFeatures:
+    def get_windows_console_features(
+        fileno: Optional[int] = None,
+    ) -> WindowsConsoleFeatures:
         """Get windows console features.
 
         Returns:
             WindowsConsoleFeatures: An instance of WindowsConsoleFeatures.
         """
-        handle = GetStdHandle()
+        handle = GetStdHandle(FILENO_TO_HANDLE.get(fileno, STDOUT))
         try:
             console_mode = GetConsoleMode(handle)
             success = True

--- a/rich/console.py
+++ b/rich/console.py
@@ -569,19 +569,23 @@ class RenderHook(ABC):
 _windows_console_features: Optional["WindowsConsoleFeatures"] = None
 
 
-def get_windows_console_features() -> "WindowsConsoleFeatures":  # pragma: no cover
+def get_windows_console_features(
+    file: Optional[IO[str]] = None,
+) -> "WindowsConsoleFeatures":  # pragma: no cover
     global _windows_console_features
     if _windows_console_features is not None:
         return _windows_console_features
     from ._windows import get_windows_console_features
 
-    _windows_console_features = get_windows_console_features()
+    fileno = get_fileno(file) if file is not None else None
+
+    _windows_console_features = get_windows_console_features(fileno)
     return _windows_console_features
 
 
-def detect_legacy_windows() -> bool:
+def detect_legacy_windows(file: Optional[IO[str]] = None) -> bool:
     """Detect legacy Windows."""
-    return WINDOWS and not get_windows_console_features().vt
+    return WINDOWS and not get_windows_console_features(file).vt
 
 
 class Console:
@@ -681,24 +685,6 @@ class Console:
         self._emoji = emoji
         self._emoji_variant: Optional[EmojiVariant] = emoji_variant
         self._highlight = highlight
-        self.legacy_windows: bool = (
-            (detect_legacy_windows() and not self.is_jupyter)
-            if legacy_windows is None
-            else legacy_windows
-        )
-
-        if width is None:
-            columns = self._environ.get("COLUMNS")
-            if columns is not None and columns.isdigit():
-                width = int(columns) - self.legacy_windows
-        if height is None:
-            lines = self._environ.get("LINES")
-            if lines is not None and lines.isdigit():
-                height = int(lines)
-
-        self.soft_wrap = soft_wrap
-        self._width = width
-        self._height = height
 
         self._color_system: Optional[ColorSystem]
 
@@ -709,13 +695,6 @@ class Console:
         self._file = file
         self.quiet = quiet
         self.stderr = stderr
-
-        if color_system is None:
-            self._color_system = None
-        elif color_system == "auto":
-            self._color_system = self._detect_color_system()
-        else:
-            self._color_system = COLOR_SYSTEMS[color_system]
 
         self._lock = threading.RLock()
         self._log_render = LogRender(
@@ -755,6 +734,32 @@ class Console:
         self._render_hooks: List[RenderHook] = []
         self._live_stack: List[Live] = []
         self._is_alt_screen = False
+
+        self.legacy_windows: bool = (
+            (detect_legacy_windows(self.file) and not self.is_jupyter)
+            if legacy_windows is None
+            else legacy_windows
+        )
+
+        if width is None:
+            columns = self._environ.get("COLUMNS")
+            if columns is not None and columns.isdigit():
+                width = int(columns) - self.legacy_windows
+        if height is None:
+            lines = self._environ.get("LINES")
+            if lines is not None and lines.isdigit():
+                height = int(lines)
+
+        self.soft_wrap = soft_wrap
+        self._width = width
+        self._height = height
+
+        if color_system is None:
+            self._color_system = None
+        elif color_system == "auto":
+            self._color_system = self._detect_color_system()
+        else:
+            self._color_system = COLOR_SYSTEMS[color_system]
 
     def __repr__(self) -> str:
         return f"<console width={self.width} {self._color_system!s}>"
@@ -801,7 +806,7 @@ class Console:
         if WINDOWS:  # pragma: no cover
             if self.legacy_windows:  # pragma: no cover
                 return ColorSystem.WINDOWS
-            windows_console_features = get_windows_console_features()
+            windows_console_features = get_windows_console_features(self.file)
             return (
                 ColorSystem.TRUECOLOR
                 if windows_console_features.truecolor


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I've grepped through the code for argless calls to `GetStdHandle()` and, where appropriate, I've updated them to use the stderr handle (-12 per https://learn.microsoft.com/en-us/windows/console/getstdhandle#parameters), when operating on stderr.
Specifically:
- `Console` now detects terminal features for stderr correctly, when stdout is redirected (before, stderr was always treated as legacy Windows when stdout is redirected, even if stderr was attached to Windows Terminal, not conhost)
- `Console(stderr=True, legacy_windows=True)` now actually operates on stderr for features that require Windows Console API instead of stdout
- public `get_windows_console_features()` and `detect_legacy_windows()` functions in `rich.console` module now accept an optional `file` argument

I didn't write any tests because it does not seem like the functions/methods that I edited had any existing ones. I assume that means it's probably okay, and I don't exactly have a good idea of what would need to be tested here anyway.

You'll notice I moved the `legacy_windows` assignment to the end of the init function. This was needed because I had to be able to pass `self.file` to `detect_legacy_windows()`. The width, height, and color system detection depend on its value, so they had to be moved as well.

Fixes #4071