### PR TITLE
docs: remove dead rich-tweets link from README (#4123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ The [Rich API](https://rich.readthedocs.io/en/latest/) makes it easy to add colo
 
 For a video introduction to Rich see [calmcode.io](https://calmcode.io/rich/introduction.html) by [@fishnets88](https://twitter.com/fishnets88).
 
-See what [people are saying about Rich](https://www.willmcgugan.com/blog/pages/post/rich-tweets/).
-
 ## Compatibility
 
 Rich works with Linux, macOS and Windows. True color / emoji works with new Windows Terminal, classic terminal is limited to 16 colors. Rich requires Python 3.8 or later.


### PR DESCRIPTION
Closes #4123

This PR resolves the issue by removing the unreachable external link under the section "See what people are saying about Rich". 

As noted in #4123 (and related issue #3586), the target domain `willmcgugan.com` has completely expired, making the link permanently broken. Deleting the line prevents users from landing on an unhosted/expired domain page.

## Checklist
- [x] PR contains only related changes (documentation update).