### PR TITLE
Fall back to inspect.getattr_static for raising descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed `inspect` showing `AttributeError` for descriptors that raise; now falls back to `inspect.getattr_static` https://github.com/Textualize/rich/pull/4124
+
 ## [15.0.0] - 2026-04-12
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -101,3 +101,4 @@ The following people have contributed to the development of Rich:
 - [Alex Zheng](https://github.com/alexzheng111)
 - [Sebastian Speitel](https://github.com/SebastianSpeitel)
 - [Kevin Turcios](https://github.com/KRRT7)
+- [Truffle](https://github.com/truffle-dev)

--- a/rich/_inspect.py
+++ b/rich/_inspect.py
@@ -130,9 +130,19 @@ class Inspect(JupyterMixin):
             return (callable(value), key.strip("_").lower())
 
         def safe_getattr(attr_name: str) -> Tuple[Any, Any]:
-            """Get attribute or any exception."""
+            """Get attribute or any exception.
+
+            Falls back to ``inspect.getattr_static`` if ``getattr`` raises
+            ``AttributeError``, so that descriptors which signal "no such
+            attribute" (e.g. SWIG bindings, lazy properties) are still surfaced.
+            """
             try:
                 return (None, getattr(obj, attr_name))
+            except AttributeError:
+                try:
+                    return (None, inspect.getattr_static(obj, attr_name))
+                except AttributeError as error:
+                    return (error, None)
             except Exception as error:
                 return (error, None)
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -382,6 +382,23 @@ def test_inspect_swig_edge_case():
         assert False, f"Object with no __class__ shouldn't raise {e}"
 
 
+def test_inspect_getattr_static_fallback():
+    """Issue #3794 - Properties that raise AttributeError fall back to
+    inspect.getattr_static so the descriptor is shown instead of the error."""
+
+    class Thing:
+        @property
+        def maybe(self):
+            raise AttributeError("not available on this instance")
+
+        def __dir__(self):
+            return ["maybe"]
+
+    rendered = render(Thing())
+    assert "AttributeError" not in rendered
+    assert "property" in rendered
+
+
 def test_inspect_module_with_class():
     def function():
         pass


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [x] AI was used to generate this PR

Agent: truffle (https://github.com/truffle-dev)

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Closes #3794. `safe_getattr` now falls back to `inspect.getattr_static` when `getattr` raises `AttributeError`, so descriptors that signal "no such attribute" (SWIG bindings, lazy properties, Pydantic dynamic fields) render the descriptor instead of the error. Other exceptions still surface as before.