### PR TITLE
docs: remove broken blog badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Downloads](https://pepy.tech/badge/rich/month)](https://pepy.tech/project/rich)
 [![codecov](https://img.shields.io/codecov/c/github/Textualize/rich?label=codecov&logo=codecov)](https://codecov.io/gh/Textualize/rich)
-[![Rich blog](https://img.shields.io/badge/blog-rich%20news-yellowgreen)](https://www.willmcgugan.com/tag/rich/)
 [![Twitter Follow](https://img.shields.io/twitter/follow/willmcgugan.svg?style=social)](https://twitter.com/willmcgugan)
 
 ![Logo](https://github.com/textualize/rich/raw/master/imgs/logo.svg)


### PR DESCRIPTION
This PR removes the broken 'blog / rich news' badge link from the README.md.

A separate PR (#4129) removes a different broken link under "See what people are saying about Rich", but this badge link remains in the README.

The removed badge points to:

`https://www.willmcgugan.com/tag/rich/`

which is currently unreachable.

Related to #4123 and #3586.

## Checklist
- [x] PR contains only related changes (documentation update).