### PR TITLE
Remove redundant min() after guards in Span

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@ The following people have contributed to the development of Rich:
 - [Jim Crist-Harif](https://github.com/jcrist)
 - [Ed Davis](https://github.com/davised)
 - [Pete Davison](https://github.com/pd93)
+- [Aayush Digikar](https://github.com/Ironsing)
 - [James Estevez](https://github.com/jstvz)
 - [Jonathan Eunice](https://github.com/jonathan-3play)
 - [Aryaz Eghbali](https://github.com/AryazE)

--- a/rich/text.py
+++ b/rich/text.py
@@ -69,7 +69,7 @@ class Span(NamedTuple):
             return self, None
 
         start, end, style = self
-        span1 = Span(start, min(end, offset), style)
+        span1 = Span(start, offset, style)
         span2 = Span(span1.end, end, style)
         return span1, span2
 
@@ -97,7 +97,7 @@ class Span(NamedTuple):
         start, end, style = self
         if offset >= end:
             return self
-        return Span(start, min(offset, end), style)
+        return Span(start, offset, style)
 
     def extend(self, cells: int) -> "Span":
         """Extend the span by the given number of cells.


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Removes redundant calls to min() in Span.right_crop and Span.split, since these have guard clauses right before the redundant call.
