### PR TITLE
Make BrokenPipeError test deterministic.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,6 +48,7 @@ The following people have contributed to the development of Rich:
 - [Paul McGuire](https://github.com/ptmcg)
 - [Antony Milne](https://github.com/AntonyMilneQB)
 - [Michael Milton](https://github.com/multimeric)
+- [Theodore Ni](https://github.com/tjni)
 - [Martina Oefelein](https://github.com/oefe)
 - [Joel Ostblom](https://github.com/joelostblom)
 - [Nathan Page](https://github.com/nathanrpage97)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1006,17 +1006,30 @@ def test_reenable_highlighting() -> None:
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 def test_brokenpipeerror() -> None:
     """Test BrokenPipe works as expected."""
-    which_py, which_head = (["which", cmd] for cmd in ("python", "head"))
-    rich_cmd = "python -m rich".split()
-    for cmd in [which_py, which_head, rich_cmd]:
-        check = subprocess.run(cmd).returncode
-        if check != 0:
-            return  # Only test on suitable Unix platforms
-    head_cmd = "head -1".split()
-    proc1 = subprocess.Popen(rich_cmd, stdout=subprocess.PIPE)
-    proc2 = subprocess.Popen(head_cmd, stdin=proc1.stdout, stdout=subprocess.PIPE)
+
+    # We write enough output to hopefully keep the writing process busy and give
+    # enough time for the reading process to exist, creating a BrokenPipeError.
+    writer = (
+        "from rich.console import Console\n"
+        "console = Console(force_terminal=True, width=240)\n"
+        "payload = 'X' * 200\n"
+        "for index in range(10000):\n"
+        "    console.print(f'{index:06d} {payload}')\n"
+    )
+    reader = "import sys; sys.stdin.buffer.read(1)"
+    proc1 = subprocess.Popen(
+        [sys.executable, "-c", writer],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    proc2 = subprocess.Popen(
+        [sys.executable, "-c", reader],
+        stdin=proc1.stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
     proc1.stdout.close()
-    output, _ = proc2.communicate()
+    proc2.communicate()
     proc1.wait()
     proc2.wait()
     assert proc1.returncode == 1

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1008,7 +1008,7 @@ def test_brokenpipeerror() -> None:
     """Test BrokenPipe works as expected."""
 
     # We write enough output to hopefully keep the writing process busy and give
-    # enough time for the reading process to exist, creating a BrokenPipeError.
+    # enough time for the reading process to exit, creating a BrokenPipeError.
     writer = (
         "from rich.console import Console\n"
         "console = Console(force_terminal=True, width=240)\n"


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## AI?

- [x] AI was used to generate this PR

I used Codex with GPT-5.4 on Medium effort to investigate and generate local scripts to reproduce the flakiness as well as to create the initial version of the patch, but then I also manually read over and tweaked it to remove unnecessary lines such as certain comments and extra assertions.

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

`test_brokenpipeerror` seems to be flaky (albeit rarely). We can try to make it deterministic by writing more data during the test to reliably trigger BrokenPipeError.

I specifically ran into this while building `python3Packages.rich` from nixpkgs locally using Nix, and during research found that some other package managers have also disabled this test, e.g.:

- https://www.mail-archive.com/gentoo-commits%40lists.gentoo.org/msg1131334.html
- https://www.mail-archive.com/guix-commits%40gnu.org/msg356105.html

I had Codex generate locally some scripts to reproduce this, and it was able to do so against Python 3.13 after a few hundred iterations, and with these changes I was not able to reproduce it again locally, so I feel it could be worth a try.

I have at present skipped creating a discussion because I feel this falls under "clear bug-fixes / typos etc". I also refrained from updating the CHANGELOG, because it appeared to me that entries under there look like external facing changes. I'm happy to make any changes needed, however.
