### PR TITLE
Fix Segment._split_cells for non-unit-width characters (emoji, CJK)

### DIFF
--- a/rich/segment.py
+++ b/rich/segment.py
@@ -126,32 +126,25 @@ class Segment(NamedTuple):
 
         cell_size = get_character_cell_size
 
-        pos = int((cut / cell_length) * len(text))
+        # Walk through characters tracking cell position,
+        # avoids the heuristic + while-loop which fails on
+        # non-unit-width characters (emoji, CJK, etc.)
+        cell_pos = 0
+        for i, char in enumerate(text):
+            char_cells = cell_size(char)
+            if cell_pos + char_cells > cut:
+                if char_cells == 2:
+                    return (
+                        _Segment(text[:i] + " ", style, control),
+                        _Segment(" " + text[i + 1 :], style, control),
+                    )
+                return (
+                    _Segment(text[:i], style, control),
+                    _Segment(text[i:], style, control),
+                )
+            cell_pos += char_cells
 
-        while True:
-            before = text[:pos]
-            cell_pos = cell_len(before)
-            out_by = cell_pos - cut
-            if not out_by:
-                return (
-                    _Segment(before, style, control),
-                    _Segment(text[pos:], style, control),
-                )
-            if out_by == -1 and cell_size(text[pos]) == 2:
-                return (
-                    _Segment(text[:pos] + " ", style, control),
-                    _Segment(" " + text[pos + 1 :], style, control),
-                )
-            if out_by == +1 and cell_size(text[pos - 1]) == 2:
-                return (
-                    _Segment(text[: pos - 1] + " ", style, control),
-                    _Segment(" " + text[pos:], style, control),
-                )
-            if cell_pos < cut:
-                pos += 1
-            else:
-                pos -= 1
-
+        return segment, _Segment("", style, control)
     def split_cells(self, cut: int) -> Tuple["Segment", "Segment"]:
         """Split segment in to two segments at the specified column.
 


### PR DESCRIPTION
## Summary

Fix `Segment._split_cells()` to correctly handle strings containing double-cell-width characters (emoji, CJK characters, etc.).

## Root Cause

The old algorithm used a heuristic initial position: `pos = int((cut / cell_length) * len(text))`. This assumes uniform character width, which fails badly for mixed-width strings.

For example:
```py
s = Segment('🦊🦊🦊\n\n\n\n\n\n')
Segment._split_cells(s, 3)
# Wrong: (Segment('🦊🦊🦊\n '), Segment(' \n\n\n\n'))
```

## Fix

Replaced the heuristic + while-loop with a character-by-character walk-through. The new algorithm:
1. Tracks cumulative cell position as it iterates over characters
2. When it finds the character that exceeds the cut point, it splits there
3. Double-width characters are replaced with two spaces as before

Fixes #3299