### PR TITLE
Speed up line-numbered syntax word wrap

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -94,6 +94,22 @@ class SyntaxWrappingSuite:
         self.console.print(self.syntax, width)
 
 
+class SyntaxLineNumbersWrappingSuite:
+    def setup(self):
+        self.console = Console(
+            file=StringIO(), color_system="truecolor", legacy_windows=False
+        )
+        self.syntax = Syntax(
+            code=snippets.PYTHON_SNIPPET * 120,
+            lexer="python",
+            word_wrap=True,
+            line_numbers=True,
+        )
+
+    def time_text_thin_terminal_heavy_wrapping(self):
+        self.console.print(self.syntax, width=30)
+
+
 class TableSuite:
     def time_table_no_wrapping(self):
         self._print_table(width=100)

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -758,12 +758,26 @@ class Syntax(JupyterMixin):
 
         for line_no, line in enumerate(lines, self.start_line + line_offset):
             if self.word_wrap:
-                wrapped_lines = console.render_lines(
-                    line,
-                    render_options.update(height=None, justify="left"),
-                    style=background_style,
-                    pad=not transparent_background,
-                )
+                wrapped_lines = [
+                    _Segment.adjust_line_length(
+                        list(
+                            _Segment.apply_style(
+                                wrapped_line.render(console), background_style
+                            )
+                        ),
+                        render_options.max_width,
+                        style=background_style,
+                        pad=not transparent_background,
+                    )
+                    for wrapped_line in line.wrap(
+                        console,
+                        render_options.max_width,
+                        justify="left",
+                        overflow=render_options.overflow,
+                        tab_size=self.tab_size,
+                        no_wrap=render_options.no_wrap,
+                    )
+                ]
             else:
                 segments = list(line.render(console, end=""))
                 if options.no_wrap:

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -743,6 +743,19 @@ class Syntax(JupyterMixin):
             highlight_number_style,
         ) = self._get_number_styles(console)
 
+        if self.word_wrap and not self.line_numbers:
+            text = Text("\n").join(lines)
+            syntax_lines = console.render_lines(
+                text,
+                render_options.update(height=None, justify="left"),
+                style=background_style,
+                pad=not transparent_background,
+                new_lines=True,
+            )
+            for syntax_line in syntax_lines:
+                yield from syntax_line
+            return
+
         for line_no, line in enumerate(lines, self.start_line + line_offset):
             if self.word_wrap:
                 wrapped_lines = console.render_lines(

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -435,6 +435,29 @@ def test_padding_plus_wrap() -> None:
     assert output == expected
 
 
+def test_word_wrap_without_line_numbers_with_line_range() -> None:
+    console = Console(
+        width=14, file=io.StringIO(), legacy_windows=False, record=True
+    )
+    syntax = Syntax(
+        "first line should not appear\n"
+        "second line wraps around here\n"
+        "third line stays\n"
+        "fourth line should not appear",
+        lexer="text",
+        word_wrap=True,
+        line_numbers=False,
+        line_range=(2, 3),
+    )
+
+    console.print(syntax)
+
+    assert (
+        console.export_text()
+        == "second line   \nwraps around  \nhere          \nthird line    \nstays         \n"
+    )
+
+
 if __name__ == "__main__":
     syntax = Panel.fit(
         Syntax(

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -436,9 +436,7 @@ def test_padding_plus_wrap() -> None:
 
 
 def test_word_wrap_without_line_numbers_with_line_range() -> None:
-    console = Console(
-        width=14, file=io.StringIO(), legacy_windows=False, record=True
-    )
+    console = Console(width=14, file=io.StringIO(), legacy_windows=False, record=True)
     syntax = Syntax(
         "first line should not appear\n"
         "second line wraps around here\n"


### PR DESCRIPTION
## Summary

Optimizes `Syntax(word_wrap=True, line_numbers=True)` by wrapping each highlighted `Text` source line directly instead of routing every source line through `Console.render_lines(...)`.

This stacks on #4177 and targets the remaining line-numbered wrapping path.

## Chiasmus framing

Observed:
  `Syntax(word_wrap=True, line_numbers=True)` renders each source line separately through `Console.render_lines(...)` so it can prefix only the first visual row with a line number.

Mirrored target:
  Keep per-source-line numbering, but avoid the heavier `Console.render_lines(...)` pipeline by using `Text.wrap(...)` and rendering the wrapped rows directly.

Hypothesis:
  Per-source-line `render_lines` calls are a meaningful share of runtime for syntax output with many line-numbered lines.

## Target workload

User-visible operation: `Console.print(Syntax(...))` for line-numbered, word-wrapped Python syntax output.

Workload:

```python
code = snippets.PYTHON_SNIPPET * 120
syntax = Syntax(code=code, lexer="python", word_wrap=True, line_numbers=True)
console = Console(file=StringIO(), color_system="truecolor", legacy_windows=False, width=30)
console.print(syntax)
```

Environment:
- Darwin arm64, `Darwin Kernel Version 25.5.0`
- Python 3.14.6
- Pygments 2.20.0
- pytest 9.0.3

## Performance

Before, on #4177 tip before this change:

```text
median: 0.769979s over 7 runs
profile: 8,041 Console.render_lines calls; render_lines cumulative 1.340s
```

After:

```text
median: 0.681495s over 7 runs
profile: Console.render_lines no longer appears in the top 20 cumulative functions
```

This is about an 11.5% speedup for the target workload.

## Correctness

```text
python3 -m pytest tests/test_syntax.py tests/test_console.py
126 passed
```

I also smoke-tested the new ASV benchmark method:

```text
SyntaxLineNumbersWrappingSuite.setup()
SyntaxLineNumbersWrappingSuite.time_text_thin_terminal_heavy_wrapping()
```

## Tradeoffs

No new cache or retained state. The implementation duplicates the small part of `Console.render_lines(...)` needed for this hot path: style application and fixed-width line adjustment after `Text.wrap(...)`.

## Stack

| Order | PR | Branch | Merge after |
| --- | --- | --- | --- |
| 1 | #4177 | `optimize-syntax-word-wrap` | `main` |
| 2 | #4178 | `perf/syntax-line-numbers-word-wrap` | #4177 |
