### PR TITLE
fix: standardize "Rich" in README.ja.md

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -49,7 +49,7 @@ Richは追加の設定を行わずとも、[Jupyter notebooks](https://jupyter.o
 python -m pip install rich
 ```
 
-以下のコマンドを実行して、ターミナルでリッチの出力をテストできます:
+以下のコマンドを実行して、ターミナルでRichの出力をテストできます:
 
 ```sh
 python -m rich


### PR DESCRIPTION
## Summary
- Standardizes library name from "リッチ" to "Rich" in Japanese README

## Fix
Line 52: 「以下のコマンドを実行して、ターミナルでRichの出力をテストできます:」

## Issue
Fixes #4050
