### PR TITLE
Wrap syntax text directly

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -110,6 +110,22 @@ class SyntaxLineNumbersWrappingSuite:
         self.console.print(self.syntax, width=30)
 
 
+class SyntaxLargeWrappingSuite:
+    def setup(self):
+        self.console = Console(
+            file=StringIO(), color_system="truecolor", legacy_windows=False
+        )
+        self.syntax = Syntax(
+            code=snippets.PYTHON_SNIPPET * 120,
+            lexer="python",
+            word_wrap=True,
+            line_numbers=False,
+        )
+
+    def time_text_thin_terminal_heavy_wrapping(self):
+        self.console.print(self.syntax, width=30)
+
+
 class TableSuite:
     def time_table_no_wrapping(self):
         self._print_table(width=100)

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -94,6 +94,22 @@ class SyntaxWrappingSuite:
         self.console.print(self.syntax, width)
 
 
+class SyntaxLineNumbersWrappingSuite:
+    def setup(self):
+        self.console = Console(
+            file=StringIO(), color_system="truecolor", legacy_windows=False
+        )
+        self.syntax = Syntax(
+            code=snippets.PYTHON_SNIPPET * 120,
+            lexer="python",
+            word_wrap=True,
+            line_numbers=True,
+        )
+
+    def time_text_thin_terminal_heavy_wrapping(self):
+        self.console.print(self.syntax, width=30)
+
+
 class TableSuite:
     def time_table_no_wrapping(self):
         self._print_table(width=100)

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -758,12 +758,26 @@ class Syntax(JupyterMixin):
 
         for line_no, line in enumerate(lines, self.start_line + line_offset):
             if self.word_wrap:
-                wrapped_lines = console.render_lines(
-                    line,
-                    render_options.update(height=None, justify="left"),
-                    style=background_style,
-                    pad=not transparent_background,
-                )
+                wrapped_lines = [
+                    _Segment.adjust_line_length(
+                        list(
+                            _Segment.apply_style(
+                                wrapped_line.render(console), background_style
+                            )
+                        ),
+                        render_options.max_width,
+                        style=background_style,
+                        pad=not transparent_background,
+                    )
+                    for wrapped_line in line.wrap(
+                        console,
+                        render_options.max_width,
+                        justify="left",
+                        overflow=render_options.overflow,
+                        tab_size=self.tab_size,
+                        no_wrap=render_options.no_wrap,
+                    )
+                ]
             else:
                 segments = list(line.render(console, end=""))
                 if options.no_wrap:

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -745,15 +745,25 @@ class Syntax(JupyterMixin):
 
         if self.word_wrap and not self.line_numbers:
             text = Text("\n").join(lines)
-            syntax_lines = console.render_lines(
-                text,
-                render_options.update(height=None, justify="left"),
-                style=background_style,
-                pad=not transparent_background,
-                new_lines=True,
-            )
-            for syntax_line in syntax_lines:
-                yield from syntax_line
+            for wrapped_text_line in text.wrap(
+                console,
+                render_options.max_width,
+                justify="left",
+                overflow=render_options.overflow,
+                tab_size=self.tab_size,
+                no_wrap=render_options.no_wrap,
+            ):
+                yield from _Segment.adjust_line_length(
+                    list(
+                        _Segment.apply_style(
+                            wrapped_text_line.render(console), background_style
+                        )
+                    ),
+                    render_options.max_width,
+                    style=background_style,
+                    pad=not transparent_background,
+                )
+                yield new_line
             return
 
         for line_no, line in enumerate(lines, self.start_line + line_offset):
@@ -796,7 +806,7 @@ class Syntax(JupyterMixin):
                 wrapped_line_left_pad = _Segment(
                     " " * numbers_column_width + " ", background_style
                 )
-                for first, wrapped_line in loop_first(wrapped_lines):
+                for first, wrapped_segments in loop_first(wrapped_lines):
                     if first:
                         line_column = str(line_no).rjust(numbers_column_width - 2) + " "
                         if highlight_line(line_no):
@@ -807,11 +817,11 @@ class Syntax(JupyterMixin):
                             yield _Segment(line_column, number_style)
                     else:
                         yield wrapped_line_left_pad
-                    yield from wrapped_line
+                    yield from wrapped_segments
                     yield new_line
             else:
-                for wrapped_line in wrapped_lines:
-                    yield from wrapped_line
+                for wrapped_segments in wrapped_lines:
+                    yield from wrapped_segments
                     yield new_line
 
     def _apply_stylized_ranges(self, text: Text) -> None:

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -743,6 +743,19 @@ class Syntax(JupyterMixin):
             highlight_number_style,
         ) = self._get_number_styles(console)
 
+        if self.word_wrap and not self.line_numbers:
+            text = Text("\n").join(lines)
+            syntax_lines = console.render_lines(
+                text,
+                render_options.update(height=None, justify="left"),
+                style=background_style,
+                pad=not transparent_background,
+                new_lines=True,
+            )
+            for syntax_line in syntax_lines:
+                yield from syntax_line
+            return
+
         for line_no, line in enumerate(lines, self.start_line + line_offset):
             if self.word_wrap:
                 wrapped_lines = console.render_lines(

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -435,6 +435,29 @@ def test_padding_plus_wrap() -> None:
     assert output == expected
 
 
+def test_word_wrap_without_line_numbers_with_line_range() -> None:
+    console = Console(
+        width=14, file=io.StringIO(), legacy_windows=False, record=True
+    )
+    syntax = Syntax(
+        "first line should not appear\n"
+        "second line wraps around here\n"
+        "third line stays\n"
+        "fourth line should not appear",
+        lexer="text",
+        word_wrap=True,
+        line_numbers=False,
+        line_range=(2, 3),
+    )
+
+    console.print(syntax)
+
+    assert (
+        console.export_text()
+        == "second line   \nwraps around  \nhere          \nthird line    \nstays         \n"
+    )
+
+
 if __name__ == "__main__":
     syntax = Panel.fit(
         Syntax(

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -436,9 +436,7 @@ def test_padding_plus_wrap() -> None:
 
 
 def test_word_wrap_without_line_numbers_with_line_range() -> None:
-    console = Console(
-        width=14, file=io.StringIO(), legacy_windows=False, record=True
-    )
+    console = Console(width=14, file=io.StringIO(), legacy_windows=False, record=True)
     syntax = Syntax(
         "first line should not appear\n"
         "second line wraps around here\n"


### PR DESCRIPTION
## Summary

Optimizes `Syntax(word_wrap=True, line_numbers=False)` by wrapping the highlighted `Text` directly and yielding adjusted segments, instead of sending the whole renderable through `Console.render_lines(...)`.

This stacks on #4178 and continues the syntax word-wrap performance work.

## Performance framing

Observed:
  The no-line-number word-wrap path still routes large syntax output through `Console.render_lines(...)`, which re-enters the generic render pipeline and then splits/crops the rendered segments.

Target:
  Wrap the highlighted syntax `Text` directly, then render and adjust each wrapped line for the configured width.

Hypothesis:
  Avoiding the generic `render_lines` path should reduce overhead for large syntax blocks while preserving padding, styles, blank lines, trailing newlines, and line ranges.

## Target workload

User-visible operation: `Console.print(Syntax(...))` for large word-wrapped Python syntax output without line numbers.

Workload:

```python
code = snippets.PYTHON_SNIPPET * 120
syntax = Syntax(code=code, lexer="python", word_wrap=True, line_numbers=False)
console = Console(file=StringIO(), color_system="truecolor", legacy_windows=False, width=30)
console.print(syntax)
```

Environment:
- Darwin arm64, `Darwin Kernel Version 25.5.0`
- Python 3.14.6
- Pygments 2.20.0
- pytest 9.0.3

## Performance

Before, on #4178 tip before this change:

```text
median: 0.756429s over 7 runs
profile: Console.render_lines cumulative 1.024s
```

After:

```text
median: 0.716699s over 7 runs
profile: Console.render_lines no longer appears in the hot path
```

This is about a 5.3% speedup for the target workload.

## Correctness

```text
python3 -m pytest tests/test_syntax.py tests/test_console.py
126 passed
```

I also checked output preservation for plain wrapped text, trailing newlines, blank middle lines, and `line_range`, and smoke-tested the new ASV benchmark method:

```text
SyntaxLargeWrappingSuite.setup()
SyntaxLargeWrappingSuite.time_text_thin_terminal_heavy_wrapping()
```

## Tradeoffs

No cache or retained state. This duplicates the small part of `Console.render_lines(...)` needed here: style application, fixed-width adjustment, and newline emission after `Text.wrap(...)`.

## Stack

| Order | PR | Branch | Merge after |
| --- | --- | --- | --- |
| 1 | #4177 | `optimize-syntax-word-wrap` | `main` |
| 2 | #4178 | `perf/syntax-line-numbers-word-wrap` | #4177 |
| 3 | #4179 | `perf/syntax-direct-word-wrap` | #4178 |
