### PR TITLE
Fix readline support on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `Console.enable_readline` method.
+
+### Fixed
+
+- Fixed `readline` support: correct cursor position https://github.com/Textualize/rich/pull/4135
+
 ## [15.0.0] - 2026-04-12
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -98,6 +98,7 @@ The following people have contributed to the development of Rich:
 - [chthollyphile](https://github.com/chthollyphile)
 - [Jonathan Helmus](https://github.com/jjhelmus)
 - [Brandon Capener](https://github.com/bcapener)
+- [Florent Xicluna](https://github.com/florentx)
 - [Alex Zheng](https://github.com/alexzheng111)
 - [Sebastian Speitel](https://github.com/SebastianSpeitel)
 - [Kevin Turcios](https://github.com/KRRT7)

--- a/docs/source/console.rst
+++ b/docs/source/console.rst
@@ -244,7 +244,11 @@ The console class has an :meth:`~rich.console.Console.input` method which works 
     console = Console()
     console.input("What is [i]your[/i] [bold red]name[/]? :smiley: ")
 
-If Python's builtin :mod:`readline` module is previously loaded, elaborate line editing and history features will be available.
+Python's builtin :mod:`readline` module can be loaded, in order to get elaborate line editing and history features::
+
+    from rich.console import Console
+
+    Console.enable_readline()
 
 Exporting
 ---------

--- a/rich/console.py
+++ b/rich/console.py
@@ -786,6 +786,14 @@ class Console:
         """Get the thread local theme stack."""
         return self._thread_locals.theme_stack
 
+    @staticmethod
+    def enable_readline():
+        """Load :mod:`readline` globally, if available."""
+        try:
+            import readline
+        except ImportError:
+            pass
+
     def _detect_color_system(self) -> Optional[ColorSystem]:
         """Detect color system from env vars."""
         if self.is_jupyter:
@@ -2176,17 +2184,23 @@ class Console:
         Returns:
             str: Text read from stdin.
         """
-        if prompt:
-            self.print(prompt, markup=markup, emoji=emoji, end="")
+        if prompt and not stream and not WINDOWS and self.file == sys.stdout:
+            with self.capture() as capture:
+                self.print(prompt, markup=markup, emoji=emoji, end="")
+            rendered = capture.get()
+        else:
+            if prompt:
+                self.print(prompt, markup=markup, emoji=emoji, end="")
+            rendered = ""
         if password:
             import getpass as _getpass_mod
 
-            result = _getpass_mod.getpass("", stream=stream)
+            result = _getpass_mod.getpass(rendered, stream=stream)
         else:
             if stream:
                 result = stream.readline()
             else:
-                result = input()
+                result = input(rendered)
         return result
 
     def export_text(self, *, clear: bool = True, styles: bool = False) -> str:


### PR DESCRIPTION
<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [x] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- ~[ ] I've added tests for new code.~
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes:
- #4135 


The `input(...)` builtins deals correctly with `readline` when it receives a prompt to print.
It is explained here: https://docs.python.org/library/functions#input

So the change consists of passing the rendered content to `input(...)` instead of printing it separately.