### PR TITLE
docs: document Syntax.stylize_range

### DIFF
--- a/docs/source/syntax.rst
+++ b/docs/source/syntax.rst
@@ -44,6 +44,43 @@ Background color
 You can override the background color from the theme by supplying a ``background_color`` argument to the constructor. This should be a string in the same format a style definition accepts, e.g. "red", "#ff0000", "rgb(255,0,0)" etc. You may also set the special value "default" which will use the default background color set in the terminal.
 
 
+Highlighting ranges
+-------------------
+
+You can apply custom styles to specific portions of the code with :meth:`~rich.syntax.Syntax.stylize_range`. This is useful for highlighting search results, marking errors, or drawing attention to particular lines.
+
+The method accepts a style and a *start* and *end* position, each given as ``(line, column)`` tuples. Line numbers are **1-based** (the first line is 1) and column offsets are **0-based** (the first column is 0).
+
+Here is an example that highlights the word ``True`` in a snippet of Python code::
+
+    from rich.console import Console
+    from rich.style import Style
+    from rich.syntax import Syntax
+
+    code = "example = True"
+    syntax = Syntax(code, "python")
+    syntax.stylize_range(Style(bgcolor="red"), (1, 10), (1, 14))
+
+    console = Console()
+    console.print(syntax)
+
+This renders the code with a red background behind ``True`` (columns 10–13, inclusive of the start and exclusive of the end).
+
+For multi-line code, increment the line number accordingly. The following example highlights ``456`` on the second line::
+
+    code = "123\n456\n789"
+    syntax = Syntax(code, "python")
+    syntax.stylize_range(Style(bgcolor="red"), (2, 0), (2, 3))
+
+You can also style a range that spans multiple lines. To highlight the entire first two lines::
+
+    syntax.stylize_range(Style(bgcolor="red"), (1, 0), (2, 11))
+
+.. tip::
+
+   ``stylize_range`` can be called multiple times on the same :class:`~rich.syntax.Syntax` object to apply different styles to different parts of the code.
+
+
 Syntax CLI
 ----------
 

--- a/examples/syntax_stylize_range.py
+++ b/examples/syntax_stylize_range.py
@@ -1,0 +1,28 @@
+"""Demonstration of Syntax.stylize_range to highlight portions of code."""
+
+from rich.console import Console
+from rich.style import Style
+from rich.syntax import Syntax
+
+console = Console()
+
+# Example 1: Highlight a single token on one line
+code = "example = True"
+syntax = Syntax(code, "python")
+syntax.stylize_range(Style(bgcolor="red"), (1, 10), (1, 14))
+console.print("Example 1 – highlight 'True' on line 1:")
+console.print(syntax)
+
+# Example 2: Highlight part of a multi-line snippet
+code = "123\n456\n789"
+syntax = Syntax(code, "python")
+syntax.stylize_range(Style(bgcolor="red"), (2, 0), (2, 3))
+console.print("\nExample 2 – highlight '456' on line 2:")
+console.print(syntax)
+
+# Example 3: Highlight a range spanning multiple lines
+code = "def greet(name):\n    return f'Hello {name}'"
+syntax = Syntax(code, "python")
+syntax.stylize_range(Style(bgcolor="red"), (1, 4), (2, 22))
+console.print("\nExample 3 – highlight across lines 1–2:")
+console.print(syntax)


### PR DESCRIPTION
## Summary

Closes #2842

Adds a "Highlighting ranges" section to `docs/source/syntax.rst` documenting the `Syntax.stylize_range()` method, which was previously undocumented.

### What's included

- **Docs section** explaining `stylize_range` with 3 progressive examples:
  - Single-token highlight on one line
  - Highlighting part of a multi-line snippet
  - Ranges spanning multiple lines
- **Runnable example file** at `examples/sylize_range.py`
- A tip noting that `stylize_range` can be called multiple times on the same `Syntax` object

### Notes

- Line/column conventions are explicitly stated (1-based lines, 0-based columns)
- Follows the existing doc style in `syntax.rst`
- No code changes — documentation only