### PR TITLE
Fix _split_cells to handle non-unit width characters correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `Segment._split_cells` not handling non-unit width characters correctly https://github.com/Textualize/rich/issues/3299
+- Fixed empty print ignoring the `end` parameter https://github.com/Textualize/rich/pull/4075
+- Fixed `Text.from_ansi` removing newlines https://github.com/Textualize/rich/pull/4076
+- Fixed `FileProxy.isatty` not proxying https://github.com/Textualize/rich/pull/4077
+- Fixed inline code in Markdown tables cells https://github.com/Textualize/rich/pull/4079
+
+### Changed
+
+- Breaking change: Dropped support for Python3.8
+
+### Fixed
+
 - Fixed empty print ignoring the `end` parameter https://github.com/Textualize/rich/pull/4075
 - Fixed `Text.from_ansi` removing newlines https://github.com/Textualize/rich/pull/4076
 - Fixed `FileProxy.isatty` not proxying https://github.com/Textualize/rich/pull/4077

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,6 +50,7 @@ The following people have contributed to the development of Rich:
 - [Michael Milton](https://github.com/multimeric)
 - [Martina Oefelein](https://github.com/oefe)
 - [Joel Ostblom](https://github.com/joelostblom)
+- [Nisha Muthurajan](https://github.com/nisha-muthurajan)
 - [Nathan Page](https://github.com/nathanrpage97)
 - [Dave Pearson](https://github.com/davep/)
 - [Avi Perl](https://github.com/avi-perl)

--- a/rich/segment.py
+++ b/rich/segment.py
@@ -120,37 +120,33 @@ class Segment(NamedTuple):
         """
         text, style, control = segment
         _Segment = Segment
+        
         cell_length = segment.cell_length
         if cut >= cell_length:
             return segment, _Segment("", style, control)
 
         cell_size = get_character_cell_size
+        cell_size = get_character_cell_size
+        cell_pos = 0
 
-        pos = int((cut / cell_length) * len(text))
-
-        while True:
-            before = text[:pos]
-            cell_pos = cell_len(before)
-            out_by = cell_pos - cut
-            if not out_by:
+        for pos, char in enumerate(text):
+            char_width = cell_size(char)
+            if cell_pos + char_width > cut:
+                if cell_pos + char_width == cut + 1 and char_width == 2:
+                    return (
+                        _Segment(text[:pos] + " ", style, control),
+                        _Segment(" " + text[pos + 1:], style, control),
+                    )
                 return (
-                    _Segment(before, style, control),
+                    _Segment(text[:pos], style, control),
                     _Segment(text[pos:], style, control),
                 )
-            if out_by == -1 and cell_size(text[pos]) == 2:
-                return (
-                    _Segment(text[:pos] + " ", style, control),
-                    _Segment(" " + text[pos + 1 :], style, control),
-                )
-            if out_by == +1 and cell_size(text[pos - 1]) == 2:
-                return (
-                    _Segment(text[: pos - 1] + " ", style, control),
-                    _Segment(" " + text[pos:], style, control),
-                )
-            if cell_pos < cut:
-                pos += 1
-            else:
-                pos -= 1
+            cell_pos += char_width
+
+        return segment, _Segment("", style, control)
+
+        
+        
 
     def split_cells(self, cut: int) -> Tuple["Segment", "Segment"]:
         """Split segment in to two segments at the specified column.

--- a/rich/segment.py
+++ b/rich/segment.py
@@ -120,7 +120,7 @@ class Segment(NamedTuple):
         """
         text, style, control = segment
         _Segment = Segment
-        
+
         cell_length = segment.cell_length
         if cut >= cell_length:
             return segment, _Segment("", style, control)
@@ -135,7 +135,7 @@ class Segment(NamedTuple):
                 if cell_pos + char_width == cut + 1 and char_width == 2:
                     return (
                         _Segment(text[:pos] + " ", style, control),
-                        _Segment(" " + text[pos + 1:], style, control),
+                        _Segment(" " + text[pos + 1 :], style, control),
                     )
                 return (
                     _Segment(text[:pos], style, control),
@@ -144,9 +144,6 @@ class Segment(NamedTuple):
             cell_pos += char_width
 
         return segment, _Segment("", style, control)
-
-        
-        
 
     def split_cells(self, cut: int) -> Tuple["Segment", "Segment"]:
         """Split segment in to two segments at the specified column.

--- a/rich/segment.py
+++ b/rich/segment.py
@@ -126,22 +126,41 @@ class Segment(NamedTuple):
             return segment, _Segment("", style, control)
 
         cell_size = get_character_cell_size
-        cell_size = get_character_cell_size
-        cell_pos = 0
 
-        for pos, char in enumerate(text):
-            char_width = cell_size(char)
-            if cell_pos + char_width > cut:
-                if cell_pos + char_width == cut + 1 and char_width == 2:
-                    return (
-                        _Segment(text[:pos] + " ", style, control),
-                        _Segment(" " + text[pos + 1 :], style, control),
-                    )
+        # Cheap initial guess assuming ~1 cell per character, then correct
+        # by walking from the guess toward the answer (not from index 0).
+        pos = min(cut, len(text) - 1)
+        cell_pos = sum(cell_size(character) for character in text[:pos])
+
+        if cell_pos + cell_size(text[pos]) > cut:
+            # Guess overshot - walk left while an earlier position also overshoots.
+            while pos > 0:
+                prev_width = cell_size(text[pos - 1])
+                prev_cell_pos = cell_pos - prev_width
+                if prev_cell_pos + prev_width > cut:
+                    pos -= 1
+                    cell_pos = prev_cell_pos
+                else:
+                    break
+        else:
+            # Guess undershot - walk right until we find the crossing point.
+            while pos < len(text) - 1:
+                cell_pos += cell_size(text[pos])
+                pos += 1
+                if cell_pos + cell_size(text[pos]) > cut:
+                    break
+
+        char_width = cell_size(text[pos])
+        if cell_pos + char_width > cut:
+            if cell_pos + char_width == cut + 1 and char_width == 2:
                 return (
-                    _Segment(text[:pos], style, control),
-                    _Segment(text[pos:], style, control),
+                    _Segment(text[:pos] + " ", style, control),
+                    _Segment(" " + text[pos + 1 :], style, control),
                 )
-            cell_pos += char_width
+            return (
+                _Segment(text[:pos], style, control),
+                _Segment(text[pos:], style, control),
+            )
 
         return segment, _Segment("", style, control)
 

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -328,15 +328,14 @@ def test_split_cells_mixed(segment: Segment) -> None:
         assert cell_len(right.text) == segment.cell_length - position
 
 
-
 def test_split_cells_emoji():
     """Regression test for #3299 — non-unit chars in _split_cells."""
     # cut=3 falls inside fox2 (cells 2-3), so fox2 becomes two spaces
     s = Segment("🦊🦊🦊\n\n\n\n\n\n")
     left, right = Segment._split_cells(s, 3)
-    assert left.text == "🦊 "        # one fox + padding space
-    assert left.cell_length == 3      # emoji(2) + space(1)
-    assert right.text.startswith(" ") # padding space on right side
+    assert left.text == "🦊 "  # one fox + padding space
+    assert left.cell_length == 3  # emoji(2) + space(1)
+    assert right.text.startswith(" ")  # padding space on right side
     assert right.text.count("🦊") == 1  # fox3 still on right
 
     # cut=3 inside fox2 again, abcdef goes to right
@@ -420,5 +419,3 @@ def test_align_bottom():
         [Segment("   ", Style())],
         [Segment("X")],
     ]
-
-

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -296,8 +296,10 @@ def test_divide_edge_2():
         ),
     ],
 )
-def test_split_cells_emoji(text, split, result):
-    assert Segment(text).split_cells(split) == result
+def test_split_cells(text: str, split: int, result: tuple) -> None:
+    """Check that _split_cells produces the correct result."""
+    segment = Segment(text)
+    assert Segment._split_cells(segment, split) == result
 
 
 @pytest.mark.parametrize(
@@ -324,6 +326,31 @@ def test_split_cells_mixed(segment: Segment) -> None:
         )  # Sanity check there aren't any sneaky control codes
         assert cell_len(left.text) == position
         assert cell_len(right.text) == segment.cell_length - position
+
+
+
+def test_split_cells_emoji():
+    """Regression test for #3299 — non-unit chars in _split_cells."""
+    # cut=3 falls inside fox2 (cells 2-3), so fox2 becomes two spaces
+    s = Segment("🦊🦊🦊\n\n\n\n\n\n")
+    left, right = Segment._split_cells(s, 3)
+    assert left.text == "🦊 "        # one fox + padding space
+    assert left.cell_length == 3      # emoji(2) + space(1)
+    assert right.text.startswith(" ") # padding space on right side
+    assert right.text.count("🦊") == 1  # fox3 still on right
+
+    # cut=3 inside fox2 again, abcdef goes to right
+    s = Segment("🦊🦊🦊abcdef")
+    left, right = Segment._split_cells(s, 3)
+    assert left.text == "🦊 "
+    assert "abcdef" in right.text
+    assert right.text.count("🦊") == 1
+
+    # Sanity: cut on exact boundary (after fox1, cell=2)
+    s = Segment("🦊🦊🦊abcdef")
+    left, right = Segment._split_cells(s, 2)
+    assert left.text == "🦊"
+    assert right.text == "🦊🦊abcdef"
 
 
 def test_split_cells_doubles() -> None:
@@ -393,3 +420,5 @@ def test_align_bottom():
         [Segment("   ", Style())],
         [Segment("X")],
     ]
+
+


### PR DESCRIPTION
Fixes #3299

The previous implementation used a proportional heuristic to estimate the starting character position, which overshot for multi-cell characters like emoji. Replace with a linear scan that accumulates real cell widths.


<!--
Please note that Rich isn't accepting any new features at this point.

If a feature can be implemented without modifying the core library, then
they should be released as a third-party module. I can accept updates to the
core library that make it easier to extend (think hooks).

Bugfixes are always welcome of course.

Sometimes it is not clear what is a feature and what is a bug fix.
If there is any doubt, please open a discussion first.

-->

<!--
*Are you contributing typo fixes?*

If your PR solely consists of typos, at least one must be in the docs to warrant an addition to CONTRIBUTORS.md
-->

## Type of changes

-✅ Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- ✅ Tests
- [ ] Other

## AI?

- [ ] AI was used to generate this PR

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- ✅ I've added tests for new code.
- ✅ I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes #3299

`Segment._split_cells` used a proportional heuristic to guess the starting 
character position:

    pos = int((cut / cell_length) * len(text))

This overshot for multi-cell characters (emoji, CJK) because it assumed all 
characters have equal width. The fallback loop then couldn't recover correctly,
producing wrong splits like `('🦊🦊 ', ' abcdef')` instead of `('🦊 ', ' abcdef')`.

Fixed by replacing the heuristic + loop with a simple linear scan that 
accumulates real cell widths character by character, stopping precisely at 
the cut point.

Added a regression test `test_split_cells_emoji` covering the two examples 
from the issue plus an exact-boundary case.
