### PR TITLE
Fix style_definition check to handle string input

### DIFF
--- a/rich/style.py
+++ b/rich/style.py
@@ -507,7 +507,7 @@ class Style:
         Returns:
             `Style`: A Style instance.
         """
-        if style_definition.strip() == "none" or not style_definition:
+        if str(style_definition).strip() == "none" or not style_definition:
             return cls.null()
 
         STYLE_ATTRIBUTES = cls.STYLE_ATTRIBUTES


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [] AI was used to generate this PR

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixed a crash caused when `style_definition` was not a string.