### PR TITLE
Fix readline support (alternative fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed `readline` support: correct cursor position https://github.com/Textualize/rich/pull/4135
+
 ## [15.0.0] - 2026-04-12
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -98,6 +98,7 @@ The following people have contributed to the development of Rich:
 - [chthollyphile](https://github.com/chthollyphile)
 - [Jonathan Helmus](https://github.com/jjhelmus)
 - [Brandon Capener](https://github.com/bcapener)
+- [Florent Xicluna](https://github.com/florentx)
 - [Alex Zheng](https://github.com/alexzheng111)
 - [Sebastian Speitel](https://github.com/SebastianSpeitel)
 - [Kevin Turcios](https://github.com/KRRT7)

--- a/rich/console.py
+++ b/rich/console.py
@@ -2186,7 +2186,8 @@ class Console:
             if stream:
                 result = stream.readline()
             else:
-                result = input()
+                # Fix readline support: pass a non-empty string
+                result = input(" \b")  # SPACE + BACKSPACE
         return result
 
     def export_text(self, *, clear: bool = True, styles: bool = False) -> str:


### PR DESCRIPTION
bug #4135

<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- ~[ ] I've added tests for new code.~
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

This is a smaller fix, for same issue:
- #4135 
- alternative to #4136

The `input(...)` builtins deals correctly with `readline` when it receives a prompt to print.
It is explained here: https://docs.python.org/library/functions#input

It consists of passing a non-empty string to `input(...)`:  [ space ] + [ backspace ].