### PR TITLE
Split quality checks from CI test matrix

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,6 +3,40 @@ name: Test Rich module
 on: [pull_request]
 
 jobs:
+  quality:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install and configure Poetry
+        # TODO: workaround for https://github.com/snok/install-poetry/issues/94
+        uses: snok/install-poetry@v1.3.4
+        with:
+          version: 1.3.1
+          virtualenvs-in-project: true
+      - name: Install dependencies
+        run: poetry install
+      - name: Format check with black
+        run: poetry run make format-check
+      - name: Typecheck with mypy
+        run: poetry run make typecheck
+      - name: Test with pytest (with coverage)
+        run: poetry run pytest tests -v --cov=./rich --cov-report=xml:./coverage.xml --cov-report term-missing
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          name: rich
+          flags: unittests
+          env_vars: OS,PYTHON
+
   build:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -12,6 +46,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           - { os: windows-latest, python-version: "3.13" }
+          - { os: ubuntu-latest, python-version: "3.11" }
     defaults:
       run:
         shell: bash
@@ -30,24 +65,5 @@ jobs:
           virtualenvs-in-project: true
       - name: Install dependencies
         run: poetry install
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-      - name: Format check with black
-        run: |
-          source $VENV
-          make format-check
-      - name: Typecheck with mypy
-        run: |
-          source $VENV
-          make typecheck
-      - name: Test with pytest (with coverage)
-        run: |
-          source $VENV
-          pytest tests -v --cov=./rich --cov-report=xml:./coverage.xml --cov-report term-missing
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          name: rich
-          flags: unittests
-          env_vars: OS,PYTHON
+      - name: Test with pytest
+        run: poetry run pytest tests -v

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -38,6 +38,7 @@ jobs:
           env_vars: OS,PYTHON
 
   build:
+    needs: quality
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -57,6 +57,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Install dependencies
-        run: uv pip install --system -e . --group dev
+        run: uv pip install --system -e . --group test
       - name: Test with pytest
         run: python -m pytest tests -v

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,16 +17,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Install dependencies
-        run: >
-          uv pip install --system -e .
-          "attrs==21.4.0"
-          "black==22.12.0"
-          "markdown-it-py==3.0.0"
-          "mypy==1.14.1"
-          "pygments==2.19.2"
-          "pytest==7.4.4"
-          "pytest-cov==3.0.0"
-          "typing-extensions==4.13.2"
+        run: uv pip install --system -e . --group dev
       - name: Format check with black
         run: python -m black --check .
       - name: Typecheck with mypy
@@ -66,12 +57,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Install dependencies
-        run: >
-          uv pip install --system -e .
-          "attrs==21.4.0"
-          "markdown-it-py==3.0.0"
-          "pygments==2.19.2"
-          "pytest==7.4.4"
-          "typing-extensions==4.13.2"
+        run: uv pip install --system -e . --group dev
       - name: Test with pytest
         run: python -m pytest tests -v

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,20 +14,25 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install and configure Poetry
-        # TODO: workaround for https://github.com/snok/install-poetry/issues/94
-        uses: snok/install-poetry@v1.3.4
-        with:
-          version: 1.3.1
-          virtualenvs-in-project: true
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
       - name: Install dependencies
-        run: poetry install
+        run: >
+          uv pip install --system -e .
+          "attrs==21.4.0"
+          "black==22.12.0"
+          "markdown-it-py==3.0.0"
+          "mypy==1.14.1"
+          "pygments==2.19.2"
+          "pytest==7.4.4"
+          "pytest-cov==3.0.0"
+          "typing-extensions==4.13.2"
       - name: Format check with black
-        run: poetry run make format-check
+        run: python -m black --check .
       - name: Typecheck with mypy
-        run: poetry run make typecheck
+        run: python -m mypy -p rich --no-incremental
       - name: Test with pytest (with coverage)
-        run: poetry run pytest tests -v --cov=./rich --cov-report=xml:./coverage.xml --cov-report term-missing
+        run: python -m pytest tests -v --cov=./rich --cov-report=xml:./coverage.xml --cov-report term-missing
       - name: Upload code coverage
         uses: codecov/codecov-action@v4
         with:
@@ -58,13 +63,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - name: Install and configure Poetry
-        # TODO: workaround for https://github.com/snok/install-poetry/issues/94
-        uses: snok/install-poetry@v1.3.4
-        with:
-          version: 1.3.1
-          virtualenvs-in-project: true
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
       - name: Install dependencies
-        run: poetry install
+        run: >
+          uv pip install --system -e .
+          "attrs==21.4.0"
+          "markdown-it-py==3.0.0"
+          "pygments==2.19.2"
+          "pytest==7.4.4"
+          "typing-extensions==4.13.2"
       - name: Test with pytest
-        run: poetry run pytest tests -v
+        run: python -m pytest tests -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,16 @@ attrs = "^21.4.0"
 pre-commit = "^2.17.0"
 typing-extensions = ">=4.0.0, <5.0"
 
+[dependency-groups]
+dev = [
+    "pytest>=7.0.0,<8.0.0",
+    "black>=22.6,<23.0",
+    "mypy>=1.11,<2.0",
+    "pytest-cov>=3.0.0,<4.0.0",
+    "attrs>=21.4.0,<22.0.0",
+    "typing-extensions>=4.0.0,<5.0",
+]
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,12 +45,15 @@ pre-commit = "^2.17.0"
 typing-extensions = ">=4.0.0, <5.0"
 
 [dependency-groups]
-dev = [
+test = [
     "pytest>=7.0.0,<8.0.0",
+    "attrs>=21.4.0,<22.0.0",
+]
+dev = [
+    { include-group = "test" },
     "black>=22.6,<23.0",
     "mypy>=1.11,<2.0",
     "pytest-cov>=3.0.0,<4.0.0",
-    "attrs>=21.4.0,<22.0.0",
     "typing-extensions>=4.0.0,<5.0",
 ]
 


### PR DESCRIPTION
## Summary

Splits OS/Python-independent quality checks out of the full test matrix and replaces Poetry-based dependency setup with uv-based installs.

Before, every matrix entry ran:

- `black --check .`
- `mypy -p rich --no-incremental`
- `pytest` with coverage
- Codecov upload

After this change:

- A single Ubuntu 3.11 `quality` job runs Black, mypy, coverage, and Codecov upload.
- The OS/Python matrix runs plain `pytest tests -v` after `quality` passes.
- The duplicate Ubuntu 3.11 matrix entry is excluded because the `quality` job already covers that runtime.
- CI installs with uv.
- `pyproject.toml` now includes PEP-style dependency groups:
  - `test` for matrix jobs: pytest plus attrs.
  - `dev` for quality: includes `test`, plus Black, mypy, pytest-cov, and typing-extensions.
- The stale `steps.cached-poetry-dependencies.outputs.cache-hit` condition is removed because there was no cache step defining it.

## Why

The previous workflow repeated format checks, type checks, coverage generation, and coverage upload across 17 matrix jobs. Those checks are not OS-specific, and coverage only needs to be uploaded once.

This keeps compatibility coverage across Windows, macOS, Ubuntu, and Python versions, while reducing repeated CI work and replacing Poetry environment setup with uv installs.

## Validation

```text
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pythonpackage.yml"); puts "yaml ok"'
actionlint .github/workflows/pythonpackage.yml
git diff --check
python3 - <<'PY'
import tomllib
with open('pyproject.toml', 'rb') as file:
    tomllib.load(file)
PY
```

I also tested both uv dependency groups in temporary virtualenvs:

```text
uv pip install -e . --group test
python -m pytest tests/test_pretty.py tests/test_syntax.py -q

uv pip install -e . --group dev
python -m black --check rich/syntax.py
python -m mypy rich/syntax.py --no-incremental
```

All passed locally.

## Expected CI impact

- Build matrix jobs: 17 -> 16
- Quality/coverage work: 17 repeated runs -> 1 run
- Codecov uploads: 17 -> 1
- Build matrix waits for `quality`, avoiding matrix spend when formatting/typechecking/coverage fails
- Matrix installs a smaller `test` dependency group instead of all dev tooling
- Replaces Poetry install/setup with uv dependency-group installs
