### PR TITLE
fix(ansi): handle CRLF line endings in Text.from_ansi

### DIFF
--- a/rich/ansi.py
+++ b/rich/ansi.py
@@ -132,6 +132,7 @@ class AnsiDecoder:
         Yields:
             Text: Marked up Text.
         """
+        terminal_text = terminal_text.replace("\r\n", "\n")
         for line in re.split(r"(?<=\n)", terminal_text):
             yield self.decode_line(line.rstrip("\n"))
 

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -102,3 +102,16 @@ def test_decode_newlines():
     assert Text.from_ansi("Hello\nWorld\n").plain == "Hello\nWorld\n"
     assert Text.from_ansi("Hello\nWorld\n\n").plain == "Hello\nWorld\n\n"
     assert Text.from_ansi("\nHello\nWorld\n\n").plain == "\nHello\nWorld\n\n"
+
+
+def test_decode_crlf():
+    """Test CRLF line endings are handled correctly.
+    Regression test for https://github.com/Textualize/rich/issues/4090
+    """
+    assert Text.from_ansi("Hello\r\nWorld\r\n").plain == "Hello\nWorld\n"
+    assert Text.from_ansi("Hello\r\n").plain == "Hello\n"
+    assert Text.from_ansi("\r\nHello\r\n").plain == "\nHello\n"
+    assert Text.from_ansi("Hello\r\n\r\nWorld").plain == "Hello\n\nWorld"
+    # Mixed line endings
+    assert Text.from_ansi("Hello\nWorld\r\n").plain == "Hello\nWorld\n"
+    assert Text.from_ansi("Hello\r\nWorld\n").plain == "Hello\nWorld\n"


### PR DESCRIPTION
## Problem

Fixes #4090.

When `Text.from_ansi` is given input with CRLF (`\r\n`) line endings, all text content is lost and only empty lines remain.

Reproduction:

```python
from rich.text import Text
Text.from_ansi("Hello\r\nWorld\r\n").plain
# Actual: '\n\n'
# Expected: 'Hello\nWorld\n'
```

## Analysis

The root cause is an interaction between line splitting and carriage-return handling:

1. `AnsiDecoder.decode()` splits on `\n` using `re.split(r"(?<=\n)", ...)`, keeping the `\n` attached to the preceding line.
2. After stripping `\n`, a line that originally ended with `\r\n` becomes `...\r`.
3. `decode_line()` then calls `line.rsplit("\r", 1)[-1]` to simulate terminal carriage-return behavior (where `\r` moves the cursor to the start of the line, effectively overwriting prior content).
4. For a line ending in `\r` (from CRLF), `rsplit("\r", 1)[-1]` returns the empty string after the final `\r`, discarding all content.

## Solution

Normalize `\r\n` to `\n` in `decode()` before splitting. This treats CRLF as a plain line-ending sequence rather than a terminal carriage-return that overwrites content.

The fix is a single line:

```python
terminal_text = terminal_text.replace("\r\n", "\n")
```

This preserves the existing behavior of standalone `\r` (used in progress bars and terminal updates) while correctly handling CRLF line endings common on Windows and in network protocols.

## Benchmarks / Verification

- All 957 existing tests pass (25 skipped).
- Added `test_decode_crlf` covering:
  - Simple CRLF: `"Hello\r\nWorld\r\n"`
  - Leading CRLF: `"\r\nHello\r\n"`
  - Consecutive CRLF: `"Hello\r\n\r\nWorld"`
  - Mixed line endings: `"Hello\nWorld\r\n"` and `"Hello\r\nWorld\n"`

## Notes

- This is a minimal, localized change with no API surface changes.
- Standalone `\r` (without following `\n`) continues to work as before, since the replace only targets the `\r\n` sequence.