### PR TITLE
docs: remove unreachable rich tweets link

### DIFF
--- a/README.de-ch.md
+++ b/README.de-ch.md
@@ -33,7 +33,6 @@ D [Rich API](https://rich.readthedocs.io/en/latest/) machts ganz eifach zom Farb
 
 E Video Iifüärig öber Rich geds onder [calmcode.io](https://calmcode.io/rich/introduction.html) vo [@fishnets88](https://twitter.com/fishnets88).
 
-Lueg was [anderi öber Rich säged](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
 
 ## Kompatibilität
 

--- a/README.de.md
+++ b/README.de.md
@@ -33,7 +33,6 @@ Die [Rich API](https://rich.readthedocs.io/en/latest/) erleichtert das Hinzufüg
 
 Eine Video-Einführung in Rich findest du unter [quietcode.io](https://calmcode.io/rich/introduction.html) von [@ fishnets88](https://twitter.com/fishnets88).
 
-Schau hier, was [andere über Rich sagen](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
 
 ## Kompatibilität
 

--- a/README.es.md
+++ b/README.es.md
@@ -33,7 +33,6 @@ La [API Rich](https://rich.readthedocs.io/en/latest/) facilita la adición de co
 
 Para ver un vídeo de introducción a Rich, consulte [calmcode.io](https://calmcode.io/rich/introduction.html) de [@fishnets88](https://twitter.com/fishnets88).
 
-Vea lo que [la gente dice sobre Rich](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
 
 ## Compatibilidad
 

--- a/README.fa.md
+++ b/README.fa.md
@@ -42,7 +42,6 @@
 
 برای معرفی ویدئویی ریچ این ویدئو را ببینید [calmcode.io](https://calmcode.io/rich/introduction.html) توسط [@fishnets88](https://twitter.com/fishnets88).
 
-ببینید [مردم در مورد ریچ چه میگویند](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
 
 ## سازگاری
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -33,7 +33,6 @@ L'[API Rich](https://rich.readthedocs.io/en/latest/) permet d'ajouter facilement
 
 Pour une introduction vidéo à Rich, voir [camelcode.io](https://calmcode.io/rich/introduction.html) par [@ fishnets88](https://twitter.com/fishnets88)
 
-Voyez ce que [les gens disent de Rich](https://www.willmcgugan.com/blog/pages/post/rich-tweets/)
 
 ## Compatibilité
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -35,7 +35,6 @@ Rich टर्मिनल में _समृद्ध_ पाठ और स�
 Rich के वीडियो परिचय के लिए देखें [@fishnets88](https://twitter.com/fishnets88) द्वारा बनाई गई [calmcode.io](https://calmcode.io/rich/introduction.html)।
 
 
-देखें [लोग रिच के बारे में क्या कह रहे हैं](https://www.willmcgugan.com/blog/pages/post/rich-tweets/)।
 
 ## अनुकूलता
 

--- a/README.id.md
+++ b/README.id.md
@@ -34,7 +34,6 @@ Rich adalah library Python yang membantu _memperindah_ tampilan output suatu pro
 
 Sebagai pengenalan Rich saksikan video berikut [calmcode.io](https://calmcode.io/rich/introduction.html) oleh [@fishnets88](https://twitter.com/fishnets88).
 
-Lihat pendapat [pengguna yang telah menggunakan Rich](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
 
 ## Kompabilitas
 

--- a/README.it.md
+++ b/README.it.md
@@ -34,7 +34,6 @@ Le [Rich API](https://rich.readthedocs.io/en/latest/) permettono di aggiungere f
 
 Per una video-introduzione di Rich puoi vedere [calmcode.io](https://calmcode.io/rich/introduction.html) by [@fishnets88](https://twitter.com/fishnets88).
 
-Guarda cosa [le persone dicono su Rich](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
 
 ## Compatibilità
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -33,7 +33,6 @@ Richは、 _リッチ_ なテキストや美しい書式設定をターミナル
 
 Richの紹介動画はこちらをご覧ください。 [calmcode.io](https://calmcode.io/rich/introduction.html) by [@fishnets88](https://twitter.com/fishnets88).
 
-[Richについての人々の感想を見る。](https://www.willmcgugan.com/blog/pages/post/rich-tweets/)
 
 ## 互換性
 

--- a/README.kr.md
+++ b/README.kr.md
@@ -33,7 +33,6 @@ Rich는 터미널에서 _풍부한(rich)_ 텍스트와 아름다운 서식을 �
 
 Rich에 대한 동영상 설명을 보시려면 [@fishnets88](https://twitter.com/fishnets88)의 [calmcode.io](https://calmcode.io/rich/introduction.html)를 확인 바랍니다.
 
-[사람들의 Rich에 대한 의견](https://www.willmcgugan.com/blog/pages/post/rich-tweets/)을 확인해보세요.
 
 ## 호환성
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ The [Rich API](https://rich.readthedocs.io/en/latest/) makes it easy to add colo
 
 For a video introduction to Rich see [calmcode.io](https://calmcode.io/rich/introduction.html) by [@fishnets88](https://twitter.com/fishnets88).
 
-See what [people are saying about Rich](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
 
 ## Compatibility
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -35,7 +35,6 @@ Rich to bilbioteka Pythona dla tekstów _rich_ i pięknego formatowania w termin
 
 Wprowadzenie wideo do Richa na [calmcode.io](https://calmcode.io/rich/introduction.html) stworzonym przez [@fishnets88](https://twitter.com/fishnets88).
 
-Zobacz co [inni mówią o Richu](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
 
 ## Kompatybilność
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -32,7 +32,6 @@ A [API do Rich](https://rich.readthedocs.io/en/latest/) permite adicionar cores 
 
 Para mais detalhes, veja um vídeo de introdução so Rich em [calmcode.io](https://calmcode.io/rich/introduction.html) por [@fishnets88](https://twitter.com/fishnets88).
 
-Veja aqui [o que estão falando sobre o Rich](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
 
 ## Compatibilidade
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -33,7 +33,6 @@ Rich это Python библиотека, позволяющая отобража
 
 Смотрите видеоинструкцию  [calmcode.io](https://calmcode.io/rich/introduction.html) от [@fishnets88](https://twitter.com/fishnets88).
 
-Посмотрите [что люди думают о Rich](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
 
 ## Cовместимость
 

--- a/README.sv.md
+++ b/README.sv.md
@@ -32,7 +32,6 @@ Rich är ett Python bibliotek för _rich_ text och vacker formattering i termina
 
 För en video demonstration av Rich kolla [calmcode.io](https://calmcode.io/rich/introduction.html) av [@fishnets88](https://twitter.com/fishnets88).
 
-Se vad [folk pratar om Rich](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
 
 ## Kompatibilitet
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -35,7 +35,6 @@ Bir Python kütüphanesi olan __rich__, terminal üzerinde gösterişli çıktı
 
 Rich'e video ile göz atmak için [@fishnets88](https://twitter.com/fishnets88) tarafından oluşturulan [calmcode.io](https://calmcode.io/rich/introduction.html) sitesine bakabilirsiniz.
 
-İnsanların [rich hakkında yazdıkları son yazılar](https://www.willmcgugan.com/blog/pages/post/rich-tweets).
 
 ## Uyumluluk
 

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -33,7 +33,6 @@ Rich 是一款提供終端機介面中 _豐富的_ 文字效果及精美的格�
 
 關於 Rich 的介紹，請參見 [@fishnets88](https://twitter.com/fishnets88) 在 [calmcode.io](https://calmcode.io/rich/introduction.html) 錄製的影片。
 
-[看看其他人對於 Rich 的討論](https://www.willmcgugan.com/blog/pages/post/rich-tweets/)。
 
 ## 相容性
 

--- a/benchmarks/snippets.py
+++ b/benchmarks/snippets.py
@@ -111,7 +111,6 @@ Richは、 _リッチ_ なテキストや美しい書式設定をターミナル
 
 Richの紹介動画はこちらをご覧ください。 [calmcode.io](https://calmcode.io/rich/introduction.html) by [@fishnets88](https://twitter.com/fishnets88).
 
-[Richについての人々の感想を見る。](https://www.willmcgugan.com/blog/pages/post/rich-tweets/)
 
 ## 互換性
 


### PR DESCRIPTION
## Summary
- remove the unreachable `rich-tweets` external link from the main README and translated READMEs
- remove the same dead URL from the benchmark markdown snippet so the repository no longer references it

## Validation
- `curl -I -L --max-time 15 https://www.willmcgugan.com/blog/pages/post/rich-tweets/` timed out
- `curl -I -L --max-time 15 https://willmcgugan.com/blog/pages/post/rich-tweets/` timed out
- `rg 'rich-tweets|willmcgugan.com/blog/pages/post/rich-tweets' -n .` returns no matches
- `python -m py_compile benchmarks/snippets.py`
- `git diff --check`

Closes #4123