### PR TITLE
tests: fix test_inspect for Python 3.15 print()

### DIFF
--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -48,6 +48,10 @@ skip_py314 = pytest.mark.skipif(
     reason="rendered differently on py3.14",
 )
 
+skip_py315 = pytest.mark.skipif(
+    sys.version_info.minor == 15 and sys.version_info.major == 3,
+    reason="rendered differently on py3.15",
+)
 
 skip_pypy3 = pytest.mark.skipif(
     hasattr(sys, "pypy_version_info"),
@@ -145,6 +149,7 @@ def test_inspect_empty_dict():
     assert render({}).startswith(expected)
 
 
+@skip_py315
 @skip_py314
 @skip_py313
 @skip_py312
@@ -169,13 +174,35 @@ def test_inspect_builtin_function_except_python311():
 @pytest.mark.skipif(
     sys.version_info < (3, 11), reason="print builtin signature only available on 3.11+"
 )
+@skip_py315  # 3.15 renamed *args to *objects
 @skip_pypy3
 def test_inspect_builtin_function_only_python311():
-    # On 3.11, the print builtin *does* have a signature, unlike in prior versions
+    # On 3.11-3.14, the print builtin *does* have a signature with *args
     expected = (
         "╭────────── <built-in function print> ───────────╮\n"
         "│ def print(*args, sep=' ', end='\\n', file=None, │\n"
         "│ flush=False):                                  │\n"
+        "│                                                │\n"
+        "│ Prints the values to a stream, or to           │\n"
+        "│ sys.stdout by default.                         │\n"
+        "│                                                │\n"
+        "│ 30 attribute(s) not shown. Run                 │\n"
+        "│ inspect(inspect) for options.                  │\n"
+        "╰────────────────────────────────────────────────╯\n"
+    )
+    assert render(print) == expected
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 15), reason="print builtin uses *objects from 3.15+"
+)
+@skip_pypy3
+def test_inspect_builtin_function_only_python315():
+    # On 3.15+, the variadic parameter was renamed from *args to *objects
+    expected = (
+        "╭────────── <built-in function print> ───────────╮\n"
+        "│ def print(*objects, sep=' ', end='\\n',         │\n"
+        "│ file=None, flush=False):                       │\n"
         "│                                                │\n"
         "│ Prints the values to a stream, or to           │\n"
         "│ sys.stdout by default.                         │\n"


### PR DESCRIPTION



<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [X] Tests
- [ ] Other

## AI?

- [X] AI was used to generate this PR

For sure I used some help here. 

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

Nothing sensible to add to the CHANGELOG.md this is not declaration of 3.15 support of course.

## Description

signature change (*args -> *objects) with 3.15

I realise rich perfectly reasonably is not supporting 3.15 yet but this allow tests to pass on 3.15a8.


