### PR TITLE
Optimize syntax word wrap without line numbers

### DIFF
--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -743,6 +743,19 @@ class Syntax(JupyterMixin):
             highlight_number_style,
         ) = self._get_number_styles(console)
 
+        if self.word_wrap and not self.line_numbers:
+            text = Text("\n").join(lines)
+            syntax_lines = console.render_lines(
+                text,
+                render_options.update(height=None, justify="left"),
+                style=background_style,
+                pad=not transparent_background,
+                new_lines=True,
+            )
+            for syntax_line in syntax_lines:
+                yield from syntax_line
+            return
+
         for line_no, line in enumerate(lines, self.start_line + line_offset):
             if self.word_wrap:
                 wrapped_lines = console.render_lines(

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -435,6 +435,29 @@ def test_padding_plus_wrap() -> None:
     assert output == expected
 
 
+def test_word_wrap_without_line_numbers_with_line_range() -> None:
+    console = Console(
+        width=14, file=io.StringIO(), legacy_windows=False, record=True
+    )
+    syntax = Syntax(
+        "first line should not appear\n"
+        "second line wraps around here\n"
+        "third line stays\n"
+        "fourth line should not appear",
+        lexer="text",
+        word_wrap=True,
+        line_numbers=False,
+        line_range=(2, 3),
+    )
+
+    console.print(syntax)
+
+    assert (
+        console.export_text()
+        == "second line   \nwraps around  \nhere          \nthird line    \nstays         \n"
+    )
+
+
 if __name__ == "__main__":
     syntax = Panel.fit(
         Syntax(

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -436,9 +436,7 @@ def test_padding_plus_wrap() -> None:
 
 
 def test_word_wrap_without_line_numbers_with_line_range() -> None:
-    console = Console(
-        width=14, file=io.StringIO(), legacy_windows=False, record=True
-    )
+    console = Console(width=14, file=io.StringIO(), legacy_windows=False, record=True)
     syntax = Syntax(
         "first line should not appear\n"
         "second line wraps around here\n"


### PR DESCRIPTION
## Summary

Optimizes `Syntax(word_wrap=True, line_numbers=False)` by batching wrapped rendering for the selected highlighted lines instead of calling `console.render_lines(...)` once per source line.

Closes #4176

## Tests

- `python3 -m pytest tests/test_syntax.py tests/test_console.py`