### PR TITLE
fix: improve handling of carriage return in ANSI decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Text.from_ansi` removing newlines https://github.com/Textualize/rich/pull/4076
 - Fixed `FileProxy.isatty` not proxying https://github.com/Textualize/rich/pull/4077
 - Fixed inline code in Markdown tables cells https://github.com/Textualize/rich/pull/4079
+- Fixed `AnsiDecoder` dropping text on lines with CRLF (`\r\n`) endings https://github.com/Textualize/rich/issues/3577
 
 ## [14.3.4] - 2026-04-11
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -101,3 +101,4 @@ The following people have contributed to the development of Rich:
 - [Alex Zheng](https://github.com/alexzheng111)
 - [Sebastian Speitel](https://github.com/SebastianSpeitel)
 - [Kevin Turcios](https://github.com/KRRT7)
+- [vinayak9769](https://github.com/vinayak9769)

--- a/rich/ansi.py
+++ b/rich/ansi.py
@@ -149,7 +149,7 @@ class AnsiDecoder:
         _Style = Style
         text = Text()
         append = text.append
-        line = line.rsplit("\r", 1)[-1]
+        line = line.rstrip("\r").rsplit("\r", 1)[-1]
         for plain_text, sgr, osc in _ansi_tokenize(line):
             if plain_text:
                 append(plain_text, self.style or None)

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -102,3 +102,5 @@ def test_decode_newlines():
     assert Text.from_ansi("Hello\nWorld\n").plain == "Hello\nWorld\n"
     assert Text.from_ansi("Hello\nWorld\n\n").plain == "Hello\nWorld\n\n"
     assert Text.from_ansi("\nHello\nWorld\n\n").plain == "\nHello\nWorld\n\n"
+    assert Text.from_ansi("Hello\r\nWorld\r\n").plain == "Hello\nWorld\n"
+    assert Text.from_ansi("\r\nHello\r\nWorld\r\n\r\n").plain == "\nHello\nWorld\n\n"


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes an issue where `AnsiDecoder` would drop all text on lines ending with Windows-style CRLF (`\r\n`) line endings. 

When lines are split by `\n` in `AnsiDecoder.decode()`, the trailing `\r` is left behind. The line-clearing shortcut in `decode_line()` (`line.rsplit("\r", 1)[-1]`) would then inadvertently discard all text preceding that trailing `\r`, resulting in empty strings.

This minor fix strips the trailing carriage return before applying the `rsplit` shortcut. This safely preserves the line text while maintaining the correct cursor return behavior for inline `\r` characters (e.g., progress bars).

**Important:** Fixes #4090 
