### PR TITLE
fix: remove unused import and unnecessary f-string prefixes

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -2576,7 +2576,7 @@ class Console:
                 x=terminal_width // 2,
                 y=margin_top + char_height + 6,
             )
-        chrome += f"""
+        chrome += """
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -1265,7 +1265,7 @@ class Progress(JupyterMixin):
                 total_bytes = self._tasks[task_id].total
         if total_bytes is None:
             raise ValueError(
-                f"unable to get the total number of bytes, please specify 'total'"
+                "unable to get the total number of bytes, please specify 'total'"
             )
 
         # update total of task or create new task

--- a/rich/screen.py
+++ b/rich/screen.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
         ConsoleOptions,
         RenderResult,
         RenderableType,
-        Group,
     )
 
 


### PR DESCRIPTION
## Summary

- Remove unused `Group` import in `rich/screen.py` (ruff F401)
- Remove `f` prefix from strings with no `{...}` placeholders in `rich/progress.py` and `rich/console.py` (ruff F541)

3 files, 3 lines changed. All safe, mechanical lint fixes — zero behavior change.

Found by [HUMMBL Arbiter](https://hummbl.io/audit) — deterministic code quality scoring for Python repositories.