### PR TITLE
fix: RichHandler now honours %z (and other timezone specifiers) in log_time_format

### DIFF
--- a/rich/logging.py
+++ b/rich/logging.py
@@ -232,7 +232,7 @@ class RichHandler(Handler):
         path = os.path.basename(record.pathname)
         level = self.get_level_text(record)
         time_format = None if self.formatter is None else self.formatter.datefmt
-        log_time = datetime.fromtimestamp(record.created)
+        log_time = datetime.fromtimestamp(record.created).astimezone()
 
         log_renderable = self._log_render(
             self.console,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,7 @@
 import io
-import os
 import logging
+import os
+import re
 from typing import Optional
 
 import pytest
@@ -160,3 +161,30 @@ def test_markup_and_highlight():
     render_plain = handler.console.file.getvalue()
     assert "FORMATTER" in render_plain
     assert log_message in render_plain
+
+
+def test_log_time_format_with_timezone():
+    """%z in log_time_format should produce a non-empty UTC-offset string."""
+    console = Console(
+        file=io.StringIO(),
+        force_terminal=True,
+        width=140,
+        color_system=None,
+        _environ={},
+    )
+    handler = RichHandler(
+        console=console,
+        log_time_format="%Y-%m-%dT%H:%M:%S%z",
+        enable_link_path=False,
+    )
+    logger = logging.getLogger("rich.tz_test")
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    logger.info("tz test")
+
+    output = console.file.getvalue()
+    # The output should contain a timestamp with a UTC offset like +0300 or -0500
+    assert re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4}", output), (
+        f"Expected timezone offset in output, got: {output!r}"
+    )


### PR DESCRIPTION
## Summary

Fixes #3877.

`RichHandler` creates the log timestamp with:

```python
log_time = datetime.fromtimestamp(record.created)
```

`datetime.fromtimestamp()` returns a **naive** `datetime` (no `tzinfo`).
When the format string contains `%z`, `strftime('%z')` on a naive datetime
returns an empty string, so the timezone offset is silently dropped.

## Fix

Call `.astimezone()` (no argument) on the naive result:

```python
log_time = datetime.fromtimestamp(record.created).astimezone()
```

`astimezone()` with no argument attaches the *local* timezone to a naive
datetime, making it timezone-aware without changing the displayed time.
`%z` then correctly emits the local UTC offset (e.g. `+0300` or `-0500`).

This is a one-character addition, requires no new imports, and is
backward-compatible — callers who don't use `%z` see no change.

## Test plan

- [x] New test `test_log_time_format_with_timezone` asserts that a format
  string containing `%z` produces a timestamp that includes a UTC offset
- [x] Existing logging tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)