### PR TITLE
fix(ansi): handle CRLF line endings in AnsiDecoder.decode

### DIFF
--- a/rich/ansi.py
+++ b/rich/ansi.py
@@ -133,7 +133,7 @@ class AnsiDecoder:
             Text: Marked up Text.
         """
         for line in re.split(r"(?<=\n)", terminal_text):
-            yield self.decode_line(line.rstrip("\n"))
+            yield self.decode_line(line.rstrip("\n\r"))
 
     def decode_line(self, line: str) -> Text:
         """Decode a line containing ansi codes.


### PR DESCRIPTION
When `Text.from_ansi()` receives a string with CRLF (\\r\\n) line endings, every line of content is lost — the result is all empty strings.

**Root cause:** `AnsiDecoder.decode()` splits on \\n, strips trailing \\n via `.rstrip("\n")`, then passes each line to `decode_line()`, which runs `.rsplit("\r", 1)[-1]` to handle terminal carriage-return overwrite semantics. When the input has CRLF endings, a bare \\r remains after stripping; `decode_line` interprets that trailing \\r as an overwrite and returns the (empty) portion after it.

**Fix:** strip trailing \\r alongside \\n in `decode()`: `.rstrip("\n\r")`.

**Reproduction:**
```python
from rich.text import Text
# Before fix: plain == '\\n\\n'  
# After fix:  plain == 'Hello\\nWorld\\n'
Text.from_ansi('Hello\\r\\nWorld\\r\\n').plain
```

Closes #4090