### PR TITLE
Fix ConsoleOptions propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Added `emoji` field to `console.ConsoleOptions` https://github.com/Textualize/rich/issues/4028
+- Fixed `ConsoleOptions` propagation https://github.com/Textualize/rich/issues/4028
 
 ## [15.0.0] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Added `emoji` field to `console.ConsoleOptions` https://github.com/Textualize/rich/issues/4028
+
 ## [14.3.3] - 2026-02-19
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,6 +76,7 @@ The following people have contributed to the development of Rich:
 - [Aaron Stephens](https://github.com/aaronst)
 - [Karolina Surma](https://github.com/befeleme)
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)
+- [Kevin Van Brunt](https://github.com/kmvanbrunt)
 - [Nils Vu](https://github.com/nilsvu)
 - [Arian Mollik Wasi](https://github.com/wasi-master)
 - [Jan van Wijk](https://github.com/jdvanwijk)

--- a/rich/columns.py
+++ b/rich/columns.py
@@ -64,7 +64,14 @@ class Columns(JupyterMixin):
     ) -> RenderResult:
         render_str = console.render_str
         renderables = [
-            render_str(renderable) if isinstance(renderable, str) else renderable
+            render_str(
+                renderable,
+                markup=options.markup,
+                emoji=options.emoji,
+                highlight=False,
+            )
+            if isinstance(renderable, str)
+            else renderable
             for renderable in self.renderables
         ]
         if not renderables:

--- a/rich/console.py
+++ b/rich/console.py
@@ -143,6 +143,8 @@ class ConsoleOptions:
     """Highlight override for render_str."""
     markup: Optional[bool] = None
     """Enable markup when rendering strings."""
+    emoji: Optional[bool] = None
+    """Enable emoji code."""
     height: Optional[int] = None
 
     @property
@@ -171,6 +173,7 @@ class ConsoleOptions:
         no_wrap: Union[Optional[bool], NoChange] = NO_CHANGE,
         highlight: Union[Optional[bool], NoChange] = NO_CHANGE,
         markup: Union[Optional[bool], NoChange] = NO_CHANGE,
+        emoji: Union[Optional[bool], NoChange] = NO_CHANGE,
         height: Union[Optional[int], NoChange] = NO_CHANGE,
     ) -> "ConsoleOptions":
         """Update values, return a copy."""
@@ -191,6 +194,8 @@ class ConsoleOptions:
             options.highlight = highlight
         if not isinstance(markup, NoChange):
             options.markup = markup
+        if not isinstance(emoji, NoChange):
+            options.emoji = emoji
         if not isinstance(height, NoChange):
             if height is not None:
                 options.max_height = height
@@ -1325,7 +1330,10 @@ class Console:
             render_iterable = renderable.__rich_console__(self, _options)
         elif isinstance(renderable, str):
             text_renderable = self.render_str(
-                renderable, highlight=_options.highlight, markup=_options.markup
+                renderable,
+                highlight=_options.highlight,
+                markup=_options.markup,
+                emoji=_options.emoji,
             )
             render_iterable = text_renderable.__rich_console__(self, _options)
         else:
@@ -1714,6 +1722,7 @@ class Console:
                 no_wrap=no_wrap,
                 markup=markup,
                 highlight=highlight,
+                emoji=emoji,
             )
 
             new_segments: List[Segment] = []
@@ -2005,7 +2014,12 @@ class Console:
             new_segments: List[Segment] = []
             extend = new_segments.extend
             render = self.render
-            render_options = self.options
+            render_options = self.options.update(
+                justify=justify,
+                emoji=emoji,
+                markup=markup,
+                highlight=highlight,
+            )
             for renderable in renderables:
                 extend(render(renderable, render_options))
             buffer_extend = self._buffer.extend

--- a/rich/measure.py
+++ b/rich/measure.py
@@ -97,7 +97,7 @@ class Measurement(NamedTuple):
             return Measurement(0, 0)
         if isinstance(renderable, str):
             renderable = console.render_str(
-                renderable, markup=options.markup, highlight=False
+                renderable, markup=options.markup, emoji=options.emoji, highlight=False
             )
         renderable = rich_cast(renderable)
         if is_renderable(renderable):

--- a/rich/rule.py
+++ b/rich/rule.py
@@ -65,7 +65,13 @@ class Rule(JupyterMixin):
         if isinstance(self.title, Text):
             title_text = self.title
         else:
-            title_text = console.render_str(self.title, style="rule.text")
+            title_text = console.render_str(
+                self.title,
+                style="rule.text",
+                markup=options.markup,
+                emoji=options.emoji,
+                highlight=False,
+            )
 
         title_text.plain = title_text.plain.replace("\n", " ")
         title_text.expand_tabs()

--- a/rich/table.py
+++ b/rich/table.py
@@ -498,7 +498,13 @@ class Table(JupyterMixin):
             text: TextType, style: StyleType, justify: "JustifyMethod" = "center"
         ) -> "RenderResult":
             render_text = (
-                console.render_str(text, style=style, highlight=False)
+                console.render_str(
+                    text,
+                    style=style,
+                    highlight=False,
+                    markup=render_options.markup,
+                    emoji=render_options.emoji,
+                )
                 if isinstance(text, str)
                 else text
             )

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -75,3 +75,29 @@ if __name__ == "__main__":
     result = render()
     print(result)
     print(repr(result))
+
+
+def test_columns_emoji_propagation():
+    console = Console()
+    columns = Columns([":1234:"])
+
+    with console.capture() as capture:
+        console.print(columns, emoji=True)
+    assert "🔢" in capture.get()
+
+    with console.capture() as capture:
+        console.print(columns, emoji=False)
+    assert ":1234:" in capture.get()
+
+
+def test_columns_markup_propagation():
+    console = Console(force_terminal=True, _environ={})
+    columns = Columns(["[blue]text[/blue]"])
+
+    with console.capture() as capture:
+        console.print(columns, markup=True)
+    assert "\x1b[34mtext\x1b[0m" in capture.get()
+
+    with console.capture() as capture:
+        console.print(columns, markup=False)
+    assert "[blue]text[/blue]" in capture.get()

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -841,6 +841,24 @@ def test_update_options_markup() -> None:
     assert options.update(markup=True).markup == True
 
 
+def test_update_options_emoji() -> None:
+    console = Console()
+    options = console.options
+    assert options.update(emoji=False).emoji == False
+    assert options.update(emoji=True).emoji == True
+
+
+def test_print_emoji() -> None:
+    console = Console()
+    with console.capture() as capture:
+        console.print(":1234:", emoji=True)
+    assert "🔢" in capture.get()
+
+    with console.capture() as capture:
+        console.print(":1234:", emoji=False)
+    assert ":1234:" in capture.get()
+
+
 def test_print_width_zero() -> None:
     console = Console()
     with console.capture() as capture:

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -34,3 +34,13 @@ def test_clamp():
     assert measurement.clamp(None, 50) == Measurement(20, 50)
     assert measurement.clamp(30, None) == Measurement(30, 100)
     assert measurement.clamp(None, None) == Measurement(20, 100)
+
+
+def test_measurement_emoji_propagation():
+    console = Console()
+    options = console.options
+
+    m_emoji = Measurement.get(console, options.update(emoji=True), ":1234:")
+    m_no_emoji = Measurement.get(console, options.update(emoji=False), ":1234:")
+
+    assert m_emoji.maximum < m_no_emoji.maximum

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -128,3 +128,29 @@ def test_repr():
 def test_error():
     with pytest.raises(ValueError):
         Rule(characters="")
+
+
+def test_rule_emoji_propagation():
+    console = Console()
+    rule = Rule(title=":1234:")
+
+    with console.capture() as capture:
+        console.print(rule, emoji=True)
+    assert "🔢" in capture.get()
+
+    with console.capture() as capture:
+        console.print(rule, emoji=False)
+    assert ":1234:" in capture.get()
+
+
+def test_rule_markup_propagation():
+    console = Console(force_terminal=True, _environ={})
+    rule = Rule(title="[blue]text[/blue]")
+
+    with console.capture() as capture:
+        console.print(rule, markup=True)
+    assert "\x1b[34mtext\x1b[0m" in capture.get()
+
+    with console.capture() as capture:
+        console.print(rule, markup=False)
+    assert "[blue]text[/blue]" in capture.get()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -410,3 +410,31 @@ if __name__ == "__main__":
     render = render_tables()
     print(render)
     print(repr(render))
+
+
+def test_table_emoji_propagation():
+    console = Console()
+    table = Table()
+    table.add_row(":1234:")
+
+    with console.capture() as capture:
+        console.print(table, emoji=True)
+    assert "🔢" in capture.get()
+
+    with console.capture() as capture:
+        console.print(table, emoji=False)
+    assert ":1234:" in capture.get()
+
+
+def test_table_markup_propagation():
+    console = Console(force_terminal=True, _environ={})
+    table = Table()
+    table.add_row("[blue]text[/blue]")
+
+    with console.capture() as capture:
+        console.print(table, markup=True)
+    assert "\x1b[34mtext\x1b[0m" in capture.get()
+
+    with console.capture() as capture:
+        console.print(table, markup=False)
+    assert "[blue]text[/blue]" in capture.get()


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [X] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes #4028 

1. Added the `emoji` field to `ConsoleOptions`, allowing `emoji` overrides passed to `console.print()` to be propagated down the rendering stack.

2. Fixed several instances (`Table`, `Rule`, `Columns`, and `Measure`) where the renderables were calling `console.render_str()` but failing to pass the some or all of `emoji`, `markup`, and `highlight` settings from the active `ConsoleOptions`.
