### PR TITLE
Fix __notes__ leaking across chained exceptions (#3960)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed `__notes__` from the outermost exception being shown on every exception in a chain; notes are now rendered only on the specific exception they were added to https://github.com/Textualize/rich/issues/3960
+
 ## [14.3.3] - 2026-02-19
 
 ### Fixed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -75,6 +75,7 @@ The following people have contributed to the development of Rich:
 - [Nicolas Simonds](https://github.com/0xDEC0DE)
 - [Aaron Stephens](https://github.com/aaronst)
 - [Karolina Surma](https://github.com/befeleme)
+- [Kanchan Thapa](https://github.com/kanchanthapa)
 - [Gabriele N. Tornetta](https://github.com/p403n1x87)
 - [Nils Vu](https://github.com/nilsvu)
 - [Arian Mollik Wasi](https://github.com/wasi-master)

--- a/rich/traceback.py
+++ b/rich/traceback.py
@@ -467,8 +467,6 @@ class Traceback:
 
         from rich import _IMPORT_CWD
 
-        notes: List[str] = getattr(exc_value, "__notes__", None) or []
-
         grouped_exceptions: Set[BaseException] = (
             set() if _visited_exceptions is None else _visited_exceptions
         )
@@ -481,6 +479,12 @@ class Traceback:
                 return "<exception str() failed>"
 
         while True:
+            # Read __notes__ from the current exception in the chain, not the
+            # outermost one. Fixes https://github.com/Textualize/rich/issues/3960
+            # where notes from the outer exception leaked onto every inner
+            # exception via the shared list reference.
+            notes: List[str] = getattr(exc_value, "__notes__", None) or []
+
             stack = Stack(
                 exc_type=safe_str(exc_type.__name__),
                 exc_value=safe_str(exc_value),

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -375,6 +375,52 @@ def test_notes() -> None:
         assert traceback.trace.stacks[0].notes == ["Hello", "World"]
 
 
+@pytest.mark.skipif(
+    sys.version_info.minor < 11, reason="Not supported before Python 3.11"
+)
+def test_notes_isolated_per_exception_in_chain() -> None:
+    """Regression test for https://github.com/Textualize/rich/issues/3960
+
+    __notes__ added to one exception in a chain must not leak onto other
+    exceptions in the chain. Matches CPython's traceback module behavior.
+    """
+    # __cause__ chain (explicit ``raise ... from ...``)
+    try:
+        try:
+            raise ValueError("inner")
+        except ValueError as exc:
+            raise RuntimeError("outer") from exc
+    except RuntimeError as err:
+        err.add_note("note-on-outer-only")
+        traceback = Traceback()
+
+    stacks = traceback.trace.stacks
+    # stacks[0] is the outermost (RuntimeError), stacks[1] is the cause
+    # (ValueError). The note must appear only on the outer stack.
+    assert stacks[0].exc_type == "RuntimeError"
+    assert stacks[0].notes == ["note-on-outer-only"]
+    assert stacks[1].exc_type == "ValueError"
+    assert stacks[1].notes == []
+
+    # __context__ chain (implicit chaining) with a note only on the inner
+    # exception in source order (the context). The outer should have no notes.
+    try:
+        try:
+            err = ValueError("context-inner")
+            err.add_note("note-on-context-only")
+            raise err
+        except ValueError:
+            raise RuntimeError("context-outer")
+    except RuntimeError:
+        traceback = Traceback()
+
+    stacks = traceback.trace.stacks
+    assert stacks[0].exc_type == "RuntimeError"
+    assert stacks[0].notes == []
+    assert stacks[1].exc_type == "ValueError"
+    assert stacks[1].notes == ["note-on-context-only"]
+
+
 def test_recursive_exception() -> None:
     """Regression test for https://github.com/Textualize/rich/issues/3708
 


### PR DESCRIPTION
When rendering a chained exception, Rich previously read __notes__ once from the outermost exception and reused the same list reference on every Stack built inside the while-loop. This caused notes added to one exception to appear on every exception in the chain, which contradicts CPython's native traceback module behavior (notes are only rendered on the specific exception they were added to via PEP 678's add_note()).

Move the __notes__ assignment inside the extraction loop so each exception contributes its own notes. Covers __cause__, __context__, and ExceptionGroup chains.

Adds test_notes_isolated_per_exception_in_chain covering both __cause__ and __context__ chaining.


<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [x ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ x] Tests
- [ ] Other

## AI?

- [x ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here.

Fixes #3960.

When displaying a chained exception whose `__notes__` were only added to
the outermost exception, Rich rendered those notes under every exception
in the chain instead of only on the one they were added to. This
contradicts CPython's built-in traceback behavior.

### Root cause

`Traceback.extract()` reads `exc_value.__notes__` into a local variable
*once*, before the `while True` loop that walks `__cause__` / `__context__`.
Every `Stack` built inside the loop then shares the same list reference,
so every stack ends up with the outermost exception's notes.

### Fix

Move the `notes = getattr(exc_value, "__notes__", None) or []` assignment
inside the loop so each iteration reads from the current `exc_value`.

### Test

Added `test_notes_isolated_per_exception_in_chain` covering both
`__cause__` (explicit `raise ... from ...`) and `__context__` (implicit
chaining) cases.

### QA

- `pytest` — 953 passed, 25 skipped
- `mypy -p rich` — no issues
- `black --check rich/traceback.py tests/test_traceback.py` — unchanged
- Coverage on `rich/traceback.py` unchanged at 88%

### AI disclosure

Per `AI_POLICY.md`: drafted with the assistance of Claude (Anthropic). The
fix approach matches the root-cause analysis posted in issue #3960 by the
reporter; I have reviewed every line and run the full QA pipeline locally.

### Before / after

Before (bug):



**Important:** Link to an issue or discussion regarding these changes. 
