### PR TITLE
Fix hyperlinks being split into multiple links when text is highlighted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- hyperlinks being split into multiple links when text is highlighted https://github.com/Textualize/rich/pull/4110
+
 ## [15.0.0] - 2026-04-12
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -101,3 +101,4 @@ The following people have contributed to the development of Rich:
 - [Alex Zheng](https://github.com/alexzheng111)
 - [Sebastian Speitel](https://github.com/SebastianSpeitel)
 - [Kevin Turcios](https://github.com/KRRT7)
+- [Filipe Brandenburger](https://github.com/filbranden)

--- a/rich/style.py
+++ b/rich/style.py
@@ -730,7 +730,7 @@ class Style:
         sys.stdout.write(f"{self.render(text)}\n")
 
     @lru_cache(maxsize=1024)
-    def _add(self, style: Optional["Style"]) -> "Style":
+    def _add(self, style: Optional["Style"], link_id: str) -> "Style":
         if style is None or style._null:
             return self
         if self._null:
@@ -745,7 +745,7 @@ class Style:
         )
         new_style._set_attributes = self._set_attributes | style._set_attributes
         new_style._link = style._link or self._link
-        new_style._link_id = style._link_id or self._link_id
+        new_style._link_id = link_id
         new_style._null = style._null
         if self._meta and style._meta:
             new_style._meta = dumps({**self.meta, **style.meta})
@@ -755,8 +755,11 @@ class Style:
         return new_style
 
     def __add__(self, style: Optional["Style"]) -> "Style":
-        combined_style = self._add(style)
-        return combined_style.copy() if combined_style.link else combined_style
+        if style is not None and style._link_id:
+            link_id = style._link_id
+        else:
+            link_id = self._link_id
+        return self._add(style, link_id)
 
 
 NULL_STYLE = Style()

--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -461,3 +461,31 @@ def test_highlight_iso8601_regex(test: str, spans: List[Span]):
     highlighter.highlight(text)
     print(text.spans)
     assert text.spans == spans
+
+
+def test_highlighter_preserves_link_across_spans():
+    """Ensure a link with highlighted text tokens renders as a single link.
+
+    A hyperlink whose text contains tokens the ReprHighlighter recognises
+    (UUID, path, filename) must render as a single clickable link.
+    """
+    from rich.console import Console
+
+    markup = (
+        "Error in job [link=https://www.example.com/issues/42]"
+        "78351748-9b32-4e08-ad3e-7e9ff124d541: see /var/log/myapp.log"
+        "[/link] for details"
+    )
+
+    console = Console(highlight=True)
+    text = console.render_str(markup)
+
+    link_ids = {
+        seg.style._link_id
+        for seg in console.render(text)
+        if seg.style and seg.style.link
+    }
+
+    assert (
+        len(link_ids) == 1
+    ), f"Expected a single link_id across all highlighted spans, got {len(link_ids)}"

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -265,3 +265,21 @@ def test_clear_meta_and_links_clears_hash():
 
     clear_style = style.clear_meta_and_links()
     assert clear_style._hash is None
+
+
+def test_add_distinct_link_ids_for_equal_link_styles():
+    """Regression test for the cache-conflation issue when lru_cache was introduced.
+
+    Two Style(link=...) objects with the same URL are equal by hash and
+    comparison, but carry different _link_id values. Combining each with a base
+    style must yield combined styles with distinct _link_ids; the lru_cache
+    must not cause the second result to inherit the first's _link_id.
+    """
+
+    s1 = Style(link="https://example.com")
+    s2 = Style(link="https://example.com")
+    assert s1 == s2  # same hash and content
+    assert s1.link_id != s2.link_id  # but distinct link ids
+
+    base = Style(bold=True)
+    assert (base + s1).link_id != (base + s2).link_id

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -275,11 +275,45 @@ def test_add_distinct_link_ids_for_equal_link_styles():
     style must yield combined styles with distinct _link_ids; the lru_cache
     must not cause the second result to inherit the first's _link_id.
     """
-
     s1 = Style(link="https://example.com")
     s2 = Style(link="https://example.com")
     assert s1 == s2  # same hash and content
     assert s1.link_id != s2.link_id  # but distinct link ids
 
     base = Style(bold=True)
+    assert (base + s1).link_id != (base + s2).link_id
+
+
+def test_add_preserves_link_id_with_identical_meta():
+    """Test that add preserves link_id.
+
+    Two Style.from_meta() calls with identical content share the same hash, so
+    they collide in _add's lru_cache. Each must still produce a combined style
+    that carries its own distinct link_id.
+    """
+    meta = {"click": "something"}
+    s1 = Style.from_meta(meta)
+    s2 = Style.from_meta(meta)
+    assert s1.link_id != s2.link_id  # precondition: distinct ids
+
+    base = Style(color="red")
+    assert (base + s1).link_id == s1.link_id
+    assert (base + s2).link_id == s2.link_id
+
+
+def test_add_distinct_link_ids_with_identical_meta():
+    """Test that adding with distinct link_id's will produce distinct list_id's.
+
+    Regression test for Textualize/textual#1587.
+
+    Two Style.from_meta() calls with identical content produce styles with different
+    _link_id values. Combining each with a base style must keep those ids distinct.
+    The cache must not cause the second result to inherit the first's link_id.
+    """
+    meta = {"click": "something"}
+    s1 = Style.from_meta(meta)
+    s2 = Style.from_meta(meta)
+    assert s1.link_id != s2.link_id  # precondition: distinct ids
+
+    base = Style(color="red")
     assert (base + s1).link_id != (base + s2).link_id


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [x] AI was used to generate this PR

I used Claude Sonnet 4.6 to work on this fix, it was fully reviewed by a human though. The process went roughly as follows:
- Claude initially suggested just dropping the `copy()` call, I told it there was probably a reason why it was there, so I asked it to figure that out and add a test that would ensure that behavior was preserved.
- Claude then suggested a lighter approach to creating the copied style, which ended in an uncached refactor of _add that would get called in that specific situation. This looked acceptable. I asked Claude to add appropriate tests.
- Then I realized if the issue was the lru_cache, we could fix it by passing the expected link_id as an argument, which would turn into a key for the lru_cache. In a sense, this seems more efficient because we don't need to copy or recreate or discard a style object. On the other hand, it might have side effects on the lru_cache itself, so I count on code review to confirm this is an appropriate approach.
- I also asked Claude to add a specific test involving the highlighter, since that's the specific issue I was trying to fix.

I understand there wasn't discussion in the issue itself, I hope this PR with the code might serve as a starting point for discussion with a proposed code change that I'm willing to iterate on. Thanks!

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review. YES PLEASE!

## Description

`Style.__add__` was calling `copy()` on every combined style that contained a
    link, which generated a fresh link_id for each highlighted sub-span within
    a single link markup region. Terminals use link_id to identify hyperlink
    boundaries, so each sub-span appeared as a separate clickable link instead
    of one continuous one.

The underlying root cause is that `_add`'s lru_cache keys on `__hash__`/`__eq__`,
    which intentionally excludes link_id. Two Style objects with the same visual
    content but different link_ids therefore collide in the cache; copy() was
    a blunt workaround that overcorrected by regenerating the id on every hit.

Fix this by having `_add` take the link_id as an argument so that the lru_cache
    will now also key by link_id, preventing the issue that required the `copy()`
    workaround altogether.

Add test cases to confirm the issue is fixed and include regression tests to prevent it from getting broken again in the future.

Fixes #4109.
