### PR TITLE
Fix RichHandler surrogate logging on strict utf-8 streams

### DIFF
--- a/rich/logging.py
+++ b/rich/logging.py
@@ -198,6 +198,15 @@ class RichHandler(Handler):
             ConsoleRenderable: Renderable to display log message.
         """
         use_markup = getattr(record, "markup", self.markup)
+
+        encoding = getattr(self.console.file, "encoding", None)
+        errors = getattr(self.console.file, "errors", None) or "strict"
+        if encoding and errors == "strict":
+            try:
+                message.encode(encoding)
+            except UnicodeEncodeError:
+                message = message.encode(encoding, "backslashreplace").decode(encoding)
+
         message_text = Text.from_markup(message) if use_markup else Text(message)
 
         highlighter = getattr(record, "highlighter", self.highlighter)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -160,3 +160,43 @@ def test_markup_and_highlight():
     render_plain = handler.console.file.getvalue()
     assert "FORMATTER" in render_plain
     assert log_message in render_plain
+
+
+def test_unicode_surrogate_message_is_escaped(tmp_path) -> None:
+    log_path = tmp_path / "rich-unicode.log"
+    actual_record: Optional[logging.LogRecord] = None
+
+    with log_path.open("w", encoding="utf-8", errors="strict") as log_file:
+        console = Console(file=log_file, force_terminal=False, _environ={})
+        handler = RichHandler(
+            console=console,
+            show_time=False,
+            show_level=False,
+            show_path=False,
+        )
+
+        def mock_handle_error(record):
+            nonlocal actual_record
+            actual_record = record
+
+        handler.handleError = mock_handle_error
+
+        logger = logging.getLogger("rich.unicode_surrogate")
+        previous_handlers = logger.handlers[:]
+        previous_propagate = logger.propagate
+        previous_level = logger.level
+
+        logger.handlers = [handler]
+        logger.propagate = False
+        logger.setLevel("INFO")
+
+        try:
+            logger.info("\udcf1")
+            log_file.flush()
+        finally:
+            logger.handlers = previous_handlers
+            logger.propagate = previous_propagate
+            logger.setLevel(previous_level)
+
+    assert actual_record is None
+    assert "\\udcf1" in log_path.read_text(encoding="utf-8")


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [ X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [X ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [X ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [ X] I've added tests for new code.
- [ X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes a UnicodeEncodeError in RichHandler when logging messages contain surrogate characters and the target stream uses strict UTF-8 encoding. The handler now escapes unencodable messages before constructing the final Rich text object, which preserves logging output instead of crashing. A regression test was added to cover strict UTF-8 stream behavior.
**Important:** Link to an issue or discussion regarding these changes. 
