### PR TITLE
Fix hyperlinks split into multiple clickable links by text highlighters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed hyperlinks being split into multiple clickable links when the link text contains tokens recognized by `ReprHighlighter` (e.g. UUIDs, file paths) https://github.com/Textualize/rich/issues/4109
+
 ## [15.0.0] - 2026-04-12
 
 ### Changed

--- a/rich/style.py
+++ b/rich/style.py
@@ -730,7 +730,7 @@ class Style:
         sys.stdout.write(f"{self.render(text)}\n")
 
     @lru_cache(maxsize=1024)
-    def _add(self, style: Optional["Style"]) -> "Style":
+    def _add(self, style: Optional["Style"], link_id: str) -> "Style":
         if style is None or style._null:
             return self
         if self._null:
@@ -745,7 +745,7 @@ class Style:
         )
         new_style._set_attributes = self._set_attributes | style._set_attributes
         new_style._link = style._link or self._link
-        new_style._link_id = style._link_id or self._link_id
+        new_style._link_id = link_id
         new_style._null = style._null
         if self._meta and style._meta:
             new_style._meta = dumps({**self.meta, **style.meta})
@@ -755,8 +755,8 @@ class Style:
         return new_style
 
     def __add__(self, style: Optional["Style"]) -> "Style":
-        combined_style = self._add(style)
-        return combined_style.copy() if combined_style.link else combined_style
+        link_id = (style._link_id if style is not None else "") or self._link_id
+        return self._add(style, link_id)
 
 
 NULL_STYLE = Style()

--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -461,3 +461,36 @@ def test_highlight_iso8601_regex(test: str, spans: List[Span]):
     highlighter.highlight(text)
     print(text.spans)
     assert text.spans == spans
+
+
+def test_highlighter_preserves_link_across_spans():
+    """Regression test for https://github.com/Textualize/rich/issues/4109.
+
+    Applying ReprHighlighter to text that already has a hyperlink must not
+    fragment the link into multiple clickable regions.  Every rendered segment
+    that carries a link must share the same link_id as the original.
+    """
+    from io import StringIO
+
+    from rich.console import Console
+    from rich.style import Style
+
+    uuid = "12345678-1234-5678-1234-567812345678"
+    link_style = Style(link="https://example.com")
+    text = Text(uuid, style=link_style)
+
+    highlighter = ReprHighlighter()
+    highlighter.highlight(text)
+
+    console = Console(file=StringIO(), highlight=False)
+    segments = list(text.render(console))
+
+    original_link_id = link_style.link_id
+    link_ids = {
+        seg.style.link_id
+        for seg in segments
+        if seg.style is not None and seg.style.link
+    }
+    assert link_ids == {original_link_id}, (
+        f"Expected single link_id {original_link_id!r}, got {link_ids!r}"
+    )

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -265,3 +265,36 @@ def test_clear_meta_and_links_clears_hash():
 
     clear_style = style.clear_meta_and_links()
     assert clear_style._hash is None
+
+
+def test_add_preserves_link_id():
+    """Regression test for https://github.com/Textualize/rich/issues/4109.
+
+    Adding a style without a link on top of a style with a link must preserve
+    the original link_id so the terminal sees one continuous hyperlink.
+    """
+    link_style = Style(link="https://example.com")
+    highlight_style = Style(color="red")
+    combined = link_style + highlight_style
+    assert combined.link_id == link_style.link_id
+
+
+def test_add_distinct_link_ids_for_equal_link_styles():
+    """Regression test for https://github.com/Textualize/rich/issues/4109.
+
+    Two Style objects that share the same URL but were constructed separately
+    must produce distinct link_ids when combined, even if the LRU cache
+    considers them equal by hash/eq.
+    """
+    style_a = Style(link="https://example.com")
+    style_b = Style(link="https://example.com")
+    # They are equal by value but carry distinct link_ids.
+    assert style_a == style_b
+    assert style_a.link_id != style_b.link_id
+
+    highlight = Style(color="red")
+    combined_a = style_a + highlight
+    combined_b = style_b + highlight
+    assert combined_a.link_id == style_a.link_id
+    assert combined_b.link_id == style_b.link_id
+    assert combined_a.link_id != combined_b.link_id


### PR DESCRIPTION
## Summary

Fixes #4109

When `ReprHighlighter` (or any `RegexHighlighter`) processes text that already carries a hyperlink, the link is fragmented into multiple separate clickable links in the terminal instead of appearing as one.

## Root Cause

`Style.__add__` called `.copy()` on any combined style that had a link. `copy()` always generates a fresh `_link_id`, so when a highlighter adds spans (e.g. `repr.uuid`) overlapping a hyperlink, different character positions received different `link_id` values. Since terminals use `link_id` to identify hyperlink boundaries, each sub-span was rendered as a separate link.

There was also a secondary issue: the LRU cache on `_add()` keys on `__hash__` / `__eq__`, which intentionally exclude `_link_id`. Two `Style` objects with identical visual content but different `_link_id` values would collide in the cache, causing the second call to inherit the first's `link_id`.

## Fix

- Added `link_id: str` as an explicit parameter to `_add()` so the LRU cache keys on it, preventing cache collisions between styles that share the same visual appearance but carry distinct hyperlinks.
- `__add__` now computes the correct `link_id` to preserve (`style._link_id or self._link_id`) and passes it directly to `_add()`, removing the need for the `.copy()` call entirely.

## Tests

- `test_add_preserves_link_id` — adding a non-link style on top of a link style preserves the original `link_id`
- `test_add_distinct_link_ids_for_equal_link_styles` — two styles with the same URL but separately constructed (different `link_id`) do not collide in the cache
- `test_highlighter_preserves_link_across_spans` — end-to-end: applying `ReprHighlighter` to a UUID string with a hyperlink produces rendered segments that all share one `link_id`