### PR TITLE
Preserve CRLF content in ANSI decoding

### DIFF
--- a/rich/ansi.py
+++ b/rich/ansi.py
@@ -132,6 +132,7 @@ class AnsiDecoder:
         Yields:
             Text: Marked up Text.
         """
+        terminal_text = terminal_text.replace("\r\n", "\n")
         for line in re.split(r"(?<=\n)", terminal_text):
             yield self.decode_line(line.rstrip("\n"))
 

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -102,3 +102,8 @@ def test_decode_newlines():
     assert Text.from_ansi("Hello\nWorld\n").plain == "Hello\nWorld\n"
     assert Text.from_ansi("Hello\nWorld\n\n").plain == "Hello\nWorld\n\n"
     assert Text.from_ansi("\nHello\nWorld\n\n").plain == "\nHello\nWorld\n\n"
+
+
+def test_decode_crlf_newlines():
+    """CRLF input should preserve line content instead of being treated as CR overwrite."""
+    assert Text.from_ansi("Hello\r\nWorld\r\n").plain == "Hello\nWorld\n"

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -116,6 +116,15 @@ def test_from_ansi():
     assert text._spans == [Span(0, 11, Style(bold=True))]
 
 
+def test_from_ansi_crlf():
+    text = Text.from_ansi("Hello, \033[1mWorld!\r\nNext\033[0m")
+    assert str(text) == "Hello, World!\nNext"
+    assert text._spans == [
+        Span(7, 13, Style(bold=True)),
+        Span(14, 18, Style(bold=True)),
+    ]
+
+
 def test_copy():
     text = Text()
     text.append("Hello", "bold")


### PR DESCRIPTION
## Summary
- normalize CRLF line endings before ANSI line splitting
- preserve `Text.from_ansi()` content for CRLF input while leaving lone `\r` overwrite handling unchanged
- add regression coverage for both plain and styled CRLF inputs

Closes #4090.

## Validation
- baseline repro on current `master`: `Text.from_ansi("Hello\r\nWorld\r\n").plain` returned `"\n\n"`
- `.venv/bin/python -m pytest tests/test_ansi.py::test_decode_crlf_newlines tests/test_text.py::test_from_ansi_crlf -q`
- `.venv/bin/python -m pytest tests/test_ansi.py tests/test_text.py -q`
- direct repro after fix: `Text.from_ansi("Hello\r\nWorld\r\n").plain == "Hello\nWorld\n"`

## Gates
- `E1` baseline repro exists: yes
- `E2` new regression tests fail on baseline: yes
- `E3` new regression tests pass after fix: yes
- `E4` nearby targeted suite passes: yes
- `E5` diff localized to `rich/ansi.py`, `tests/test_ansi.py`, and `tests/test_text.py`: yes
