### PR TITLE
Suppress final live render for non-interactive output

### DIFF
--- a/rich/live.py
+++ b/rich/live.py
@@ -292,7 +292,7 @@ class Live(JupyterMixin, RenderHook):
         elif (
             not self._started and not self.transient
         ):  # if it is finished render the final output for files or dumb_terminals
-            renderables = [*renderables, self._live_render]
+            pass
 
         return renderables
 


### PR DESCRIPTION
Related issue: #3040

## Description

This draft PR explores a possible fix for issue #3040 ("Interactive progress bars are being written to files").

### Reproduction

Using the following example:

```python
from rich.progress import track
from time import sleep

for _ in track(range(10), description="Doing stuff"):
    sleep(0.1)
```

and redirecting stdout:

```bash
python repro.py > output.txt
```

the resulting file contains:

```text
Doing stuff ---------------------------------------- 100% 0:00:01
```

### Investigation

While investigating, I found that `Live.process_renderables()` explicitly renders the final live output for non-interactive outputs:

```python
elif (
    not self._started and not self.transient
):
    renderables = [*renderables, self._live_render]
```

The documentation states that Rich removes animations such as progress bars when not writing to a terminal, so I wanted to explore whether the final rendered progress output should also be suppressed.

### Change

This draft removes the final live render for non-interactive outputs, which prevents progress bars from being written to redirected output files.

### Notes

This is submitted as a draft PR to gather feedback on the intended behavior before adding tests or making further changes.
