### PR TITLE
fix: use linear scan in Segment._split_cells for correct wide-char splits

### DIFF
--- a/rich/segment.py
+++ b/rich/segment.py
@@ -126,31 +126,30 @@ class Segment(NamedTuple):
 
         cell_size = get_character_cell_size
 
-        pos = int((cut / cell_length) * len(text))
-
-        while True:
-            before = text[:pos]
-            cell_pos = cell_len(before)
-            out_by = cell_pos - cut
-            if not out_by:
-                return (
-                    _Segment(before, style, control),
-                    _Segment(text[pos:], style, control),
-                )
-            if out_by == -1 and cell_size(text[pos]) == 2:
+        # Walk the string character-by-character, accumulating cell widths.
+        # The previous heuristic (pos = int((cut / cell_length) * len(text)))
+        # produced an incorrect initial position for strings that mix wide
+        # (2-cell) characters with 1-cell characters, and the non-backtracking
+        # while-loop could not recover from that, leading to wrong split points.
+        # See: https://github.com/Textualize/rich/issues/3299
+        cell_pos = 0
+        for pos, char in enumerate(text):
+            char_width = cell_size(char)
+            if cell_pos + char_width > cut:
+                # The cut falls inside a double-width character; replace it
+                # with a space on each side to preserve total display width.
                 return (
                     _Segment(text[:pos] + " ", style, control),
                     _Segment(" " + text[pos + 1 :], style, control),
                 )
-            if out_by == +1 and cell_size(text[pos - 1]) == 2:
+            cell_pos += char_width
+            if cell_pos == cut:
                 return (
-                    _Segment(text[: pos - 1] + " ", style, control),
-                    _Segment(" " + text[pos:], style, control),
+                    _Segment(text[: pos + 1], style, control),
+                    _Segment(text[pos + 1 :], style, control),
                 )
-            if cell_pos < cut:
-                pos += 1
-            else:
-                pos -= 1
+        # Fallback (should not be reached given cut < cell_length guard above)
+        return segment, _Segment("", style, control)
 
     def split_cells(self, cut: int) -> Tuple["Segment", "Segment"]:
         """Split segment in to two segments at the specified column.


### PR DESCRIPTION
## Summary

Fixes #3299 — `Segment._split_cells` produces wrong split points for strings that mix 2-cell wide characters (emoji, CJK) with 1-cell characters.

## Problem

The previous implementation used a heuristic to compute an initial character position:
```python
pos = int((cut / cell_length) * len(text))
```
This ratio is inaccurate when the string mixes 2-cell and 1-cell characters. The subsequent `while True` loop adjusted `pos` by ±1 but could not backtrack far enough to recover from a bad starting position, converging on the wrong split point.

**Reproduction (from the issue):**
```python
s = Segment("🦊🦊🦊\n\n\n\n\n\n")
print(Segment._split_cells(s, 3))  # Wrong: includes all 3 foxes (6 cells) on the left

s = Segment("🦊🦊🦊abcdef")
print(Segment._split_cells(s, 3))  # Wrong: includes all 3 foxes on the left
```

## Fix

Replace the heuristic + while-loop with a simple **O(n) linear scan** that walks characters one at a time, accumulating cell widths, stopping exactly at `cut`:

```python
cell_pos = 0
for pos, char in enumerate(text):
    char_width = cell_size(char)
    if cell_pos + char_width > cut:
        # cut falls inside a wide char — pad both sides with a space
        return (
            _Segment(text[:pos] + " ", style, control),
            _Segment(" " + text[pos + 1 :], style, control),
        )
    cell_pos += char_width
    if cell_pos == cut:
        return (
            _Segment(text[: pos + 1], style, control),
            _Segment(text[pos + 1 :], style, control),
        )
```

**After fix:**
```python
Segment._split_cells(Segment("🦊🦊🦊\n\n\n\n\n\n"), 3)
# (Segment("🦊 "), Segment(" 🦊\n\n\n\n\n\n"))  ✅

Segment._split_cells(Segment("🦊🦊🦊abcdef"), 3)
# (Segment("🦊 "), Segment(" 🦊abcdef"))  ✅
```

The `lru_cache` decorator is preserved so performance characteristics remain the same for repeated calls.