### PR TITLE
Fix ANSI decoding of CRLF line endings

### DIFF
--- a/rich/ansi.py
+++ b/rich/ansi.py
@@ -133,7 +133,11 @@ class AnsiDecoder:
             Text: Marked up Text.
         """
         for line in re.split(r"(?<=\n)", terminal_text):
-            yield self.decode_line(line.rstrip("\n"))
+            if line.endswith("\n"):
+                line = line[:-1]
+                if line.endswith("\r"):
+                    line = line[:-1]
+            yield self.decode_line(line)
 
     def decode_line(self, line: str) -> Text:
         """Decode a line containing ansi codes.

--- a/tests/test_ansi.py
+++ b/tests/test_ansi.py
@@ -102,3 +102,5 @@ def test_decode_newlines():
     assert Text.from_ansi("Hello\nWorld\n").plain == "Hello\nWorld\n"
     assert Text.from_ansi("Hello\nWorld\n\n").plain == "Hello\nWorld\n\n"
     assert Text.from_ansi("\nHello\nWorld\n\n").plain == "\nHello\nWorld\n\n"
+    assert Text.from_ansi("Hello\r\nWorld\r\n").plain == "Hello\nWorld\n"
+    assert Text.from_ansi("Hello\rWorld").plain == "World"


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## AI?

- [x] AI was used to generate this PR

I used Codex to help investigate the issue, implement the small fix, and add the regression test. I reviewed the change and understand the behavior being fixed.

AI generated PRs may be accepted, but only if @willmcgugan has responded on an issue or discussion.

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate (see note about typos above).
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes #4090.

`Text.from_ansi()` was dropping text when the input used CRLF (`\r\n`) line endings. The decoder split lines on `\n` but left the preceding `\r`, and `decode_line()` then interpreted that `\r` as terminal carriage-return overwrite behavior.

This change removes `\r` only when it is part of a CRLF line ending before decoding the line. Standalone carriage-return behavior is preserved.

Added regression coverage for:

- `Text.from_ansi("Hello\r\nWorld\r\n").plain == "Hello\nWorld\n"`
- existing carriage-return overwrite behavior with `Text.from_ansi("Hello\rWorld").plain == "World"`

I was able to run direct local regression checks, but not the full pytest suite because pytest is not installed in my local Python environment.