### PR TITLE
docs: fix typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -757,7 +757,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed pretty printing of objects with fo magic with **getattr** https://github.com/textualize/rich/issues/1492
+- Fixed pretty printing of objects with no magic with **getattr** https://github.com/textualize/rich/issues/1492
 
 ## [10.9.0] - 2021-08-29
 


### PR DESCRIPTION
> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `fo magic` → `no magic` in `CHANGELOG.md`.
