### PR TITLE
feat: add IterationSpeedColumn to progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `IterationSpeedColumn` to display iteration speed (e.g. `1.2 it/s`), with tqdm-style inversion for slow tasks (e.g. `2.0 s/it`), and an optional `unit` parameter for custom labels. https://github.com/Textualize/rich/issues/926
+- Added `IterationSpeedColumn` to display iteration speed (e.g. `1.2 it/s`), with tqdm-style inversion for slow tasks (e.g. `2.0 s/it`), and an optional `unit` parameter for custom labels.
 - Enhanced `TaskProgressColumn.render_speed` with slow-task inversion and a `style` parameter.
 
 ## [15.0.0] - 2026-04-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `IterationSpeedColumn` to display iteration speed (e.g. `1.2 it/s`), with tqdm-style inversion for slow tasks (e.g. `2.0 s/it`), and an optional `unit` parameter for custom labels. https://github.com/Textualize/rich/issues/926
+- Enhanced `TaskProgressColumn.render_speed` with slow-task inversion and a `style` parameter.
+
 ## [15.0.0] - 2026-04-12
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,6 +39,7 @@ The following people have contributed to the development of Rich:
 - [Hugo van Kemenade](https://github.com/hugovk)
 - [Andrew Kettmann](https://github.com/akettmann)
 - [Alexander Krasnikov](https://github.com/askras)
+- [Pierre Lapolla](https://github.com/PierreLapolla)
 - [Martin Larralde](https://github.com/althonos)
 - [Hedy Li](https://github.com/hedythedev)
 - [Henry Mai](https://github.com/tanducmai)

--- a/docs/source/progress.rst
+++ b/docs/source/progress.rst
@@ -161,6 +161,7 @@ The following column objects are available:
 - :class:`~rich.progress.TotalFileSizeColumn` Displays total file size (assumes the steps are bytes).
 - :class:`~rich.progress.DownloadColumn` Displays download progress (assumes the steps are bytes).
 - :class:`~rich.progress.TransferSpeedColumn` Displays transfer speed (assumes the steps are bytes).
+- :class:`~rich.progress.IterationSpeedColumn` Displays iteration speed (e.g. ``1.2 it/s``), or seconds per iteration for slow tasks (e.g. ``2.0 s/it``). Accepts a ``unit`` parameter for custom labels.
 - :class:`~rich.progress.SpinnerColumn` Displays a "spinner" animation.
 - :class:`~rich.progress.RenderableColumn` Displays an arbitrary Rich renderable in the column.
 

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -752,7 +752,7 @@ class TaskProgressColumn(TextColumn):
         """
         if speed is None:
             return Text("", style=style)
-        if speed < 1:
+        if 0 < speed < 1:
             return Text(f"{1 / speed:.1f} s/{unit}", style=style)
         scale, suffix = filesize.pick_unit_and_suffix(
             int(speed),

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -734,24 +734,33 @@ class TaskProgressColumn(TextColumn):
         )
 
     @classmethod
-    def render_speed(cls, speed: Optional[float]) -> Text:
-        """Render the speed in iterations per second.
+    def render_speed(
+        cls,
+        speed: Optional[float],
+        style: StyleType = "progress.percentage",
+        unit: str = "it",
+    ) -> Text:
+        """Render the speed in iterations per second, or seconds per iteration for slow tasks.
 
         Args:
-            task (Task): A Task object.
+            speed (Optional[float]): Speed in iterations per second, or None if unknown.
+            style (StyleType, optional): Style to apply. Defaults to "progress.percentage".
+            unit (str, optional): Unit label for iterations. Defaults to "it".
 
         Returns:
             Text: Text object containing the task speed.
         """
         if speed is None:
-            return Text("", style="progress.percentage")
-        unit, suffix = filesize.pick_unit_and_suffix(
+            return Text("", style=style)
+        if speed < 1:
+            return Text(f"{1 / speed:.1f} s/{unit}", style=style)
+        scale, suffix = filesize.pick_unit_and_suffix(
             int(speed),
             ["", "×10³", "×10⁶", "×10⁹", "×10¹²"],
             1000,
         )
-        data_speed = speed / unit
-        return Text(f"{data_speed:.1f}{suffix} it/s", style="progress.percentage")
+        data_speed = speed / scale
+        return Text(f"{data_speed:.1f}{suffix} {unit}/s", style=style)
 
     def render(self, task: "Task") -> Text:
         if task.total is None and self.show_speed:
@@ -767,6 +776,24 @@ class TaskProgressColumn(TextColumn):
         if self.highlighter:
             self.highlighter.highlight(text)
         return text
+
+
+class IterationSpeedColumn(ProgressColumn):
+    """Renders iteration speed, e.g. '1.2 it/s', or seconds per iteration for slow tasks, e.g. '2.0 s/it'.
+
+    Args:
+        unit (str, optional): Unit label for iterations. Defaults to "it".
+    """
+
+    def __init__(self, unit: str = "it", table_column: Optional[Column] = None) -> None:
+        self.unit = unit
+        super().__init__(table_column=table_column)
+
+    def render(self, task: "Task") -> Text:
+        speed = task.finished_speed or task.speed
+        return TaskProgressColumn.render_speed(
+            speed, style="progress.data.speed", unit=self.unit
+        )
 
 
 class TimeRemainingColumn(ProgressColumn):

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -14,6 +14,7 @@ from rich.progress import (
     BarColumn,
     DownloadColumn,
     FileSizeColumn,
+    IterationSpeedColumn,
     MofNCompleteColumn,
     Progress,
     RenderableColumn,
@@ -682,6 +683,34 @@ def test_task_progress_column_speed() -> None:
 
     speed_text = TaskProgressColumn.render_speed(8888888)
     assert speed_text.plain == "8.9×10⁶ it/s"
+
+    speed_text = TaskProgressColumn.render_speed(0.5)
+    assert speed_text.plain == "2.0 s/it"
+
+    speed_text = TaskProgressColumn.render_speed(0.1)
+    assert speed_text.plain == "10.0 s/it"
+
+
+def test_iteration_speed_column() -> None:
+    column = IterationSpeedColumn()
+    task = Task(TaskID(1), "test", 100, 50, _get_time=lambda: 1.0)
+
+    assert column.render(task).plain == ""
+
+    task.finished_speed = 5.0
+    assert column.render(task).plain == "5.0 it/s"
+
+    task.finished_speed = 0.5
+    assert column.render(task).plain == "2.0 s/it"
+
+    assert column.render(task).style == "progress.data.speed"
+
+    column = IterationSpeedColumn(unit="sample")
+    task.finished_speed = 5.0
+    assert column.render(task).plain == "5.0 sample/s"
+
+    task.finished_speed = 0.5
+    assert column.render(task).plain == "2.0 s/sample"
 
 
 if __name__ == "__main__":

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -690,6 +690,9 @@ def test_task_progress_column_speed() -> None:
     speed_text = TaskProgressColumn.render_speed(0.1)
     assert speed_text.plain == "10.0 s/it"
 
+    speed_text = TaskProgressColumn.render_speed(0.0)
+    assert speed_text.plain == "0.0 it/s"
+
 
 def test_iteration_speed_column() -> None:
     column = IterationSpeedColumn()


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## AI?

- [x] AI was used to generate this PR

> Generated with Claude Sonnet 4.6 via [Claude Code](https://claude.ai/code), with human supervision and design decisions throughout.

## Checklist

- [x] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Adds `IterationSpeedColumn`, a progress column that displays iteration speed
(e.g. `1.2 it/s`). For slow tasks (speed < 1 it/s), it displays inverted
time-per-iteration (e.g. `2.0 s/it`), matching tqdm's behaviour. An optional
`unit` parameter (default `"it"`) allows custom labels such as `"sample/s"` or
`"epoch/s"`.

This feature was already approved and merged by @willmcgugan in #3332, then
reverted solely due to dynamic `setattr` on the `Task` dataclass
(`task.last_speed = ...`), which breaks static type checkers. This
implementation avoids that entirely — `Task` is never mutated. The column reads
`task.finished_speed or task.speed`, both existing fields already tracked by
the framework.

`TaskProgressColumn.render_speed` is also enhanced (backward compatibly) with
the same slow-task inversion and a `style` parameter, so unbounded tasks using
`show_speed=True` benefit too.

**Related:**
- https://github.com/Textualize/rich/discussions/926 — original feature request
- https://github.com/Textualize/rich/pull/3332 — first implementation, merged then reverted
- https://github.com/Textualize/rich/pull/3533 — separate open attempt at the same feature