### PR TITLE
Use safe blockquote prefix on legacy Windows

### DIFF
--- a/rich/markdown.py
+++ b/rich/markdown.py
@@ -208,7 +208,9 @@ class BlockQuote(TextElement):
         lines = console.render_lines(self.elements, render_options, style=self.style)
         style = self.style
         new_line = Segment("\n")
-        padding = Segment("▌ ", style)
+        quote_bar = "| " if options.legacy_windows or options.ascii_only else "▌ "
+        padding = Segment(quote_bar, style)
+
         for line in lines:
             yield padding
             yield from line

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -215,6 +215,20 @@ def test_inline_code_in_table_cells() -> None:
     assert result == expected
 
 
+def test_markdown_blockquote_uses_safe_prefix_on_legacy_windows():
+    console = Console(
+        width=40,
+        file=io.StringIO(),
+        color_system=None,
+        legacy_windows=True,
+        _environ={},
+    )
+    console.print(Markdown("> hello"))
+    output = console.file.getvalue()
+    assert "| hello" in output
+    assert "▌" not in output
+
+
 if __name__ == "__main__":
     markdown = Markdown(MARKDOWN)
     rendered = render(markdown)


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [X ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [X ] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [X ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [X ] I've added tests for new code.
- [ X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here.
Fixes Markdown blockquote rendering on legacy Windows / restricted encodings by falling back from ▌ to | when the output environment is not safe for the Unicode block character. Normal environments still use the original blockquote marker. A regression test was added to verify the safe fallback behavior.

**Important:** Link to an issue or discussion regarding these changes. 
