### PR TITLE
Fix Set `is_jupyter=True` on Jupyterlite

### DIFF
--- a/rich/console.py
+++ b/rich/console.py
@@ -508,14 +508,18 @@ def _is_jupyter() -> bool:  # pragma: no cover
         get_ipython  # type: ignore[name-defined]
     except NameError:
         return False
+
     ipython = get_ipython()  # type: ignore[name-defined]
+    ipython_cls_str = str(ipython.__class__)
     shell = ipython.__class__.__name__
+
     if (
-        "google.colab" in str(ipython.__class__)
+        "google.colab" in ipython_cls_str
+        or "pyodide" in ipython_cls_str
         or os.getenv("DATABRICKS_RUNTIME_VERSION")
         or shell == "ZMQInteractiveShell"
     ):
-        return True  # Jupyter notebook or qtconsole
+        return True  # Jupyter notebook, Jupyterlite or qtconsole
     elif shell == "TerminalInteractiveShell":
         return False  # Terminal running IPython
     else:

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1133,3 +1133,15 @@ def test_tty_compatible() -> None:
     assert not console.is_terminal
     # Should not have auto-detected
     assert not console.file.called_isatty
+
+
+def test_is_jupyter_in_jupyterlite(monkeypatch):
+    monkeypatch.setattr(
+        "rich.console.get_ipython",
+        type("Interpreter", (object,), {"__module__": "pyodide_kernel.interpreter"}),
+        raising=False,
+    )
+
+    console = Console(file=io.StringIO(), force_jupyter=None)
+
+    assert console.is_jupyter


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

When working on jupyterlite, the `console` is now in `jupyter` mode when the console is created without `force_jupyter` value.
