### PR TITLE
Skip hidden line-range syntax prefix text

### DIFF
--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -110,6 +110,22 @@ class SyntaxLineNumbersWrappingSuite:
         self.console.print(self.syntax, width=30)
 
 
+class SyntaxLargeWrappingSuite:
+    def setup(self):
+        self.console = Console(
+            file=StringIO(), color_system="truecolor", legacy_windows=False
+        )
+        self.syntax = Syntax(
+            code=snippets.PYTHON_SNIPPET * 120,
+            lexer="python",
+            word_wrap=True,
+            line_numbers=False,
+        )
+
+    def time_text_thin_terminal_heavy_wrapping(self):
+        self.console.print(self.syntax, width=30)
+
+
 class TableSuite:
     def time_table_no_wrapping(self):
         self._print_table(width=100)

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -142,6 +142,23 @@ class SyntaxLargeNoWrapSuite:
         self.console.print(self.syntax, width=80)
 
 
+class SyntaxLineRangeSuite:
+    def setup(self):
+        self.console = Console(
+            file=StringIO(), color_system="truecolor", legacy_windows=False
+        )
+        self.syntax = Syntax(
+            code=snippets.PYTHON_SNIPPET * 120,
+            lexer="python",
+            word_wrap=False,
+            line_numbers=False,
+            line_range=(3000, 3060),
+        )
+
+    def time_text_wide_terminal_line_range(self):
+        self.console.print(self.syntax, width=80)
+
+
 class TableSuite:
     def time_table_no_wrapping(self):
         self._print_table(width=100)

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -126,6 +126,22 @@ class SyntaxLargeWrappingSuite:
         self.console.print(self.syntax, width=30)
 
 
+class SyntaxLargeNoWrapSuite:
+    def setup(self):
+        self.console = Console(
+            file=StringIO(), color_system="truecolor", legacy_windows=False
+        )
+        self.syntax = Syntax(
+            code=snippets.PYTHON_SNIPPET * 120,
+            lexer="python",
+            word_wrap=False,
+            line_numbers=False,
+        )
+
+    def time_text_wide_terminal_no_wrapping(self):
+        self.console.print(self.syntax, width=80)
+
+
 class TableSuite:
     def time_table_no_wrapping(self):
         self._print_table(width=100)

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -94,6 +94,22 @@ class SyntaxWrappingSuite:
         self.console.print(self.syntax, width)
 
 
+class SyntaxLineNumbersWrappingSuite:
+    def setup(self):
+        self.console = Console(
+            file=StringIO(), color_system="truecolor", legacy_windows=False
+        )
+        self.syntax = Syntax(
+            code=snippets.PYTHON_SNIPPET * 120,
+            lexer="python",
+            word_wrap=True,
+            line_numbers=True,
+        )
+
+    def time_text_thin_terminal_heavy_wrapping(self):
+        self.console.print(self.syntax, width=30)
+
+
 class TableSuite:
     def time_table_no_wrapping(self):
         self._print_table(width=100)

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -758,12 +758,26 @@ class Syntax(JupyterMixin):
 
         for line_no, line in enumerate(lines, self.start_line + line_offset):
             if self.word_wrap:
-                wrapped_lines = console.render_lines(
-                    line,
-                    render_options.update(height=None, justify="left"),
-                    style=background_style,
-                    pad=not transparent_background,
-                )
+                wrapped_lines = [
+                    _Segment.adjust_line_length(
+                        list(
+                            _Segment.apply_style(
+                                wrapped_line.render(console), background_style
+                            )
+                        ),
+                        render_options.max_width,
+                        style=background_style,
+                        pad=not transparent_background,
+                    )
+                    for wrapped_line in line.wrap(
+                        console,
+                        render_options.max_width,
+                        justify="left",
+                        overflow=render_options.overflow,
+                        tab_size=self.tab_size,
+                        no_wrap=render_options.no_wrap,
+                    )
+                ]
             else:
                 segments = list(line.render(console, end=""))
                 if options.no_wrap:

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -745,15 +745,25 @@ class Syntax(JupyterMixin):
 
         if self.word_wrap and not self.line_numbers:
             text = Text("\n").join(lines)
-            syntax_lines = console.render_lines(
-                text,
-                render_options.update(height=None, justify="left"),
-                style=background_style,
-                pad=not transparent_background,
-                new_lines=True,
-            )
-            for syntax_line in syntax_lines:
-                yield from syntax_line
+            for wrapped_text_line in text.wrap(
+                console,
+                render_options.max_width,
+                justify="left",
+                overflow=render_options.overflow,
+                tab_size=self.tab_size,
+                no_wrap=render_options.no_wrap,
+            ):
+                yield from _Segment.adjust_line_length(
+                    list(
+                        _Segment.apply_style(
+                            wrapped_text_line.render(console), background_style
+                        )
+                    ),
+                    render_options.max_width,
+                    style=background_style,
+                    pad=not transparent_background,
+                )
+                yield new_line
             return
 
         for line_no, line in enumerate(lines, self.start_line + line_offset):
@@ -796,7 +806,7 @@ class Syntax(JupyterMixin):
                 wrapped_line_left_pad = _Segment(
                     " " * numbers_column_width + " ", background_style
                 )
-                for first, wrapped_line in loop_first(wrapped_lines):
+                for first, wrapped_segments in loop_first(wrapped_lines):
                     if first:
                         line_column = str(line_no).rjust(numbers_column_width - 2) + " "
                         if highlight_line(line_no):
@@ -807,11 +817,11 @@ class Syntax(JupyterMixin):
                             yield _Segment(line_column, number_style)
                     else:
                         yield wrapped_line_left_pad
-                    yield from wrapped_line
+                    yield from wrapped_segments
                     yield new_line
             else:
-                for wrapped_line in wrapped_lines:
-                    yield from wrapped_line
+                for wrapped_segments in wrapped_lines:
+                    yield from wrapped_segments
                     yield new_line
 
     def _apply_stylized_ranges(self, text: Text) -> None:

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -693,15 +693,18 @@ class Syntax(JupyterMixin):
                     text, options=options.update(width=code_width)
                 )
             else:
-                syntax_lines = console.render_lines(
-                    text,
-                    options.update(width=code_width, height=None, justify="left"),
-                    style=self.background_style,
-                    pad=True,
-                    new_lines=True,
-                )
-                for syntax_line in syntax_lines:
-                    yield from syntax_line
+                for line in text.split("\n", allow_blank=True):
+                    line_style = console.get_style(line.style, default=Style.null())
+                    yield from Segment.adjust_line_length(
+                        list(
+                            Segment.apply_style(
+                                line.render(console), self.background_style
+                            )
+                        ),
+                        code_width,
+                        style=line_style,
+                    )
+                    yield Segment.line()
             return
 
         start_line, end_line = self.line_range or (None, None)

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -743,6 +743,19 @@ class Syntax(JupyterMixin):
             highlight_number_style,
         ) = self._get_number_styles(console)
 
+        if self.word_wrap and not self.line_numbers:
+            text = Text("\n").join(lines)
+            syntax_lines = console.render_lines(
+                text,
+                render_options.update(height=None, justify="left"),
+                style=background_style,
+                pad=not transparent_background,
+                new_lines=True,
+            )
+            for syntax_line in syntax_lines:
+                yield from syntax_line
+            return
+
         for line_no, line in enumerate(lines, self.start_line + line_offset):
             if self.word_wrap:
                 wrapped_lines = console.render_lines(

--- a/rich/syntax.py
+++ b/rich/syntax.py
@@ -526,9 +526,10 @@ class Syntax(JupyterMixin):
                             _token_type, token = next(tokens)
                         except StopIteration:
                             break
-                        yield (token, None)
                         if token.endswith("\n"):
                             line_no += 1
+                    if line_no:
+                        yield ("\n" * line_no, None)
                     # Generate spans until line end
                     for token_type, token in tokens:
                         yield (token, _get_theme_style(token_type))

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -435,6 +435,29 @@ def test_padding_plus_wrap() -> None:
     assert output == expected
 
 
+def test_word_wrap_without_line_numbers_with_line_range() -> None:
+    console = Console(
+        width=14, file=io.StringIO(), legacy_windows=False, record=True
+    )
+    syntax = Syntax(
+        "first line should not appear\n"
+        "second line wraps around here\n"
+        "third line stays\n"
+        "fourth line should not appear",
+        lexer="text",
+        word_wrap=True,
+        line_numbers=False,
+        line_range=(2, 3),
+    )
+
+    console.print(syntax)
+
+    assert (
+        console.export_text()
+        == "second line   \nwraps around  \nhere          \nthird line    \nstays         \n"
+    )
+
+
 if __name__ == "__main__":
     syntax = Panel.fit(
         Syntax(

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -436,9 +436,7 @@ def test_padding_plus_wrap() -> None:
 
 
 def test_word_wrap_without_line_numbers_with_line_range() -> None:
-    console = Console(
-        width=14, file=io.StringIO(), legacy_windows=False, record=True
-    )
+    console = Console(width=14, file=io.StringIO(), legacy_windows=False, record=True)
     syntax = Syntax(
         "first line should not appear\n"
         "second line wraps around here\n"


### PR DESCRIPTION
## Workload

Render a large Python `Syntax` object with a late `line_range` and no wrapping or line numbers:

`PYTHONPATH=. uvx --with pytest-benchmark pytest /tmp/rich_pytest_bench_syntax.py --benchmark-only --benchmark-min-rounds=15 --benchmark-max-time=1 --benchmark-cprofile=cumtime --benchmark-cprofile-top=15 --benchmark-columns="min,median,mean,rounds,iterations"`

Input: `snippets.PYTHON_SNIPPET * 120`, `lexer="python"`, `word_wrap=False`, `line_numbers=False`, `line_range=(3000, 3060)`, width 80.

This matters for callers that render only a small late slice of a large highlighted source file.

## Results

Before, at `6d54cb8d`:

- `test_highlight_line_range_3000`: 65.1610 ms median over 15 rounds
- `test_render_line_range_3000`: 71.1404 ms median over 15 rounds

After, at `06406dd2`:

- `test_highlight_line_range_3000`: 62.9820 ms median over 15 rounds
- `test_render_line_range_3000`: 68.3597 ms median over 15 rounds

The pytest-benchmark cProfile output shows the previous path spent extra time in `Text.append_tokens` appending skipped prefix tokens before the requested range. The new path still tokenizes the prefix so lexer state is preserved, but emits only newline placeholders for skipped lines.

## Correctness

- `python3 -m pytest tests/test_syntax.py tests/test_console.py`
- `uvx black --check rich/syntax.py benchmarks/benchmarks.py tests/test_syntax.py`

## Tradeoffs

No behavior change intended. Late line ranges still tokenize from the beginning of the source to keep Pygments lexer state correct. This only avoids storing the skipped source text in the intermediate `Text`.

## Stack

| Order | PR | Branch | Depends on |
| --- | --- | --- | --- |
| 1 | #4177 | `optimize-syntax-word-wrap` | main |
| 2 | #4178 | `perf/syntax-line-numbers-word-wrap` | #4177 |
| 3 | #4179 | `perf/syntax-direct-word-wrap` | #4178 |
| 4 | #4181 | `perf/syntax-direct-no-wrap` | #4179 |
| 5 | This PR | `perf/syntax-line-range-skip-prefix` | #4181 |