### PR TITLE
Fix RichHandler console highlighter fallback

### DIFF
--- a/rich/logging.py
+++ b/rich/logging.py
@@ -96,6 +96,7 @@ class RichHandler(Handler):
     ) -> None:
         super().__init__(level=level)
         self.console = console or get_console()
+        self._highlighter = highlighter
         self.highlighter = highlighter or self.HIGHLIGHTER_CLASS()
         self._log_render = LogRender(
             show_time=show_time,
@@ -200,7 +201,10 @@ class RichHandler(Handler):
         use_markup = getattr(record, "markup", self.markup)
         message_text = Text.from_markup(message) if use_markup else Text(message)
 
-        highlighter = getattr(record, "highlighter", self.highlighter)
+        if "highlighter" in record.__dict__:
+            highlighter = record.highlighter
+        else:
+            highlighter = self._highlighter or self.console.highlighter
         if highlighter:
             message_text = highlighter(message_text)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,11 +1,13 @@
 import io
 import os
 import logging
+import re
 from typing import Optional
 
 import pytest
 
 from rich.console import Console
+from rich.highlighter import ReprHighlighter
 from rich.logging import RichHandler
 
 handler = RichHandler(
@@ -160,3 +162,23 @@ def test_markup_and_highlight():
     render_plain = handler.console.file.getvalue()
     assert "FORMATTER" in render_plain
     assert log_message in render_plain
+
+
+def test_handler_uses_console_highlighter_when_not_overridden():
+    class HashHighlighter(ReprHighlighter):
+        highlights = [
+            *ReprHighlighter.highlights,
+            re.compile(r"\b(?P<git_hash>FOO)\b"),
+        ]
+
+    console = Console(highlighter=HashHighlighter())
+    handler = RichHandler(console=console)
+    record = logging.LogRecord("rich", logging.INFO, __file__, 1, "message", (), None)
+
+    rendered = handler.render_message(record, "A git hash FOO")
+
+    assert rendered.plain == "A git hash FOO"
+    assert len(rendered.spans) == 1
+    assert rendered.spans[0].start == 11
+    assert rendered.spans[0].end == 14
+    assert rendered.spans[0].style == "repr.git_hash"


### PR DESCRIPTION
Fixes #3887.

RichHandler now falls back to the attached console's highlighter when the handler itself was not given one explicitly, which keeps logging behavior aligned with Console.print() for custom console highlighters.

Added a regression test that reproduces the issue with a Console-bound custom highlighter and verifies explicit record-level overrides still win.