### PR TITLE
fix readline support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `Console.enable_readline` method.
+
+### Fixed
+
+- Fixed `readline` support: correct cursor position when navigating to the start of the line
+
 ## [15.0.0] - 2026-04-12
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -98,6 +98,7 @@ The following people have contributed to the development of Rich:
 - [chthollyphile](https://github.com/chthollyphile)
 - [Jonathan Helmus](https://github.com/jjhelmus)
 - [Brandon Capener](https://github.com/bcapener)
+- [Florent Xicluna](https://github.com/florentx)
 - [Alex Zheng](https://github.com/alexzheng111)
 - [Sebastian Speitel](https://github.com/SebastianSpeitel)
 - [Kevin Turcios](https://github.com/KRRT7)

--- a/docs/source/console.rst
+++ b/docs/source/console.rst
@@ -244,7 +244,11 @@ The console class has an :meth:`~rich.console.Console.input` method which works 
     console = Console()
     console.input("What is [i]your[/i] [bold red]name[/]? :smiley: ")
 
-If Python's builtin :mod:`readline` module is previously loaded, elaborate line editing and history features will be available.
+Python's builtin :mod:`readline` module can be loaded, in order to get elaborate line editing and history features::
+
+    from rich.console import Console
+
+    Console.enable_readline()
 
 Exporting
 ---------

--- a/rich/console.py
+++ b/rich/console.py
@@ -786,6 +786,14 @@ class Console:
         """Get the thread local theme stack."""
         return self._thread_locals.theme_stack
 
+    @staticmethod
+    def enable_readline():
+        """Load :mod:`readline` globally, if available."""
+        try:
+            import readline
+        except ImportError:
+            pass
+
     def _detect_color_system(self) -> Optional[ColorSystem]:
         """Detect color system from env vars."""
         if self.is_jupyter:
@@ -2176,17 +2184,23 @@ class Console:
         Returns:
             str: Text read from stdin.
         """
-        if prompt:
-            self.print(prompt, markup=markup, emoji=emoji, end="")
+        if prompt and not stream and not WINDOW and self.file == sys.stdout:
+            with self.capture() as capture:
+                self.print(prompt, markup=markup, emoji=emoji, end="")
+            rendered = capture.get()
+        else:
+            if prompt:
+                self.print(prompt, markup=markup, emoji=emoji, end="")
+            rendered = ""
         if password:
             import getpass as _getpass_mod
 
-            result = _getpass_mod.getpass("", stream=stream)
+            result = _getpass_mod.getpass(rendered, stream=stream)
         else:
             if stream:
                 result = stream.readline()
             else:
-                result = input()
+                result = input(rendered)
         return result
 
     def export_text(self, *, clear: bool = True, styles: bool = False) -> str:


### PR DESCRIPTION
On Linux, I had the issue when using `Prompt.ask(...)` , `Confirm.ask(...)`  or `Console.input(...)`.
I import builtin `readline` to get line editing capability.

When navigating the line to the left with the arrow key, cursor goes to the start of the line and overwrite the prompt text.
This can be fixed, if the `input` built-in function receives the prompt text.

Also I've added a convenient helper (static method) to enable `readline`.